### PR TITLE
Change throwing schema function to schema property accessor.

### DIFF
--- a/Sources/OpenAPIKit/Either/Either.swift
+++ b/Sources/OpenAPIKit/Either/Either.swift
@@ -99,3 +99,12 @@ extension Either where B == OpenAPI.Header {
     /// Retrieve the header if that is what this property contains.
     public var headerValue: B? { b }
 }
+
+// MARK: - Convenience constructors
+extension Either where A == Bool {
+    public static func boolean(_ boolean: Bool) -> Self { .a(boolean) }
+}
+
+extension Either where B == JSONSchema {
+    public static func schema(_ schema: JSONSchema) -> Self { .b(schema) }
+}

--- a/Sources/OpenAPIKit/Schema Conformances/SchemaProtocols.swift
+++ b/Sources/OpenAPIKit/Schema Conformances/SchemaProtocols.swift
@@ -12,5 +12,5 @@
 /// OpenAPI schema representing itself.
 public protocol OpenAPISchemaType {
     /// The best `JSONSchema` representation for this type.
-    static func openAPISchema() throws -> JSONSchema
+    static var openAPISchema: JSONSchema { get }
 }

--- a/Sources/OpenAPIKit/Schema Conformances/SwiftPrimitiveTypes+OpenAPI.swift
+++ b/Sources/OpenAPIKit/Schema Conformances/SwiftPrimitiveTypes+OpenAPI.swift
@@ -7,55 +7,31 @@
 
 import Foundation
 
-/**
-
-Notable omissions in this library's default offerings:
-
-Base 64 encoded characters:
-.string(.byte)
-
-Any sequence of octets:
-.string(.binary)
-
-RFC3339 full-date:
-.string(.date)
-
-RFC3339 date-time: (note this is somewhat covered in `Date+OpenAPI.swift`)
-.string(.dateTime)
-
-A hint to UIs to obscure input:
-.string(.password)
-
-Any object:
-.object(.generic)
-
-**/
-
 extension Optional: OpenAPISchemaType where Wrapped: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
-		return try Wrapped.openAPISchema().optionalSchemaObject()
+    static public var openAPISchema: JSONSchema {
+		return Wrapped.openAPISchema.optionalSchemaObject()
 	}
 }
 
 extension Array: OpenAPISchemaType where Element: OpenAPISchemaType {
-    static public func openAPISchema() throws -> JSONSchema {
+    static public var openAPISchema: JSONSchema {
         return .array(.init(format: .generic,
                             required: true),
-                      .init(items: try Element.openAPISchema()))
+                      .init(items: Element.openAPISchema))
     }
 }
 
 extension Dictionary: OpenAPISchemaType where Key == String, Value: OpenAPISchemaType {
-    static public func openAPISchema() throws -> JSONSchema {
+    static public var openAPISchema: JSONSchema {
         return .object(.init(format: .generic,
                              required: true),
                        .init(properties: [:],
-                             additionalProperties: .init(try Value.openAPISchema())))
+                             additionalProperties: .init(Value.openAPISchema)))
     }
 }
 
 extension String: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .string(.init(format: .generic,
 							 required: true),
 					   .init())
@@ -63,14 +39,14 @@ extension String: OpenAPISchemaType {
 }
 
 extension Bool: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .boolean(.init(format: .generic,
 							  required: true))
 	}
 }
 
 extension Double: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .number(.init(format: .double,
 							 required: true),
 					   .init())
@@ -78,7 +54,7 @@ extension Double: OpenAPISchemaType {
 }
 
 extension Float: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .number(.init(format: .float,
 							 required: true),
 					   .init())
@@ -86,7 +62,7 @@ extension Float: OpenAPISchemaType {
 }
 
 extension Int: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .integer(.init(format: .generic,
 							  required: true),
 						.init())
@@ -94,7 +70,7 @@ extension Int: OpenAPISchemaType {
 }
 
 extension Int32: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .integer(.init(format: .int32,
 							  required: true),
 						.init())
@@ -102,7 +78,7 @@ extension Int32: OpenAPISchemaType {
 }
 
 extension Int64: OpenAPISchemaType {
-	static public func openAPISchema() throws -> JSONSchema {
+	static public var openAPISchema: JSONSchema {
 		return .integer(.init(format: .int64,
 							  required: true),
 						.init())

--- a/Tests/OpenAPIKitTests/Schema Conformances/SwiftPrimitiveTypes+OpenAPITests.swift
+++ b/Tests/OpenAPIKitTests/Schema Conformances/SwiftPrimitiveTypes+OpenAPITests.swift
@@ -11,70 +11,88 @@ import OpenAPIKit
 
 class SwiftPrimitiveTypesTests: XCTestCase {
 
-    func test_StringNode() {
-        XCTAssertEqual(try! String.openAPISchema(), .string)
+    func test_StringSchema() {
+        XCTAssertEqual(String.openAPISchema, .string)
     }
 
-    func test_BoolNode() {
-        XCTAssertEqual(try! Bool.openAPISchema(), .boolean)
+    func test_BoolSchema() {
+        XCTAssertEqual(Bool.openAPISchema, .boolean)
     }
 
-    func test_DoubleNode() {
-        XCTAssertEqual(try! Double.openAPISchema(), .number(format: .double))
+    func test_DoubleSchema() {
+        XCTAssertEqual(Double.openAPISchema, .number(format: .double))
     }
 
-    func test_FloatNode() {
-        XCTAssertEqual(try! Float.openAPISchema(), .number(format: .float))
+    func test_FloatSchema() {
+        XCTAssertEqual(Float.openAPISchema, .number(format: .float))
     }
 
-    func test_IntNode() {
-        XCTAssertEqual(try! Int.openAPISchema(), .integer)
+    func test_IntSchema() {
+        XCTAssertEqual(Int.openAPISchema, .integer)
     }
 
-    func test_Int32Node() {
-        XCTAssertEqual(try! Int32.openAPISchema(), .integer(format: .int32))
+    func test_Int32Schema() {
+        XCTAssertEqual(Int32.openAPISchema, .integer(format: .int32))
     }
 
-    func test_Int64Node() {
-        XCTAssertEqual(try! Int64.openAPISchema(), .integer(format: .int64))
+    func test_Int64Schema() {
+        XCTAssertEqual(Int64.openAPISchema, .integer(format: .int64))
     }
 
-    func test_ArrayNode() {
-        XCTAssertEqual(try! [String].openAPISchema(), .array(items: .string))
+    func test_ArraySchema() {
+        XCTAssertEqual([String].openAPISchema, .array(items: .string))
 
-        XCTAssertEqual(try! [Bool].openAPISchema(), .array(items: .boolean))
+        XCTAssertEqual([Bool].openAPISchema, .array(items: .boolean))
 
-        XCTAssertEqual(try! [Double].openAPISchema(), .array(items: .number(format: .double)))
+        XCTAssertEqual([Double].openAPISchema, .array(items: .number(format: .double)))
 
-        XCTAssertEqual(try! [Float].openAPISchema(), .array(items: .number(format: .float)))
+        XCTAssertEqual([Float].openAPISchema, .array(items: .number(format: .float)))
 
-        XCTAssertEqual(try! [Int].openAPISchema(), .array(items: .integer))
+        XCTAssertEqual([Int].openAPISchema, .array(items: .integer))
 
-        XCTAssertEqual(try! [Int32].openAPISchema(), .array(items: .integer(format: .int32)))
+        XCTAssertEqual([Int32].openAPISchema, .array(items: .integer(format: .int32)))
 
-        XCTAssertEqual(try! [Int64].openAPISchema(), .array(items: .integer(format: .int64)))
+        XCTAssertEqual([Int64].openAPISchema, .array(items: .integer(format: .int64)))
 
-        XCTAssertEqual(try! [String?].openAPISchema(), .array(items: .string(required: false)))
+        XCTAssertEqual([String?].openAPISchema, .array(items: .string(required: false)))
     }
 
-    func test_OptionalNodeType() {
-        XCTAssertEqual(try! String?.openAPISchema(), .string(required:false))
+    func test_OptionalSchema() {
+        XCTAssertEqual(String?.openAPISchema, .string(required:false))
 
-        XCTAssertEqual(try! Bool?.openAPISchema(), .boolean(required: false))
+        XCTAssertEqual(Bool?.openAPISchema, .boolean(required: false))
 
-        XCTAssertEqual(try! Double?.openAPISchema(), .number(format: .double, required: false))
+        XCTAssertEqual(Double?.openAPISchema, .number(format: .double, required: false))
 
-        XCTAssertEqual(try! Float?.openAPISchema(), .number(format: .float, required: false))
+        XCTAssertEqual(Float?.openAPISchema, .number(format: .float, required: false))
 
-        XCTAssertEqual(try! Int?.openAPISchema(), .integer(required: false))
+        XCTAssertEqual(Int?.openAPISchema, .integer(required: false))
 
-        XCTAssertEqual(try! Int32?.openAPISchema(), .integer(format: .int32, required: false))
+        XCTAssertEqual(Int32?.openAPISchema, .integer(format: .int32, required: false))
 
-        XCTAssertEqual(try! Int64?.openAPISchema(), .integer(format: .int64, required: false))
+        XCTAssertEqual(Int64?.openAPISchema, .integer(format: .int64, required: false))
 
-        XCTAssertEqual(try! [String]?.openAPISchema(), .array(required: false, items: .string))
+        XCTAssertEqual([String]?.openAPISchema, .array(required: false, items: .string))
 
-        XCTAssertEqual(try! [String?]?.openAPISchema(), .array(required: false, items: .string(required: false)))
+        XCTAssertEqual([String?]?.openAPISchema, .array(required: false, items: .string(required: false)))
+    }
+
+    func test_DictionarySchema() {
+        XCTAssertEqual([String: String].openAPISchema, .object(additionalProperties: .schema(.string)))
+
+        XCTAssertEqual([String: Bool].openAPISchema, .object(additionalProperties: .schema(.boolean)))
+
+        XCTAssertEqual([String: Double].openAPISchema, .object(additionalProperties: .schema(.number(format: .double))))
+
+        XCTAssertEqual([String: Float].openAPISchema, .object(additionalProperties: .schema(.number(format: .float))))
+
+        XCTAssertEqual([String: Int].openAPISchema, .object(additionalProperties: .schema(.integer)))
+
+        XCTAssertEqual([String: Int32].openAPISchema, .object(additionalProperties: .schema(.integer(format: .int32))))
+
+        XCTAssertEqual([String: Int64].openAPISchema, .object(additionalProperties: .schema(.integer(format: .int64))))
+
+        XCTAssertEqual([String: String?].openAPISchema, .object(additionalProperties: .schema(.string(required: false))))
     }
 
     static let localTestEncoder = JSONEncoder()

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
@@ -3887,12 +3887,20 @@ extension SchemaObjectTests {
                 [ "hello": false]
             ]
         )
-        let _ = JSONSchema.object(
+        let addProp1 = JSONSchema.object(
             additionalProperties: .init(true)
         )
-        let _ = JSONSchema.object(
+        let addProp2 = JSONSchema.object(
             additionalProperties: .init(.boolean)
         )
+        let addProp3 = JSONSchema.object(
+            additionalProperties: .boolean(true)
+        )
+        let addProp4 = JSONSchema.object(
+            additionalProperties: .schema(.boolean)
+        )
+        XCTAssertEqual(addProp1, addProp3)
+        XCTAssertEqual(addProp2, addProp4)
 
         // a little respect paid to JSON:API
         let _ = JSONSchema.object(


### PR DESCRIPTION
⚠️ Breaking Changes ⚠️ 
The throwing `openAPISchema()` function has been changed to the `openAPISchema` property (which is, naturally, non-throwing) because this function never needed to throw anyway in the end. It has been quite a few versions since any code relied on a throwing variant of it.