### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can wrap any error you get back from a decoder in `OpenAPI.Error` to get a f
 
 ```swift
 do {
-  try decoder.docode(OpenAPI.Document, from: ...)
+  try decoder.decode(OpenAPI.Document, from: ...)
 } catch let error {
   print(OpenAPI.Error(from: error).localizedDescription)  
 }


### PR DESCRIPTION
Replaces "docode" with "[decode](https://github.com/mattpolzin/OpenAPIKit/blob/84ac940182dcba8a7bc8c73eb4d4a3f108655f4e/Tests/OpenAPIKitTests/DocumentTests.swift#L116)".

Apologies if jumping to a PR instead of first opening an issue violates the [contributing guidelines](https://github.com/mattpolzin/OpenAPIKit/blob/master/CONTRIBUTING.md). If that's a problem, I'd be more than happy to create an issue for this to link against.