### PR TITLE
Fix bug with decoding schemas that have no 'type' property

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
@@ -540,21 +540,21 @@ extension JSONSchemaFragment: Decodable {
             }
         }
 
-        if !numericOrIntegerContainer.allKeys.isEmpty || typeHint == .integer || typeHint == .number {
+        if typeHint == .integer || typeHint == .number || !numericOrIntegerContainer.allKeys.isEmpty {
             if typeHint == .integer {
                 self = .integer(generalContext, try .init(from: decoder))
             } else {
                 self = .number(generalContext, try .init(from: decoder))
             }
-        } else if !stringContainer.allKeys.isEmpty || typeHint == .string {
+        } else if typeHint == .string || !stringContainer.allKeys.isEmpty {
             try assertNoTypeConflict(with: .string)
             self = .string(generalContext, try .init(from: decoder))
 
-        } else if !arrayContainer.allKeys.isEmpty || typeHint == .array {
+        } else if typeHint == .array || !arrayContainer.allKeys.isEmpty {
             try assertNoTypeConflict(with: .array)
             self = .array(generalContext, try .init(from: decoder))
 
-        } else if !objectContainer.allKeys.isEmpty || typeHint == .object {
+        } else if typeHint == .object || !objectContainer.allKeys.isEmpty {
             try assertNoTypeConflict(with: .object)
             self = .object(generalContext, try .init(from: decoder))
 

--- a/Tests/OpenAPIKitCompatibilitySuite/PetStoreAPITests.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/PetStoreAPITests.swift
@@ -1,0 +1,111 @@
+//
+//  PetStoreAPITests.swift
+//
+//
+//  Created by Mathew Polzin on 2/17/20.
+//
+
+import XCTest
+import OpenAPIKit
+import Yams
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+final class PetStoreAPICampatibilityTests: XCTestCase {
+    var petStoreAPI: Result<OpenAPI.Document, Error>? = nil
+    var apiDoc: OpenAPI.Document? {
+        guard case .success(let document) = petStoreAPI else { return nil }
+        return document
+    }
+
+    override func setUp() {
+        if petStoreAPI == nil {
+            petStoreAPI = Result {
+                try YAMLDecoder().decode(
+                    OpenAPI.Document.self,
+                    from: String(contentsOf: URL(string: "https://raw.githubusercontent.com/swagger-api/swagger-petstore/master/src/main/resources/openapi.yaml")!)
+                )
+            }
+        }
+    }
+
+    func test_successfullyParsedDocument() {
+        switch petStoreAPI {
+        case nil:
+            XCTFail("Did not attempt to pull Google Books API documentation like expected.")
+        case .failure(let error):
+            let prettyError = OpenAPI.Error(from: error)
+            XCTFail(prettyError.localizedDescription + "\n coding path: " + prettyError.codingPathString)
+        case .success:
+            break
+        }
+    }
+
+    func test_successfullyParsedBasicMetadata() {
+        guard let apiDoc = apiDoc else { return }
+
+        // title is Swagger Petstore - OpenAPI 3.0
+        XCTAssertEqual(apiDoc.info.title, "Swagger Petstore - OpenAPI 3.0")
+
+        // description is set
+        XCTAssertFalse(apiDoc.info.description?.isEmpty ?? true)
+
+        // contact email is "apiteam@swagger.io"
+        XCTAssertEqual(apiDoc.info.contact?.email, "apiteam@swagger.io")
+
+        // no contact name is provided
+        XCTAssert(apiDoc.info.contact?.name?.isEmpty ?? true)
+
+        // server is specified
+        XCTAssertNotNil(apiDoc.servers.first)
+        XCTAssertEqual(apiDoc.servers.first?.url.path, "/v3")
+    }
+
+    func test_successfullyParsedTags() {
+        guard let apiDoc = apiDoc else { return }
+
+        XCTAssertEqual(apiDoc.tags?.map { $0.name }, ["pet", "store", "user"])
+    }
+
+    func test_successfullyParsedRoutes() {
+        guard let apiDoc = apiDoc else { return }
+
+        // just check for a few of the known paths
+        XCTAssert(apiDoc.paths.contains(key: "/pet"))
+        XCTAssert(apiDoc.paths.contains(key: "/pet/findByStatus"))
+        XCTAssert(apiDoc.paths.contains(key: "/pet/findByTags"))
+        XCTAssert(apiDoc.paths.contains(key: "/pet/{petId}"))
+        XCTAssert(apiDoc.paths.contains(key: "/pet/{petId}/uploadImage"))
+        XCTAssert(apiDoc.paths.contains(key: "/store/inventory"))
+
+        // check for a known POST response
+        XCTAssertNotNil(apiDoc.paths["/pet/{petId}/uploadImage"]?.post?.responses[200 as OpenAPI.Response.StatusCode])
+
+        // and a known GET response
+        XCTAssertNotNil(apiDoc.paths["/pet/{petId}"]?.get?.responses[200 as OpenAPI.Response.StatusCode])
+
+        // check for parameters
+        XCTAssertFalse(apiDoc.paths["/pet/{petId}"]?.get?.parameters.isEmpty ?? true)
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.name, "petId")
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.parameterLocation, .path)
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.schemaOrContent.schemaValue?.schema.schemaValue, .integer(format: .int64, required: false))
+    }
+
+    func test_successfullyParsedComponents() {
+        guard let apiDoc = apiDoc else { return }
+
+        // check for known schema
+        XCTAssertNotNil(apiDoc.components.schemas["Customer"])
+        guard case .object(_, let objectContext) = apiDoc.components[JSONReference<JSONSchema>.component(named: "Customer")] else {
+            XCTFail("Expected customer schema to be an object")
+            return
+        }
+        XCTAssertEqual(objectContext.properties["username"], .string(required: false, example: "fehguy"))
+
+        // check for known security scheme
+        XCTAssertNotNil(apiDoc.components.securitySchemes["api_key"])
+        XCTAssertEqual(apiDoc.components.securitySchemes["api_key"], OpenAPI.SecurityScheme.apiKey(name: "api_key", location: .header))
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/OpenAPIKit/issues/50.

Change decoding logic such that `JSONSchema` parsing succeeds as long as it is possible to determine which type of schema is being parsed, regardless of whether that type is explicitly specified in the schema.