### PR TITLE
Ordered dictionary improvements

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,15 @@
+name: Code Coverage
+
+on: [push]
+
+jobs:
+  codecov:
+    container: 
+      image: swift:5.2-bionic
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: swift test --enable-test-discovery --enable-code-coverage
+    - uses: mattpolzin/swift-codecov-action@0.3.0
+      with:
+        MINIMUM_COVERAGE: 98

--- a/Sources/OpenAPIKit/Either/Either.swift
+++ b/Sources/OpenAPIKit/Either/Either.swift
@@ -105,6 +105,10 @@ extension Either where A == Bool {
     public static func boolean(_ boolean: Bool) -> Self { .a(boolean) }
 }
 
+extension Either where A: _OpenAPIReference {
+    public static func reference(_ reference: A) -> Self { .a(reference) }
+}
+
 extension Either where B == JSONSchema {
     public static func schema(_ schema: JSONSchema) -> Self { .b(schema) }
 }

--- a/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
+++ b/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  DocumentDecodingError.swift
 //  
 //
 //  Created by Mathew Polzin on 2/23/20.
@@ -60,8 +60,10 @@ extension OpenAPI.Error.Decoding.Document {
         switch context {
         case .other(let decodingError):
             return decodingError.relativeCodingPathString
-        case .inconsistency:
-            return ""
+        case .inconsistency(let error):
+            return error.codingPath.isEmpty
+                ? ""
+                : error.codingPath.dropLast().stringValue
         case .path(let pathError):
             return pathError.relativeCodingPathString
         }

--- a/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
@@ -29,26 +29,26 @@ public struct OrderedDictionary<Key, Value> where Key: Hashable {
     }
 
     public init<S>(grouping values: S, by keyForValue: (S.Element) throws -> Key) rethrows where Value == [S.Element], S : Sequence {
-        var dict = Self()
+        var temporaryDictionary = Self()
 
         for value in values {
-            try dict[keyForValue(value), default: [S.Element]()].append(value)
+            try temporaryDictionary[keyForValue(value), default: [S.Element]()].append(value)
         }
-        self = dict
+        self = temporaryDictionary
     }
 
     public init<S>(_ keysAndValues: S, uniquingKeysWith combine: (Value, Value) throws -> Value) rethrows where S : Sequence, S.Element == (Key, Value) {
-        var dict = Self()
+        var temporaryDictionary = Self()
 
         for (key, value) in keysAndValues {
-            if let existing = dict[key] {
-                try dict[key] = combine(existing, value)
+            if let existing = temporaryDictionary[key] {
+                try temporaryDictionary[key] = combine(existing, value)
             } else {
-                dict[key] = value
+                temporaryDictionary[key] = value
             }
         }
 
-        self = dict
+        self = temporaryDictionary
     }
 
     /// Get/Set the value for the given key.
@@ -197,11 +197,11 @@ extension OrderedDictionary: Collection {
 extension OrderedDictionary {
     public struct Iterator: Sequence, IteratorProtocol {
         private var idxReciprocal: Int
-        private let dict: OrderedDictionary
+        private let dictionary: OrderedDictionary
 
-        fileprivate init(_ dict: OrderedDictionary) {
-            self.dict = dict
-            self.idxReciprocal = dict.count
+        fileprivate init(_ dictionary: OrderedDictionary) {
+            self.dictionary = dictionary
+            self.idxReciprocal = dictionary.count
         }
 
         public mutating func next() -> (key: Key, value: Value)? {
@@ -210,8 +210,8 @@ extension OrderedDictionary {
             }
 
             defer { idxReciprocal -= 1 }
-            let key = dict.orderedKeys[dict.orderedKeys.count - idxReciprocal]
-            let value = dict.unorderedHash[key]
+            let key = dictionary.orderedKeys[dictionary.orderedKeys.count - idxReciprocal]
+            let value = dictionary.unorderedHash[key]
 
             return value.map { (key, $0) }
         }
@@ -257,8 +257,8 @@ extension OrderedDictionary: Encodable where Key: Encodable, Value: Encodable {
     public func encode(to encoder: Encoder) throws {
 
         // try for String
-        if let encDict = self as? OrderedDictionary<String, Value> {
-            try encodeStringDict(encDict, to: encoder)
+        if let encodableDictionary = self as? OrderedDictionary<String, Value> {
+            try encodeStringDict(encodableDictionary, to: encoder)
             return
         }
 
@@ -270,8 +270,8 @@ extension OrderedDictionary: Encodable where Key: Encodable, Value: Encodable {
         }
 
         // try for RawRepresentable with String RawValues
-        if let encDict = self as? StringRawKeyEncodable {
-            let kvPairs = zip(encDict.orderedStringKeys, self.values)
+        if let encodableDictionary = self as? StringRawKeyEncodable {
+            let kvPairs = zip(encodableDictionary.orderedStringKeys, self.values)
             try encodeKeyValuePairs(kvPairs, to: encoder)
             return
         }
@@ -355,14 +355,14 @@ extension OrderedDictionary: Decodable where Key: Decodable, Value: Decodable {
         }
 
         // try for LosslessStringConvertible
-        if let decDictType = Self.self as? LosslessStringKeyDecodable.Type {
-            self = try decDictType.decodeLosslessStringDict(from: decoder) as! Self
+        if let decodableDictionaryType = Self.self as? LosslessStringKeyDecodable.Type {
+            self = try decodableDictionaryType.decodeLosslessStringDict(from: decoder) as! Self
             return
         }
 
         // try for RawRepresentable with String RawValues
-        if let decDictType = Self.self as? StringRawKeyDecodable.Type {
-            self = try decDictType.decodeRawStringDict(from: decoder) as! Self
+        if let decodableDictionaryType = Self.self as? StringRawKeyDecodable.Type {
+            self = try decodableDictionaryType.decodeRawStringDict(from: decoder) as! Self
             return
         }
 
@@ -386,16 +386,16 @@ extension OrderedDictionary: Decodable where Key: Decodable, Value: Decodable {
     /// Decode a `String`-keyed OrderedDictionary from a hash.
     internal static func decodeStringDict(
         from decoder: Decoder
-    ) throws -> OrderedDictionary<String, Value> {
+    ) throws -> Any {
         let container = try decoder.container(keyedBy: AnyCodingKey.self)
 
-        var dict = OrderedDictionary<String, Value>()
+        var dictionary = OrderedDictionary<String, Value>()
 
         for key in container.allKeys {
-            dict[key.stringValue] = try container.decode(Value.self, forKey: key)
+            dictionary[key.stringValue] = try container.decode(Value.self, forKey: key)
         }
 
-        return dict
+        return dictionary
     }
 }
 
@@ -412,16 +412,22 @@ extension OrderedDictionary: LosslessStringKeyDecodable where Key: LosslessStrin
     ) throws -> Any {
         let container = try decoder.container(keyedBy: AnyCodingKey.self)
 
-        var dict = OrderedDictionary<Key, Value>()
+        var dictionary = OrderedDictionary<Key, Value>()
 
         for key in container.allKeys {
-            guard let dictKey = Key(key.stringValue) else {
-                throw DecodingError.typeMismatch(Key.self, DecodingError.Context(codingPath: container.codingPath + [key], debugDescription: "OrderedDictionary key could not be decoded as required type."))
+            guard let dictionaryKey = Key(key.stringValue) else {
+                throw DecodingError.typeMismatch(
+                    Key.self,
+                    DecodingError.Context(
+                        codingPath: container.codingPath + [key],
+                        debugDescription: "OrderedDictionary key could not be decoded as required type."
+                    )
+                )
             }
-            dict[dictKey] = try container.decode(Value.self, forKey: key)
+            dictionary[dictionaryKey] = try container.decode(Value.self, forKey: key)
         }
 
-        return dict
+        return dictionary
     }
 }
 
@@ -438,15 +444,21 @@ extension OrderedDictionary: StringRawKeyDecodable where Key: RawRepresentable, 
     ) throws -> Any {
         let container = try decoder.container(keyedBy: AnyCodingKey.self)
 
-        var dict = OrderedDictionary<Key, Value>()
+        var dictionary = OrderedDictionary<Key, Value>()
 
         for key in container.allKeys {
-            guard let dictKey = Key(rawValue: key.stringValue) else {
-                throw DecodingError.typeMismatch(Key.self, DecodingError.Context(codingPath: container.codingPath + [key], debugDescription: "OrderedDictionary key could not be decoded as required type."))
+            guard let dictionaryKey = Key(rawValue: key.stringValue) else {
+                throw DecodingError.typeMismatch(
+                    Key.self,
+                    DecodingError.Context(
+                        codingPath: container.codingPath + [key],
+                        debugDescription: "OrderedDictionary key could not be decoded as required type."
+                    )
+                )
             }
-            dict[dictKey] = try container.decode(Value.self, forKey: key)
+            dictionary[dictionaryKey] = try container.decode(Value.self, forKey: key)
         }
 
-        return dict
+        return dictionary
     }
 }

--- a/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
@@ -405,6 +405,10 @@ private protocol LosslessStringKeyDecodable {
     ) throws -> Any
 }
 
+internal struct KeyDecodingError: Swift.Error {
+    let localizedDescription: String
+}
+
 extension OrderedDictionary: LosslessStringKeyDecodable where Key: LosslessStringConvertible, Value: Decodable {
     /// Decode a `LosslessStringConvertible`-keyed OrderedDictionary from a hash.
     internal static func decodeLosslessStringDict(
@@ -416,11 +420,16 @@ extension OrderedDictionary: LosslessStringKeyDecodable where Key: LosslessStrin
 
         for key in container.allKeys {
             guard let dictionaryKey = Key(key.stringValue) else {
+                let errorMessage = (Key.self as? StringConvertibleHintProvider.Type)?
+                    .problem(with: key.stringValue)
+                    ?? "OrderedDictionary key could not be decoded as required type."
+
                 throw DecodingError.typeMismatch(
                     Key.self,
                     DecodingError.Context(
                         codingPath: container.codingPath + [key],
-                        debugDescription: "OrderedDictionary key could not be decoded as required type."
+                        debugDescription: errorMessage,
+                        underlyingError: KeyDecodingError(localizedDescription: errorMessage)
                     )
                 )
             }
@@ -448,11 +457,16 @@ extension OrderedDictionary: StringRawKeyDecodable where Key: RawRepresentable, 
 
         for key in container.allKeys {
             guard let dictionaryKey = Key(rawValue: key.stringValue) else {
+                let errorMessage = (Key.self as? StringConvertibleHintProvider.Type)?
+                    .problem(with: key.stringValue)
+                    ?? "OrderedDictionary key could not be decoded as required type."
+
                 throw DecodingError.typeMismatch(
                     Key.self,
                     DecodingError.Context(
                         codingPath: container.codingPath + [key],
-                        debugDescription: "OrderedDictionary key could not be decoded as required type."
+                        debugDescription: errorMessage,
+                        underlyingError: KeyDecodingError(localizedDescription: errorMessage)
                     )
                 )
             }

--- a/Sources/OpenAPIKit/OrderedDictionary/StringConvertibleHintProvider.swift
+++ b/Sources/OpenAPIKit/OrderedDictionary/StringConvertibleHintProvider.swift
@@ -1,0 +1,17 @@
+//
+//  StringConvertibleHintProvider.swift
+//  
+//
+//  Created by Mathew Polzin on 3/29/20.
+//
+
+internal protocol StringConvertibleHintProvider {
+    /// Get a `String` describing why the given value cannot
+    /// be used to create this type. Returns `nil` if there are no
+    /// problems with the provided value.
+    ///
+    /// The idea is for this function to augment the use of `init?(rawValue:)`
+    /// or `init?(_ description:)` by providing a hint as to why initialization
+    /// from a `String` value will fail.
+    static func problem(with proposedString: String) -> String?
+}

--- a/Tests/OpenAPIKitErrorReportingTests/ComponentErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/ComponentErrorTests.swift
@@ -32,7 +32,7 @@ components:
 
             print(error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected `h#llo` value in Document.components.schemas to be parsable as ComponentKey but it was not.")
+            XCTAssertEqual(openAPIError.localizedDescription, #"Inconsistency encountered when parsing `h#llo` in Document.components.schemas: Keys for components in the Components Object must conform to the regex `^[a-zA-Z0-9\.\-_]+$`. 'h#llo' does not..."#)
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["components", "schemas", "h#llo"])
         }
     }

--- a/Tests/OrderedDictionaryTests/OrderedDictionaryTests.swift
+++ b/Tests/OrderedDictionaryTests/OrderedDictionaryTests.swift
@@ -657,10 +657,10 @@ hello: thing
         let dictString =
 """
 [
-x: x,
-hello,
-x: y,
-there
+    x: x,
+    hello,
+    x: y,
+    there
 ]
 """
 
@@ -674,10 +674,10 @@ there
         let dictString2 =
 """
 [
-x: y,
-there,
-x: x,
-hello
+    x: y,
+    there,
+    x: x,
+    hello
 ]
 """
 
@@ -693,10 +693,10 @@ hello
         let dictData =
 """
 [
-{"x": "x"},
-"hello",
-{"x": "y"},
-"there"
+    {"x": "x"},
+    "hello",
+    {"x": "y"},
+    "there"
 ]
 """.data(using: .utf8)!
 
@@ -710,10 +710,10 @@ hello
         let dictData2 =
 """
 [
-{"x": "y"},
-"there",
-{"x": "x"},
-"hello"
+    {"x": "y"},
+    "there",
+    {"x": "x"},
+    "hello"
 ]
 """.data(using: .utf8)!
 
@@ -729,10 +729,10 @@ hello
         let dictData =
 """
 [
-{"x": "x"},
-"hello",
-{"x": "y"},
-"there"
+    {"x": "x"},
+    "hello",
+    {"x": "y"},
+    "there"
 ]
 """.data(using: .utf8)!
 
@@ -746,10 +746,10 @@ hello
         let dictData2 =
 """
 [
-{"x": "y"},
-"there",
-{"x": "x"},
-"hello"
+    {"x": "y"},
+    "there",
+    {"x": "x"},
+    "hello"
 ]
 """.data(using: .utf8)!
 
@@ -764,37 +764,36 @@ hello
     func test_failedKeyDecodeYAML() {
         let dictString =
 """
-[
 x: x
-]
 """
 
         XCTAssertThrowsError(try YAMLDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictString))
+        XCTAssertThrowsError(try YAMLDecoder().decode(OrderedDictionary<TestKey3, String>.self, from: dictString))
     }
 
     func test_failedKeyDecodeJSON() {
         let dictData =
 """
-[
 {"x": "x"}
-]
 """.data(using: .utf8)!
 
         XCTAssertThrowsError(try JSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData))
+        XCTAssertThrowsError(try JSONDecoder().decode(OrderedDictionary<TestKey3, String>.self, from: dictData))
     }
 
     func test_failedKeyDecodeFineJSON() {
         let dictData =
 """
 [
-{"x": "x"},
-"hello",
-{"x": "y"},
-"there"
+    {"x": "x"},
+    "hello",
+    {"x": "y"},
+    "there"
 ]
 """.data(using: .utf8)!
 
         XCTAssertThrowsError(try FineJSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData))
+        XCTAssertThrowsError(try FineJSONDecoder().decode(OrderedDictionary<TestKey3, String>.self, from: dictData))
     }
 }
 
@@ -807,4 +806,27 @@ fileprivate struct TestKey2: Hashable, Codable {
     let x: String
 
     init(_ x: String) { self.x = x }
+}
+
+fileprivate enum TestKey3: String, LosslessStringConvertible, Codable {
+    case one
+    case two
+
+    init?(_ description: String) {
+        switch description {
+        case "one":
+            self = .one
+        case "two":
+            self = .two
+        default:
+            return nil
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .one: return "one"
+        case .two: return "two"
+        }
+    }
 }


### PR DESCRIPTION
Add ability to provide better error reporting when failing to decode a `LosslessStringConvertible` or `RawRepresentable` key of an `OrderedDictionary`. Use that support to improve error reporting of keys in components dictionaries.

Fixes bug with OrderedDictionary tests as well.