### PR TITLE
handle schema fragments

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
@@ -1,0 +1,575 @@
+//
+//  JSONSchemaFragment.swift
+//  
+//
+//  Created by Mathew Polzin on 4/20/20.
+//
+
+public protocol JSONSchemaFragmentContext {
+    var format: String? { get }
+    var description: String? { get }
+    var title: String? { get }
+    var nullable: Bool? { get }
+    var deprecated: Bool? { get }
+    var externalDocs: OpenAPI.ExternalDocumentation? { get }
+    var allowedValues: [AnyCodable]? { get }
+    var example: AnyCodable? { get }
+    var readOnly: Bool? { get }
+    var writeOnly: Bool? { get }
+}
+
+public enum JSONSchemaFragment: Equatable {
+
+    case general(GeneralContext)
+    case boolean(GeneralContext)
+    case integer(
+        GeneralContext,
+        IntegerContext
+    )
+    case number(
+        GeneralContext,
+        NumericContext
+    )
+    case string(
+        GeneralContext,
+        StringContext
+    )
+    case array(
+        GeneralContext,
+        ArrayContext
+    )
+
+    // object context
+    case object(
+        GeneralContext,
+        ObjectContext
+    )
+}
+
+extension JSONSchemaFragment {
+    public struct GeneralContext: Equatable {
+        public var format: String? = nil
+        public var description: String? = nil
+        public var title: String? = nil
+        public var nullable: Bool? = nil
+        public var deprecated: Bool? = nil
+        public var externalDocs: OpenAPI.ExternalDocumentation? = nil
+        public var allowedValues: [AnyCodable]? = nil
+        public var example: AnyCodable? = nil
+        public var readOnly: Bool? = nil
+        public var writeOnly: Bool? = nil
+
+        public init(
+            format: String? = nil,
+            description: String? = nil,
+            title: String? = nil,
+            nullable: Bool? = nil,
+            deprecated: Bool? = nil,
+            externalDocs: OpenAPI.ExternalDocumentation? = nil,
+            allowedValues: [AnyCodable]? = nil,
+            example: AnyCodable? = nil,
+            readOnly: Bool? = nil,
+            writeOnly: Bool? = nil
+        ) {
+            self.format = format
+            self.description = description
+            self.title = title
+            self.nullable = nullable
+            self.deprecated = deprecated
+            self.externalDocs = externalDocs
+            self.allowedValues = allowedValues
+            self.example = example
+            self.readOnly = readOnly
+            self.writeOnly = writeOnly
+        }
+    }
+
+    public struct IntegerContext: Equatable {
+        public var multipleOf: Int? = nil
+        public var maximum: Int? = nil
+        public var exclusiveMaximum: Bool? = nil
+        public var minimum: Int? = nil
+        public var exclusiveMinimum: Bool? = nil
+
+        public init(
+            multipleOf: Int? = nil,
+            maximum: Int? = nil,
+            exclusiveMaximum: Bool? = nil,
+            minimum: Int? = nil,
+            exclusiveMinimum: Bool? = nil
+        ) {
+            self.multipleOf = multipleOf
+            self.maximum = maximum
+            self.minimum = minimum
+            self.exclusiveMaximum = exclusiveMaximum
+            self.exclusiveMinimum = exclusiveMinimum
+        }
+
+        public init?(from numericContext: NumericContext) {
+            if let multipleOf = numericContext.multipleOf {
+                guard let integerMultipleOf = Int(exactly: multipleOf) else { return nil }
+                self.multipleOf = integerMultipleOf
+            } else {
+                self.multipleOf = nil
+            }
+
+            if let maximum = numericContext.maximum {
+                guard let integerMaximum = Int(exactly: maximum) else { return nil }
+                self.maximum = integerMaximum
+            } else {
+                self.maximum = nil
+            }
+
+            if let minimum = numericContext.minimum {
+                guard let integerMinimum = Int(exactly: minimum) else { return nil }
+                self.minimum = integerMinimum
+            } else {
+                self.minimum = nil
+            }
+
+            self.exclusiveMaximum = numericContext.exclusiveMaximum
+            self.exclusiveMinimum = numericContext.exclusiveMinimum
+        }
+    }
+
+    public struct NumericContext: Equatable {
+        public var multipleOf: Double? = nil
+        public var maximum: Double? = nil
+        public var exclusiveMaximum: Bool? = nil
+        public var minimum: Double? = nil
+        public var exclusiveMinimum: Bool? = nil
+
+        public init(
+            multipleOf: Double? = nil,
+            maximum: Double? = nil,
+            exclusiveMaximum: Bool? = nil,
+            minimum: Double? = nil,
+            exclusiveMinimum: Bool? = nil
+        ) {
+            self.multipleOf = multipleOf
+            self.maximum = maximum
+            self.minimum = minimum
+            self.exclusiveMaximum = exclusiveMaximum
+            self.exclusiveMinimum = exclusiveMinimum
+        }
+    }
+
+    public struct StringContext: Equatable {
+        public var maxLength: Int? = nil
+        public var minLength: Int? = nil
+        public var pattern: String? = nil // regex
+
+        public init(
+            maxLength: Int? = nil,
+            minLength: Int? = nil,
+            pattern: String? = nil
+        ) {
+            self.maxLength = maxLength
+            self.minLength = minLength
+            self.pattern = pattern
+        }
+    }
+
+    public struct ArrayContext: Equatable {
+        public var items: JSONSchema? = nil
+        public var maxItems: Int? = nil
+        public var minItems: Int? = nil
+        public var uniqueItems: Bool? = nil
+
+        public init(
+            items: JSONSchema? = nil,
+            maxItems: Int? = nil,
+            minItems: Int? = nil,
+            uniqueItems: Bool? = nil
+        ) {
+            self.items = items
+            self.maxItems = maxItems
+            self.minItems = minItems
+            self.uniqueItems = uniqueItems
+        }
+    }
+
+    public struct ObjectContext: Equatable {
+        public var maxProperties: Int? = nil
+        public var minProperties: Int? = nil
+        public var properties: [String: JSONSchema]? = nil
+        public var additionalProperties: Either<Bool, JSONSchema>? = nil
+        public var required: [String]? = nil
+
+        public init(
+            maxProperties: Int? = nil,
+            minProperties: Int? = nil,
+            properties: [String: JSONSchema]? = nil,
+            additionalProperties: Either<Bool, JSONSchema>? = nil,
+            required: [String]? = nil
+        ) {
+            self.maxProperties = maxProperties
+            self.minProperties = minProperties
+            self.properties = properties
+            self.additionalProperties = additionalProperties
+            self.required = required
+        }
+    }
+}
+
+extension JSONSchemaFragment: JSONSchemaFragmentContext {
+
+    public var format: String? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.format
+        }
+    }
+
+    public var description: String? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.description
+        }
+    }
+
+    public var title: String? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.title
+        }
+    }
+
+    public var nullable: Bool? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.nullable
+        }
+    }
+
+    public var deprecated: Bool? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.deprecated
+        }
+    }
+
+    public var externalDocs: OpenAPI.ExternalDocumentation? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.externalDocs
+        }
+    }
+
+    public var allowedValues: [AnyCodable]? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.allowedValues
+        }
+    }
+
+    public var example: AnyCodable? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.example
+        }
+    }
+
+    public var readOnly: Bool? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.readOnly
+        }
+    }
+
+    public var writeOnly: Bool? {
+        switch self {
+        case .general(let generalContext),
+             .boolean(let generalContext),
+             .integer(let generalContext, _),
+             .number(let generalContext, _),
+             .string(let generalContext, _),
+             .array(let generalContext, _),
+             .object(let generalContext, _):
+            return generalContext.writeOnly
+        }
+    }
+}
+
+extension JSONSchemaFragment {
+    private typealias GeneralCodingKeys = JSONSchema.ContextCodingKeys
+    private typealias IntegerCodingKeys = JSONSchema.IntegerContext.CodingKeys
+    private typealias NumericCodingKeys = JSONSchema.NumericContext.CodingKeys
+    private typealias StringCodingKeys = JSONSchema.StringContext.CodingKeys
+    private typealias ArrayCodingKeys = JSONSchema.ArrayContext.CodingKeys
+    private typealias ObjectCodingKeys = JSONSchema.ObjectContext.CodingKeys
+}
+
+extension JSONSchemaFragment: Encodable {
+    private func encodeGeneralProperties(for type: JSONType?, to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: GeneralCodingKeys.self)
+
+        try type.encodeIfNotNil(to: &container, forKey: .type)
+        try format.encodeIfNotNil(to: &container, forKey: .format)
+        try description.encodeIfNotNil(to: &container, forKey: .description)
+        try title.encodeIfNotNil(to: &container, forKey: .title)
+        try nullable.encodeIfNotNil(to: &container, forKey: .nullable)
+        try deprecated.encodeIfNotNil(to: &container, forKey: .deprecated)
+        try externalDocs.encodeIfNotNil(to: &container, forKey: .externalDocs)
+        try allowedValues.encodeIfNotNil(to: &container, forKey: .allowedValues)
+        try example.encodeIfNotNil(to: &container, forKey: .example)
+        try readOnly.encodeIfNotNil(to: &container, forKey: .readOnly)
+        try writeOnly.encodeIfNotNil(to: &container, forKey: .writeOnly)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+
+        switch self {
+        case .general:
+            try encodeGeneralProperties(for: nil, to: encoder)
+        case .boolean:
+            try encodeGeneralProperties(for: .boolean, to: encoder)
+        case .integer(_, let integerContext):
+            try encodeGeneralProperties(for: .integer, to: encoder)
+
+            var container = encoder.container(keyedBy: IntegerCodingKeys.self)
+            try integerContext.multipleOf.encodeIfNotNil(to: &container, forKey: .multipleOf)
+            try integerContext.maximum.encodeIfNotNil(to: &container, forKey: .maximum)
+            try integerContext.exclusiveMaximum.encodeIfNotNil(to: &container, forKey: .exclusiveMaximum)
+            try integerContext.minimum.encodeIfNotNil(to: &container, forKey: .minimum)
+            try integerContext.exclusiveMinimum.encodeIfNotNil(to: &container, forKey: .exclusiveMinimum)
+        case .number(_, let numericContext):
+            try encodeGeneralProperties(for: .number, to: encoder)
+
+            var container = encoder.container(keyedBy: NumericCodingKeys.self)
+            try numericContext.multipleOf.encodeIfNotNil(to: &container, forKey: .multipleOf)
+            try numericContext.maximum.encodeIfNotNil(to: &container, forKey: .maximum)
+            try numericContext.exclusiveMaximum.encodeIfNotNil(to: &container, forKey: .exclusiveMaximum)
+            try numericContext.minimum.encodeIfNotNil(to: &container, forKey: .minimum)
+            try numericContext.exclusiveMinimum.encodeIfNotNil(to: &container, forKey: .exclusiveMinimum)
+
+        case .string(_, let stringContext):
+            try encodeGeneralProperties(for: .string, to: encoder)
+
+            var container = encoder.container(keyedBy: StringCodingKeys.self)
+            try stringContext.maxLength.encodeIfNotNil(to: &container, forKey: .maxLength)
+            try stringContext.minLength.encodeIfNotNil(to: &container, forKey: .minLength)
+            try stringContext.pattern.encodeIfNotNil(to: &container, forKey: .pattern)
+
+        case .array(_, let arrayContext):
+            try encodeGeneralProperties(for: .array, to: encoder)
+
+            var container = encoder.container(keyedBy: ArrayCodingKeys.self)
+            try arrayContext.items.encodeIfNotNil(to: &container, forKey: .items)
+            try arrayContext.maxItems.encodeIfNotNil(to: &container, forKey: .maxItems)
+            try arrayContext.minItems.encodeIfNotNil(to: &container, forKey: .minItems)
+            try arrayContext.uniqueItems.encodeIfNotNil(to: &container, forKey: .uniqueItems)
+
+        case .object(_, let objectContext):
+            try encodeGeneralProperties(for: .object, to: encoder)
+
+            var container = encoder.container(keyedBy: ObjectCodingKeys.self)
+            try objectContext.maxProperties.encodeIfNotNil(to: &container, forKey: .maxProperties)
+            try objectContext.minProperties.encodeIfNotNil(to: &container, forKey: .minProperties)
+            try objectContext.properties.encodeIfNotNil(to: &container, forKey: .properties)
+            try objectContext.additionalProperties.encodeIfNotNil(to: &container, forKey: .additionalProperties)
+            try objectContext.required.encodeIfNotNil(to: &container, forKey: .required)
+        }
+    }
+}
+
+extension JSONSchemaFragment.GeneralContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.GeneralCodingKeys.self)
+
+        format = try container.decodeIfPresent(String.self, forKey: .format)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        nullable = try container.decodeIfPresent(Bool.self, forKey: .nullable)
+        deprecated = try container.decodeIfPresent(Bool.self, forKey: .deprecated)
+        externalDocs = try container.decodeIfPresent(OpenAPI.ExternalDocumentation.self, forKey: .externalDocs)
+        allowedValues = try container.decodeIfPresent([AnyCodable].self, forKey: .allowedValues)
+        example = try container.decodeIfPresent(AnyCodable.self, forKey: .example)
+        readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly)
+        writeOnly = try container.decodeIfPresent(Bool.self, forKey: .writeOnly)
+    }
+}
+
+extension JSONSchemaFragment.IntegerContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.IntegerCodingKeys.self)
+
+        multipleOf = try container.decodeIfPresent(Int.self, forKey: .multipleOf)
+        maximum = try container.decodeIfPresent(Int.self, forKey: .maximum)
+        exclusiveMaximum = try container.decodeIfPresent(Bool.self, forKey: .exclusiveMaximum)
+        minimum = try container.decodeIfPresent(Int.self, forKey: .minimum)
+        exclusiveMinimum = try container.decodeIfPresent(Bool.self, forKey: .exclusiveMinimum)
+    }
+}
+
+extension JSONSchemaFragment.NumericContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.NumericCodingKeys.self)
+
+        multipleOf = try container.decodeIfPresent(Double.self, forKey: .multipleOf)
+        maximum = try container.decodeIfPresent(Double.self, forKey: .maximum)
+        exclusiveMaximum = try container.decodeIfPresent(Bool.self, forKey: .exclusiveMaximum)
+        minimum = try container.decodeIfPresent(Double.self, forKey: .minimum)
+        exclusiveMinimum = try container.decodeIfPresent(Bool.self, forKey: .exclusiveMinimum)
+    }
+}
+
+extension JSONSchemaFragment.StringContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.StringCodingKeys.self)
+
+        maxLength = try container.decodeIfPresent(Int.self, forKey: .maxLength)
+        minLength = try container.decodeIfPresent(Int.self, forKey: .minLength)
+        pattern = try container.decodeIfPresent(String.self, forKey: .pattern)
+    }
+}
+
+extension JSONSchemaFragment.ArrayContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.ArrayCodingKeys.self)
+
+        items = try container.decodeIfPresent(JSONSchema.self, forKey: .items)
+        maxItems = try container.decodeIfPresent(Int.self, forKey: .maxItems)
+        minItems = try container.decodeIfPresent(Int.self, forKey: .minItems)
+        uniqueItems = try container.decodeIfPresent(Bool.self, forKey: .uniqueItems)
+    }
+}
+
+extension JSONSchemaFragment.ObjectContext: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: JSONSchemaFragment.ObjectCodingKeys.self)
+
+        maxProperties = try container.decodeIfPresent(Int.self, forKey: .maxProperties)
+        minProperties = try container.decodeIfPresent(Int.self, forKey: .minProperties)
+        properties = try container.decodeIfPresent([String: JSONSchema].self, forKey: .properties)
+        additionalProperties = try container.decodeIfPresent(Either<Bool, JSONSchema>.self, forKey: .additionalProperties)
+        required = try container.decodeIfPresent([String].self, forKey: .required)
+    }
+}
+
+extension JSONSchemaFragment: Decodable {
+    public init(from decoder: Decoder) throws {
+
+        let generalContext = try GeneralContext(from: decoder)
+
+        let generalContainer = try decoder.container(keyedBy: JSONSchemaFragment.GeneralCodingKeys.self)
+        let numericOrIntegerContainer = try decoder.container(keyedBy: JSONSchemaFragment.NumericCodingKeys.self)
+        let stringContainer = try decoder.container(keyedBy: JSONSchemaFragment.StringCodingKeys.self)
+        let arrayContainer = try decoder.container(keyedBy: JSONSchemaFragment.ArrayCodingKeys.self)
+        let objectContainer = try decoder.container(keyedBy: JSONSchemaFragment.ObjectCodingKeys.self)
+
+        let typeHint = try generalContainer.decodeIfPresent(JSONType.self, forKey: .type)
+
+        let keysFrom = [
+            numericOrIntegerContainer.allKeys.isEmpty ? nil : "number/integer",
+            stringContainer.allKeys.isEmpty ? nil : "string",
+            arrayContainer.allKeys.isEmpty ? nil : "array",
+            objectContainer.allKeys.isEmpty ? nil : "object"
+        ].compactMap { $0 }
+
+        if keysFrom.count > 1 {
+            throw InconsistencyError(
+                subjectName: "Schema Fragment",
+                details: "A schema fragment within an `allOf` contains properties for multiple types of schemas, namely: \(keysFrom).",
+                codingPath: decoder.codingPath
+            )
+        }
+
+        func assertNoTypeConflict(with type: JSONType) throws {
+            guard let typeHint = typeHint else { return }
+            guard typeHint == type else {
+                throw InconsistencyError(
+                    subjectName: "Schema Fragment",
+                    details: "Found schema attributes not consistent with the type specified: \(typeHint)",
+                    codingPath: decoder.codingPath
+                )
+            }
+        }
+
+        if !numericOrIntegerContainer.allKeys.isEmpty || typeHint == .integer || typeHint == .number {
+            if typeHint == .integer {
+                self = .integer(generalContext, try .init(from: decoder))
+            } else {
+                self = .number(generalContext, try .init(from: decoder))
+            }
+        } else if !stringContainer.allKeys.isEmpty || typeHint == .string {
+            try assertNoTypeConflict(with: .string)
+            self = .string(generalContext, try .init(from: decoder))
+
+        } else if !arrayContainer.allKeys.isEmpty || typeHint == .array {
+            try assertNoTypeConflict(with: .array)
+            self = .array(generalContext, try .init(from: decoder))
+
+        } else if !objectContainer.allKeys.isEmpty || typeHint == .object {
+            try assertNoTypeConflict(with: .object)
+            self = .object(generalContext, try .init(from: decoder))
+
+        } else if typeHint == .boolean {
+            self = .boolean(generalContext)
+            
+        } else if !generalContainer.allKeys.isEmpty {
+            self = .general(generalContext)
+
+        } else {
+            throw InconsistencyError(
+                subjectName: "Schema Fragment",
+                details: "A totally empty schema fragment was found in an `allOf` array.",
+                codingPath: decoder.codingPath
+            )
+        }
+    }
+}

--- a/Sources/OpenAPIKit/Schema Object/SchemaObject.swift
+++ b/Sources/OpenAPIKit/Schema Object/SchemaObject.swift
@@ -17,7 +17,7 @@ public enum JSONSchema: Equatable, JSONSchemaContext {
     case number(Context<JSONTypeFormat.NumberFormat>, NumericContext)
     case integer(Context<JSONTypeFormat.IntegerFormat>, IntegerContext)
     case string(Context<JSONTypeFormat.StringFormat>, StringContext)
-    indirect case all(of: [JSONSchema])
+    indirect case all(of: [JSONSchemaFragment])
     indirect case one(of: [JSONSchema])
     indirect case any(of: [JSONSchema])
     indirect case not(JSONSchema)
@@ -722,7 +722,7 @@ extension JSONSchema {
         return .array(generalContext, arrayContext)
     }
 
-    public static func all(of schemas: JSONSchema...) -> JSONSchema {
+    public static func all(of schemas: JSONSchemaFragment...) -> JSONSchema {
         return .all(of: schemas)
     }
 
@@ -824,7 +824,7 @@ extension JSONSchema: Decodable {
         let container = try decoder.container(keyedBy: SubschemaCodingKeys.self)
 
         if container.contains(.allOf) {
-            self = .all(of: try container.decode([JSONSchema].self, forKey: .allOf))
+            self = .all(of: try container.decode([JSONSchemaFragment].self, forKey: .allOf))
             return
         }
 

--- a/Sources/OpenAPIKit/Schema Object/SchemaObjectContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/SchemaObjectContext.swift
@@ -314,8 +314,9 @@ extension JSONSchema {
 
 // MARK: - Codable
 
-extension JSONSchema.Context {
-    private enum CodingKeys: String, CodingKey {
+extension JSONSchema {
+    // not nested because Context is a generic type
+    internal enum ContextCodingKeys: String, CodingKey {
         case type
         case format
         case title
@@ -327,13 +328,13 @@ extension JSONSchema.Context {
         case readOnly
         case writeOnly
         case deprecated
-//        case constantValue = "const"
+//      case constantValue = "const"
     }
 }
 
 extension JSONSchema.Context: Encodable {
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: JSONSchema.ContextCodingKeys.self)
 
         try container.encode(format.jsonType, forKey: .type)
 
@@ -373,7 +374,7 @@ extension JSONSchema.Context: Encodable {
 
 extension JSONSchema.Context: Decodable {
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let container = try decoder.container(keyedBy: JSONSchema.ContextCodingKeys.self)
 
         format = try container.decodeIfPresent(Format.self, forKey: .format) ?? .unspecified
 
@@ -415,7 +416,7 @@ extension JSONSchema.Context: Decodable {
 }
 
 extension JSONSchema.NumericContext {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case multipleOf
         case maximum
         case exclusiveMaximum
@@ -463,7 +464,7 @@ extension JSONSchema.NumericContext: Decodable {
 }
 
 extension JSONSchema.IntegerContext {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case multipleOf
         case maximum
         case exclusiveMaximum
@@ -511,7 +512,7 @@ extension JSONSchema.IntegerContext: Decodable {
 }
 
 extension JSONSchema.StringContext {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case maxLength
         case minLength
         case pattern
@@ -543,7 +544,7 @@ extension JSONSchema.StringContext: Decodable {
 }
 
 extension JSONSchema.ArrayContext {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case items
         case maxItems
         case minItems
@@ -583,7 +584,7 @@ extension JSONSchema.ArrayContext: Decodable {
 }
 
 extension JSONSchema.ObjectContext {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: String, CodingKey {
         case maxProperties
         case minProperties
         case properties

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -1,0 +1,792 @@
+//
+//  SchemaFragmentTests.swift
+//  
+//
+//  Created by Mathew Polzin on 4/21/20.
+//
+
+import Foundation
+import OpenAPIKit
+import XCTest
+
+final class SchemaFragmentTests: XCTestCase {
+    func test_init() {
+        func assertNoGeneralProperties(_ fragment: JSONSchemaFragment, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertNil(fragment.allowedValues, file: file, line: line)
+            XCTAssertNil(fragment.deprecated, file: file, line: line)
+            XCTAssertNil(fragment.description, file: file, line: line)
+            XCTAssertNil(fragment.example, file: file, line: line)
+            XCTAssertNil(fragment.externalDocs, file: file, line: line)
+            XCTAssertNil(fragment.format, file: file, line: line)
+            XCTAssertNil(fragment.nullable, file: file, line: line)
+            XCTAssertNil(fragment.readOnly, file: file, line: line)
+            XCTAssertNil(fragment.title, file: file, line: line)
+            XCTAssertNil(fragment.writeOnly, file: file, line: line)
+        }
+
+        // minimal
+        assertNoGeneralProperties(JSONSchemaFragment.general(.init()))
+        assertNoGeneralProperties(JSONSchemaFragment.integer(.init(), .init()))
+        assertNoGeneralProperties(JSONSchemaFragment.number(.init(), .init()))
+        assertNoGeneralProperties(JSONSchemaFragment.array(.init(), .init()))
+        assertNoGeneralProperties(JSONSchemaFragment.object(.init(), .init()))
+
+        func assertSameGeneralProperties(_ fragment: JSONSchemaFragment, as properties: JSONSchemaFragment.GeneralContext, file: StaticString = #file, line: UInt = #line) {
+            XCTAssertEqual(fragment.allowedValues, properties.allowedValues, file: file, line: line)
+            XCTAssertEqual(fragment.deprecated, properties.deprecated, file: file, line: line)
+            XCTAssertEqual(fragment.description, properties.description, file: file, line: line)
+            XCTAssertEqual(fragment.example, properties.example, file: file, line: line)
+            XCTAssertEqual(fragment.externalDocs, properties.externalDocs, file: file, line: line)
+            XCTAssertEqual(fragment.format, properties.format, file: file, line: line)
+            XCTAssertEqual(fragment.nullable, properties.nullable, file: file, line: line)
+            XCTAssertEqual(fragment.readOnly, properties.readOnly, file: file, line: line)
+            XCTAssertEqual(fragment.title, properties.title, file: file, line: line)
+            XCTAssertEqual(fragment.writeOnly, properties.writeOnly, file: file, line: line)
+        }
+
+        // maximal
+        let generalProperties = JSONSchemaFragment.GeneralContext(format: "date", description: "a date", title: "Date", nullable: false, deprecated: false, externalDocs: .init(url: URL(string: "http://url.com")!), allowedValues: [], example: "2020-01-01", readOnly: false, writeOnly: false)
+        let t1 = JSONSchemaFragment.general(generalProperties)
+        assertSameGeneralProperties(t1, as: generalProperties)
+        let t2 = JSONSchemaFragment.integer(generalProperties, .init(multipleOf: 10, maximum: 20, exclusiveMaximum: false, minimum: 0, exclusiveMinimum: true))
+        assertSameGeneralProperties(t2, as: generalProperties)
+        let t3 = JSONSchemaFragment.number(generalProperties, .init(multipleOf: 12.5, maximum: 25, exclusiveMaximum: false, minimum: 0, exclusiveMinimum: false))
+        assertSameGeneralProperties(t3, as: generalProperties)
+        let t4 = JSONSchemaFragment.string(generalProperties, .init(maxLength: 5, minLength: 1, pattern: ".*"))
+        assertSameGeneralProperties(t4, as: generalProperties)
+        let t5 = JSONSchemaFragment.array(generalProperties, .init(items: .string, maxItems: 7, minItems: 2, uniqueItems: true))
+        assertSameGeneralProperties(t5, as: generalProperties)
+        let t6 = JSONSchemaFragment.object(generalProperties, .init(maxProperties: 100, minProperties: 0, properties: ["hello": .string], additionalProperties: .init(.string), required: ["hello"]))
+        assertSameGeneralProperties(t6, as: generalProperties)
+    }
+
+    func test_IntegerContextFromNumericContext() {
+        let numeric1 = JSONSchemaFragment.NumericContext(maximum: 5.5)
+        let integer1 = JSONSchemaFragment.IntegerContext(from: numeric1)
+        XCTAssertNil(integer1)
+
+        let numeric2 = JSONSchemaFragment.NumericContext(minimum: 5.5)
+        let integer2 = JSONSchemaFragment.IntegerContext(from: numeric2)
+        XCTAssertNil(integer2)
+
+        let numeric3 = JSONSchemaFragment.NumericContext(multipleOf: 5.5)
+        let integer3 = JSONSchemaFragment.IntegerContext(from: numeric3)
+        XCTAssertNil(integer3)
+
+        let numeric4 = JSONSchemaFragment.NumericContext(multipleOf: 10, maximum: 100, exclusiveMaximum: false, minimum: 0, exclusiveMinimum: false)
+        let integer4 = JSONSchemaFragment.IntegerContext(from: numeric4)
+        XCTAssertEqual(integer4?.exclusiveMaximum, false)
+        XCTAssertEqual(integer4?.exclusiveMinimum, false)
+        XCTAssertEqual(integer4?.maximum, 100)
+        XCTAssertEqual(integer4?.minimum, 0)
+        XCTAssertEqual(integer4?.multipleOf, 10)
+
+        let numeric5 = JSONSchemaFragment.NumericContext(maximum: 100, exclusiveMaximum: true, minimum: 0, exclusiveMinimum: true)
+        let integer5 = JSONSchemaFragment.IntegerContext(from: numeric5)
+        XCTAssertEqual(integer5?.exclusiveMaximum, true)
+        XCTAssertEqual(integer5?.exclusiveMinimum, true)
+        XCTAssertEqual(integer5?.maximum, 100)
+        XCTAssertEqual(integer5?.minimum, 0)
+        XCTAssertNil(integer5?.multipleOf)
+
+        let numeric6 = JSONSchemaFragment.NumericContext(multipleOf: 10, exclusiveMaximum: false, minimum: 0, exclusiveMinimum: false)
+        let integer6 = JSONSchemaFragment.IntegerContext(from: numeric6)
+        XCTAssertEqual(integer6?.exclusiveMaximum, false)
+        XCTAssertEqual(integer6?.exclusiveMinimum, false)
+        XCTAssertNil(integer6?.maximum)
+        XCTAssertEqual(integer6?.minimum, 0)
+        XCTAssertEqual(integer6?.multipleOf, 10)
+
+        let numeric7 = JSONSchemaFragment.NumericContext(multipleOf: 10, maximum: 100, minimum: 0, exclusiveMinimum: false)
+        let integer7 = JSONSchemaFragment.IntegerContext(from: numeric7)
+        XCTAssertNil(integer7?.exclusiveMaximum)
+        XCTAssertEqual(integer7?.exclusiveMinimum, false)
+        XCTAssertEqual(integer7?.maximum, 100)
+        XCTAssertEqual(integer7?.minimum, 0)
+        XCTAssertEqual(integer7?.multipleOf, 10)
+
+        let numeric8 = JSONSchemaFragment.NumericContext(multipleOf: 10, maximum: 100, exclusiveMaximum: false, exclusiveMinimum: false)
+        let integer8 = JSONSchemaFragment.IntegerContext(from: numeric8)
+        XCTAssertEqual(integer8?.exclusiveMaximum, false)
+        XCTAssertEqual(integer8?.exclusiveMinimum, false)
+        XCTAssertEqual(integer8?.maximum, 100)
+        XCTAssertNil(integer8?.minimum)
+        XCTAssertEqual(integer8?.multipleOf, 10)
+
+        let numeric9 = JSONSchemaFragment.NumericContext(multipleOf: 10, maximum: 100, exclusiveMaximum: false, minimum: 0)
+        let integer9 = JSONSchemaFragment.IntegerContext(from: numeric9)
+        XCTAssertEqual(integer9?.exclusiveMaximum, false)
+        XCTAssertNil(integer9?.exclusiveMinimum)
+        XCTAssertEqual(integer9?.maximum, 100)
+        XCTAssertEqual(integer9?.minimum, 0)
+        XCTAssertEqual(integer9?.multipleOf, 10)
+    }
+}
+
+// MARK: - Codable Tests
+extension SchemaFragmentTests {
+    func test_decodeFailsWithNoProperties() {
+        let t = "{}".data(using: .utf8)!
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+    }
+
+    func test_decodeFailsWithConflictingProperties() {
+        let t =
+"""
+{
+    "properties" : {
+        "hello": { "type": "string" }
+    },
+    "items": {
+        "type" : "string"
+    }
+}
+""".data(using: .utf8)!
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+    }
+
+    func test_decodeFailsWithTypeAndPropertyConflict() {
+        let t =
+"""
+{
+    "type": "object",
+    "items": {
+        "type" : "string"
+    }
+}
+""".data(using: .utf8)!
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+    }
+
+    func test_decodeFailsWithIntegerWithFloatingPointMin() {
+        let t =
+"""
+{
+    "type": "integer",
+    "minimum": 10.5
+}
+""".data(using: .utf8)!
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+    }
+
+    func test_generalEncode() throws {
+        let t = JSONSchemaFragment.general(.init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.general(.init(format: "date", title: "creation date", readOnly: true))
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "format" : "date",
+  "readOnly" : true,
+  "title" : "creation date"
+}
+"""
+        )
+    }
+
+    func test_generalDecode() throws {
+        let t =
+"""
+{
+  "format" : "date",
+  "readOnly" : true,
+  "title" : "creation date"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(
+            decoded,
+            JSONSchemaFragment.general(.init(format: "date", title: "creation date", readOnly: true))
+        )
+    }
+
+    func test_booleanEncode() throws {
+        let t = JSONSchemaFragment.boolean(.init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "boolean"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.boolean(.init(description: "hello"))
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "description" : "hello",
+  "type" : "boolean"
+}
+"""
+        )
+    }
+
+    func test_booleanDecode() throws {
+        let t =
+"""
+{
+    "type": "boolean"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.boolean(.init()))
+
+        let t2 =
+"""
+{
+    "type": "boolean",
+    "description": "hello world"
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.boolean(.init(description: "hello world")))
+    }
+
+    func test_integerEncode() throws {
+        let t = JSONSchemaFragment.integer(.init(), .init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "integer"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.integer(.init(title: "hi"), .init())
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "title" : "hi",
+  "type" : "integer"
+}
+"""
+        )
+
+        let t3 = JSONSchemaFragment.integer(.init(), .init(minimum: 10))
+
+        let encoded3 = try testStringFromEncoding(of: t3)
+
+        assertJSONEquivalent(
+            encoded3,
+"""
+{
+  "minimum" : 10,
+  "type" : "integer"
+}
+"""
+        )
+    }
+
+    func test_integerDecode() throws {
+        let t =
+"""
+{
+  "type" : "integer"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.integer(.init(), .init()))
+
+        let t2 =
+"""
+{
+  "title" : "hi",
+  "type" : "integer"
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.integer(.init(title: "hi"), .init()))
+
+        let t3 =
+"""
+{
+  "minimum" : 10,
+  "type" : "integer"
+}
+""".data(using: .utf8)!
+
+        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+
+        XCTAssertEqual(decoded3, JSONSchemaFragment.integer(.init(), .init(minimum: 10)))
+    }
+
+    func test_numberEncode() throws {
+        let t = JSONSchemaFragment.number(.init(), .init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "number"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.number(.init(title: "hi"), .init())
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "title" : "hi",
+  "type" : "number"
+}
+"""
+        )
+
+        let t3 = JSONSchemaFragment.number(.init(), .init(minimum: 10))
+
+        let encoded3 = try testStringFromEncoding(of: t3)
+
+        assertJSONEquivalent(
+            encoded3,
+"""
+{
+  "minimum" : 10,
+  "type" : "number"
+}
+"""
+        )
+    }
+
+    func test_numberDecode() throws {
+        let t =
+"""
+{
+  "type" : "number"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.number(.init(), .init()))
+
+        let t2 =
+"""
+{
+  "title" : "hi",
+  "type" : "number"
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.number(.init(title: "hi"), .init()))
+
+        let t3 =
+"""
+{
+  "minimum" : 10,
+  "type" : "number"
+}
+""".data(using: .utf8)!
+
+        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+
+        XCTAssertEqual(decoded3, JSONSchemaFragment.number(.init(), .init(minimum: 10)))
+
+        let t4 =
+"""
+{
+  "minimum" : 10.5
+}
+""".data(using: .utf8)!
+
+        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+
+        XCTAssertEqual(decoded4, JSONSchemaFragment.number(.init(), .init(minimum: 10.5)))
+    }
+
+    func test_stringEncode() throws {
+        let t = JSONSchemaFragment.string(.init(), .init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "string"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.string(.init(writeOnly: false), .init())
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "type" : "string",
+  "writeOnly" : false
+}
+"""
+        )
+
+        let t3 = JSONSchemaFragment.string(.init(), .init(maxLength: 3))
+
+        let encoded3 = try testStringFromEncoding(of: t3)
+
+        assertJSONEquivalent(
+            encoded3,
+"""
+{
+  "maxLength" : 3,
+  "type" : "string"
+}
+"""
+        )
+    }
+
+    func test_stringDecode() throws {
+        let t =
+"""
+{
+  "type" : "string"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.string(.init(), .init()))
+
+        let t2 =
+"""
+{
+  "type" : "string",
+  "writeOnly" : false
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.string(.init(writeOnly: false), .init()))
+
+        let t3 =
+"""
+{
+  "maxLength" : 3,
+  "type" : "string"
+}
+""".data(using: .utf8)!
+
+        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+
+        XCTAssertEqual(decoded3, JSONSchemaFragment.string(.init(), .init(maxLength: 3)))
+
+        let t4 =
+"""
+{
+  "minLength" : 7
+}
+""".data(using: .utf8)!
+
+        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+
+        XCTAssertEqual(decoded4, JSONSchemaFragment.string(.init(), .init(minLength: 7)))
+    }
+
+    func test_arrayEncode() throws {
+        let t = JSONSchemaFragment.array(.init(), .init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "array"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.array(.init(writeOnly: true), .init())
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "type" : "array",
+  "writeOnly" : true
+}
+"""
+        )
+
+        let t3 = JSONSchemaFragment.array(.init(), .init(uniqueItems: true))
+
+        let encoded3 = try testStringFromEncoding(of: t3)
+
+        assertJSONEquivalent(
+            encoded3,
+"""
+{
+  "type" : "array",
+  "uniqueItems" : true
+}
+"""
+        )
+
+        let t4 = JSONSchemaFragment.array(.init(), .init(items: .string))
+
+        let encoded4 = try testStringFromEncoding(of: t4)
+
+        assertJSONEquivalent(
+            encoded4,
+"""
+{
+  "items" : {
+    "type" : "string"
+  },
+  "type" : "array"
+}
+"""
+        )
+    }
+
+    func test_arrayDecode() throws {
+        let t =
+"""
+{
+  "type" : "array"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.array(.init(), .init()))
+
+        let t2 =
+"""
+{
+  "type" : "array",
+  "writeOnly" : true
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.array(.init(writeOnly: true), .init()))
+
+        let t3 =
+"""
+{
+  "maxItems" : 3,
+  "type" : "array"
+}
+""".data(using: .utf8)!
+
+        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+
+        XCTAssertEqual(decoded3, JSONSchemaFragment.array(.init(), .init(maxItems: 3)))
+
+        let t4 =
+"""
+{
+  "minItems" : 7
+}
+""".data(using: .utf8)!
+
+        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+
+        XCTAssertEqual(decoded4, JSONSchemaFragment.array(.init(), .init(minItems: 7)))
+
+        let t5 =
+"""
+{
+  "items" : {
+    "type" : "string"
+  }
+}
+""".data(using: .utf8)!
+
+        let decoded5 = try testDecoder.decode(JSONSchemaFragment.self, from: t5)
+
+        XCTAssertEqual(decoded5, JSONSchemaFragment.array(.init(), .init(items: .string(required: false))))
+    }
+
+    func test_objectEncode() throws {
+        let t = JSONSchemaFragment.object(.init(), .init())
+
+        let encoded = try testStringFromEncoding(of: t)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "type" : "object"
+}
+"""
+        )
+
+        let t2 = JSONSchemaFragment.object(.init(writeOnly: true), .init())
+
+        let encoded2 = try testStringFromEncoding(of: t2)
+
+        assertJSONEquivalent(
+            encoded2,
+"""
+{
+  "type" : "object",
+  "writeOnly" : true
+}
+"""
+        )
+
+        let t3 = JSONSchemaFragment.object(.init(), .init(required: ["hello"]))
+
+        let encoded3 = try testStringFromEncoding(of: t3)
+
+        assertJSONEquivalent(
+            encoded3,
+"""
+{
+  "required" : [
+    "hello"
+  ],
+  "type" : "object"
+}
+"""
+        )
+
+        let t4 = JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string]))
+
+        let encoded4 = try testStringFromEncoding(of: t4)
+
+        assertJSONEquivalent(
+            encoded4,
+"""
+{
+  "properties" : {
+    "hello" : {
+      "type" : "string"
+    }
+  },
+  "type" : "object"
+}
+"""
+        )
+    }
+
+    func test_minimalObjectDecode() throws {
+        let t =
+"""
+{
+  "type" : "object"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+
+        XCTAssertEqual(decoded, JSONSchemaFragment.object(.init(), .init()))
+
+        let t2 =
+"""
+{
+  "type" : "object",
+  "writeOnly" : true
+}
+""".data(using: .utf8)!
+
+        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+
+        XCTAssertEqual(decoded2, JSONSchemaFragment.object(.init(writeOnly: true), .init()))
+
+        let t3 =
+"""
+{
+  "required" : [
+    "hello"
+  ],
+  "type" : "object"
+}
+""".data(using: .utf8)!
+
+        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+
+        XCTAssertEqual(decoded3, JSONSchemaFragment.object(.init(), .init(required: ["hello"])))
+
+        let t4 =
+"""
+{
+  "properties" : {
+    "hello" : {
+      "type" : "string"
+    }
+  },
+  "type" : "object"
+}
+""".data(using: .utf8)!
+
+        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+
+        XCTAssertEqual(decoded4, JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string(required: false)])))
+
+        let t5 =
+"""
+{
+  "properties" : {
+    "hello" : {
+      "type" : "string"
+    }
+  }
+}
+""".data(using: .utf8)!
+
+        let decoded5 = try testDecoder.decode(JSONSchemaFragment.self, from: t5)
+
+        XCTAssertEqual(decoded5, JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string(required: false)])))
+    }
+}

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
@@ -26,7 +26,7 @@ final class SchemaObjectTests: XCTestCase {
         let dateString = JSONSchema.string(.init(format: .date, required: true), .init())
         let dateTimeString = JSONSchema.string(.init(format: .dateTime, required: true), .init())
         let passwordString = JSONSchema.string(.init(format: .password, required: true), .init())
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -98,7 +98,7 @@ final class SchemaObjectTests: XCTestCase {
         let number = JSONSchema.number(.init(format: .unspecified, required: true), .init())
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -160,7 +160,7 @@ final class SchemaObjectTests: XCTestCase {
         let number = JSONSchema.number(.init(format: .unspecified, required: true), .init())
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -188,7 +188,7 @@ final class SchemaObjectTests: XCTestCase {
         let number = JSONSchema.number(.init(format: .unspecified, required: true), .init())
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -273,7 +273,7 @@ final class SchemaObjectTests: XCTestCase {
         let number = JSONSchema.number(.init(format: .unspecified, required: true), .init())
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -319,7 +319,7 @@ final class SchemaObjectTests: XCTestCase {
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true, title: "hello"), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true, title: "hello"), .init())
 
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -349,7 +349,7 @@ final class SchemaObjectTests: XCTestCase {
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true, description: "hello"), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true, description: "hello"), .init())
 
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -381,7 +381,7 @@ final class SchemaObjectTests: XCTestCase {
         let integer = JSONSchema.integer(.init(format: .unspecified, required: true, externalDocs: .init(url: URL(string: "http://google.com")!)), .init())
         let string = JSONSchema.string(.init(format: .unspecified, required: true, externalDocs: .init(url: URL(string: "http://google.com")!)), .init())
 
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
         let anyOf = JSONSchema.any(of: [boolean])
         let oneOf = JSONSchema.one(of: [boolean])
         let not = JSONSchema.not(boolean)
@@ -416,7 +416,7 @@ final class SchemaObjectTests: XCTestCase {
             .optionalSchemaObject()
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
             .optionalSchemaObject()
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
             .optionalSchemaObject()
         let anyOf = JSONSchema.any(of: [boolean])
             .optionalSchemaObject()
@@ -453,7 +453,7 @@ final class SchemaObjectTests: XCTestCase {
             .requiredSchemaObject()
         let string = JSONSchema.string(.init(format: .unspecified, required: false), .init())
             .requiredSchemaObject()
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
             .requiredSchemaObject()
         let anyOf = JSONSchema.any(of: [boolean])
             .requiredSchemaObject()
@@ -490,7 +490,7 @@ final class SchemaObjectTests: XCTestCase {
             .nullableSchemaObject()
         let string = JSONSchema.string(.init(format: .unspecified, required: true), .init())
             .nullableSchemaObject()
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
             .nullableSchemaObject()
         let anyOf = JSONSchema.any(of: [boolean])
             .nullableSchemaObject()
@@ -545,7 +545,7 @@ final class SchemaObjectTests: XCTestCase {
             .with(allowedValues: ["hello"])
 
         // nonesense:
-        let allOf = JSONSchema.all(of: [boolean])
+        let allOf = JSONSchema.all(of: [.string(.init(), .init())])
             .with(allowedValues: ["hello"])
         let anyOf = JSONSchema.any(of: [boolean])
             .with(allowedValues: ["hello"])
@@ -607,7 +607,7 @@ final class SchemaObjectTests: XCTestCase {
             .with(example: "hello world")
 
         // nonsense:
-        XCTAssertThrowsError(try JSONSchema.all(of: [object])
+        XCTAssertThrowsError(try JSONSchema.all(of: [.string(.init(), .init())])
             .with(example: ["hello"]))
         XCTAssertThrowsError(try JSONSchema.any(of: [object])
             .with(example: ["hello"]))
@@ -3469,8 +3469,8 @@ extension SchemaObjectTests {
 
     func test_encodeAll() {
         let allOf = JSONSchema.all(of: [
-            .object(.init(format: .unspecified, required: true), .init(properties: ["hello": .string(.init(format: .generic, required: false), .init())])),
-            .object(.init(format: .unspecified, required: true), .init(properties: ["world": .boolean(.init(format: .generic, required: false))]))
+            .object(.init(), .init(properties: ["hello": .string(.init(format: .generic, required: false), .init())])),
+            .object(.init(), .init())
         ])
 
         testEncodingPropertyLines(entity: allOf, propertyLines: [
@@ -3484,11 +3484,6 @@ extension SchemaObjectTests {
             "    \"type\" : \"object\"",
             "  },",
             "  {",
-            "    \"properties\" : {",
-            "      \"world\" : {",
-            "        \"type\" : \"boolean\"",
-            "      }",
-            "    },",
             "    \"type\" : \"object\"",
             "  }",
             "]"
@@ -3500,7 +3495,7 @@ extension SchemaObjectTests {
         {
             "allOf": [
                 { "type": "object" },
-                { "type": "object", "properties": { "hello": { "type": "boolean" } } }
+                { "properties": { "hello": { "type": "boolean" } } }
             ]
         }
         """.data(using: .utf8)!
@@ -3508,8 +3503,8 @@ extension SchemaObjectTests {
         let all = try! testDecoder.decode(JSONSchema.self, from: allData)
 
         XCTAssertEqual(all, JSONSchema.all(of: [
-            .object(.init(format: .generic, required: false), .init(properties: [:])),
-            .object(.init(format: .generic, required: false), .init(properties: ["hello": .boolean(.init(format: .generic, required: false))]))
+            .object(.init(), .init()),
+            .object(.init(), .init(properties: ["hello": .boolean(.init(format: .generic, required: false))]))
         ]))
     }
 
@@ -3967,12 +3962,13 @@ extension SchemaObjectTests {
 
     func test_allOf() {
         let t1: JSONSchema = .all(of:
-            .object(properties: ["hello": .string]),
-            .object(properties: ["world": .boolean])
+            .object(.init(), .init(properties: ["hello": .string])),
+            .object(.init(), .init(properties: ["world": .boolean]))
         )
-        let t2: JSONSchema = .all(of: [
-            .object(properties: ["hello": .string]),
-            .object(properties: ["world": .boolean])
+        let t2: JSONSchema = .all(
+            of: [
+                .object(.init(), .init(properties: ["hello": .string])),
+                .object(.init(), .init(properties: ["world": .boolean]))
             ]
         )
 


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/52.

`JSONSchema` did not have the flexibility to represent the fragments of schemas that are possible when using the `JSONSchema.all(of:)` case. This PR introduces `JSONSchemaFragment` to address that limitation.

⚠️ Breaking Change ⚠️ 
 `JSONSchema.all(of:)` used to store an array of `JSONSchema` whereas now it stores an array of `JSONSchemaFragment`.