### PR TITLE
Pull in key decoding fix and apply follow-up fixes.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mattpolzin/OrderedDictionary.git",
         "state": {
           "branch": null,
-          "revision": "0ae556a691ca71e3221ecaf21ce448d3283fdf8b",
-          "version": "1.0.0"
+          "revision": "33a40de47e798d58f42e84e529d087f795f5a9db",
+          "version": "1.1.1"
         }
       },
       {

--- a/Sources/OpenAPIKit/ContentType.swift
+++ b/Sources/OpenAPIKit/ContentType.swift
@@ -44,5 +44,16 @@ extension OpenAPI {
         case yaml = "application/x-yaml"
         /// ZIP archive
         case zip = "application/zip"
+
+
+        // MARK: - patterns
+
+        case applicationAll = "application/*"
+        case audioAll = "audio/*"
+        case imageAll = "image/*"
+        case textAll = "text/*"
+        case videoAll = "video/*"
+
+        case all = "*/*"
     }
 }

--- a/Tests/OpenAPIKitCompatibilitySuite/GoogleBooksAPI.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/GoogleBooksAPI.swift
@@ -35,23 +35,9 @@ final class GoogleBooksAPICampatibilityTests: XCTestCase {
         switch booksAPI {
         case nil:
             XCTFail("Did not attempt to pull Google Books API documentation like expected.")
-        case .failure(let error as DecodingError):
-            let codingPath: String
-            let debugDetails: String
-            let underlyingError: String
-            switch error {
-            case .dataCorrupted(let context), .keyNotFound(_, let context), .typeMismatch(_, let context), .valueNotFound(_, let context):
-                codingPath = context.codingPath.map { $0.stringValue }.joined(separator: " -> ")
-                debugDetails = context.debugDescription
-                underlyingError = context.underlyingError.map { "\n underlying error: " + String(describing: $0) } ?? ""
-            @unknown default:
-                codingPath = ""
-                debugDetails = ""
-                underlyingError = ""
-            }
-            XCTFail(error.failureReason ?? error.errorDescription ?? error.localizedDescription + "\n coding path: " + codingPath + "\n debug description: " + debugDetails + underlyingError)
         case .failure(let error):
-            XCTFail(error.localizedDescription)
+            let prettyError = OpenAPI.Error(from: error)
+            XCTFail(prettyError.localizedDescription + "\n coding path: " + prettyError.codingPathString)
         case .success:
             break
         }

--- a/Tests/OpenAPIKitCompatibilitySuite/TomTomAPI.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/TomTomAPI.swift
@@ -35,23 +35,9 @@ final class TomTomAPICampatibilityTests: XCTestCase {
         switch tomtomAPI {
         case nil:
             XCTFail("Did not attempt to pull Google Books API documentation like expected.")
-        case .failure(let error as DecodingError):
-            let codingPath: String
-            let debugDetails: String
-            let underlyingError: String
-            switch error {
-            case .dataCorrupted(let context), .keyNotFound(_, let context), .typeMismatch(_, let context), .valueNotFound(_, let context):
-                codingPath = context.codingPath.map { $0.stringValue }.joined(separator: " -> ")
-                debugDetails = context.debugDescription
-                underlyingError = context.underlyingError.map { "\n underlying error: " + String(describing: $0) } ?? ""
-            @unknown default:
-                codingPath = ""
-                debugDetails = ""
-                underlyingError = ""
-            }
-            XCTFail(error.failureReason ?? error.errorDescription ?? error.localizedDescription + "\n coding path: " + codingPath + "\n debug description: " + debugDetails + underlyingError)
         case .failure(let error):
-            XCTFail(error.localizedDescription)
+            let prettyError = OpenAPI.Error(from: error)
+            XCTFail(prettyError.localizedDescription + "\n coding path: " + prettyError.codingPathString)
         case .success:
             break
         }


### PR DESCRIPTION
OrderedDictionary was quietly failing to decode keys. Now it is loud. This allowed the existing compatibility suite to bring to light a couple of shortcomings in status code and content type decoding which are fixed by this PR.