### PR TITLE
More vendor extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
 - [x] enum
 - [x] default
 - [x] description
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Components Object (`OpenAPI.Components`)
 - [x] schemas

--- a/README.md
+++ b/README.md
@@ -339,13 +339,13 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
     - [x] allowReserved
     - [x] example
     - [x] examples
-- [x] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Request Body Object (`OpenAPI.Request`)
 - [x] description
 - [x] content
 - [x] required
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Media Type Object (`OpenAPI.Content`)
 - [x] schema
@@ -371,7 +371,7 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
 - [x] headers
 - [x] content
 - [ ] links
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Callback Object
 - [ ] *{expression}*
@@ -456,7 +456,7 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
 - [x] bearerFormat (`SecurityType` `.http` case)
 - [x] flows (`SecurityType` `.oauth2` case)
 - [x] openIdConnectUrl (`SecurityType` `.openIdConnect` case)
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### OAuth Flows Object (`OpenAPI.OauthFlows`)
 - [x] implicit

--- a/Sources/OpenAPIKit/CodableVendorExtendable.swift
+++ b/Sources/OpenAPIKit/CodableVendorExtendable.swift
@@ -40,6 +40,14 @@ extension ExtendableCodingKey {
     internal static func key(for value: String) -> Self {
         return Self(stringValue: value) ?? .extendedKey(for: value)
     }
+
+    internal init?(intValue: Int) {
+        return nil
+    }
+
+    internal var intValue: Int? {
+        return nil
+    }
 }
 
 internal protocol CodableVendorExtendable: VendorExtendable {

--- a/Sources/OpenAPIKit/Component Object/Components.swift
+++ b/Sources/OpenAPIKit/Component Object/Components.swift
@@ -242,10 +242,6 @@ extension OpenAPI.Components {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .schemas:
@@ -265,10 +261,6 @@ extension OpenAPI.Components {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Content/Content.swift
+++ b/Sources/OpenAPIKit/Content/Content.swift
@@ -187,10 +187,6 @@ extension OpenAPI.Content {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .schema:
@@ -204,10 +200,6 @@ extension OpenAPI.Content {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -28,15 +28,17 @@ extension OpenAPI {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(openAPIVersion: Version = .v3_0_0,
-                    info: Info,
-                    servers: [Server],
-                    paths: PathItem.Map,
-                    components: Components,
-                    security: [SecurityRequirement] = [],
-                    tags: [Tag]? = nil,
-                    externalDocs: ExternalDocumentation? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            openAPIVersion: Version = .v3_0_0,
+            info: Info,
+            servers: [Server],
+            paths: PathItem.Map,
+            components: Components,
+            security: [SecurityRequirement] = [],
+            tags: [Tag]? = nil,
+            externalDocs: ExternalDocumentation? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.openAPIVersion = openAPIVersion
             self.info = info
             self.servers = servers

--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -190,10 +190,6 @@ extension OpenAPI.Document {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .openAPIVersion:
@@ -215,10 +211,6 @@ extension OpenAPI.Document {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/DocumentInfo.swift
@@ -166,10 +166,6 @@ extension OpenAPI.Document.Info.License {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .name:
@@ -179,10 +175,6 @@ extension OpenAPI.Document.Info.License {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }
@@ -244,10 +236,6 @@ extension OpenAPI.Document.Info.Contact {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .name:
@@ -259,10 +247,6 @@ extension OpenAPI.Document.Info.Contact {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }
@@ -341,10 +325,6 @@ extension OpenAPI.Document.Info {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .title:
@@ -362,10 +342,6 @@ extension OpenAPI.Document.Info {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -134,10 +134,6 @@ extension OpenAPI.Example {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .summary:
@@ -151,10 +147,6 @@ extension OpenAPI.Example {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Operation.swift
+++ b/Sources/OpenAPIKit/Operation.swift
@@ -262,10 +262,6 @@ extension OpenAPI.Operation {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .tags:
@@ -293,10 +289,6 @@ extension OpenAPI.Operation {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Parameter/Parameter.swift
+++ b/Sources/OpenAPIKit/Parameter/Parameter.swift
@@ -344,10 +344,6 @@ extension OpenAPI.Parameter {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .name:
@@ -379,10 +375,6 @@ extension OpenAPI.Parameter {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/PathItem.swift
+++ b/Sources/OpenAPIKit/PathItem.swift
@@ -361,10 +361,6 @@ extension OpenAPI.PathItem {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .summary:
@@ -394,10 +390,6 @@ extension OpenAPI.PathItem {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Request.swift
+++ b/Sources/OpenAPIKit/Request.swift
@@ -71,10 +71,6 @@ extension OpenAPI.Request {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .description:
@@ -86,10 +82,6 @@ extension OpenAPI.Request {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Response.swift
+++ b/Sources/OpenAPIKit/Response.swift
@@ -182,10 +182,6 @@ extension OpenAPI.Response {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .description:
@@ -197,10 +193,6 @@ extension OpenAPI.Response {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Sources/OpenAPIKit/Response.swift
+++ b/Sources/OpenAPIKit/Response.swift
@@ -229,6 +229,8 @@ extension OpenAPI.Response: Decodable {
             headers = try container.decodeIfPresent(OpenAPI.Header.Map.self, forKey: .headers)
             content = try container.decodeIfPresent(OpenAPI.Content.Map.self, forKey: .content) ?? [:]
 
+            vendorExtensions = try Self.extensions(from: decoder)
+
         } catch let error as InconsistencyError {
 
             throw OpenAPI.Error.Decoding.Response(error)
@@ -239,8 +241,6 @@ extension OpenAPI.Response: Decodable {
 
             throw OpenAPI.Error.Decoding.Response(error)
         }
-
-        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -39,17 +39,28 @@ extension OpenAPI.Server {
     /// OpenAPI Spec "Server Variable Object"
     ///
     /// See [OpenAPI Server Variable Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#server-variable-object).
-    public struct Variable: Equatable {
-        public let `enum`: [String]
-        public let `default`: String
-        public let description: String?
+    public struct Variable: Equatable, CodableVendorExtendable {
+        public var `enum`: [String]
+        public var `default`: String
+        public var description: String?
 
-        public init(enum: [String] = [],
-                    default: String,
-                    description: String? = nil) {
+        /// Dictionary of vendor extensions.
+        ///
+        /// These should be of the form:
+        /// `[ "x-extensionKey": <anything>]`
+        /// where the values are anything codable.
+        public var vendorExtensions: [String: AnyCodable]
+
+        public init(
+            enum: [String] = [],
+            default: String,
+            description: String? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.enum = `enum`
             self.default = `default`
             self.description = description
+            self.vendorExtensions = vendorExtensions
         }
     }
 }
@@ -140,6 +151,8 @@ extension OpenAPI.Server.Variable: Encodable {
         try container.encode(`default`, forKey: .default)
 
         try container.encodeIfPresent(description, forKey: .description)
+
+        try encodeExtensions(to: &container)
     }
 }
 
@@ -152,13 +165,54 @@ extension OpenAPI.Server.Variable: Decodable {
         `default` = try container.decode(String.self, forKey: .default)
 
         description = try container.decodeIfPresent(String.self, forKey: .description)
+
+        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 
 extension OpenAPI.Server.Variable {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: ExtendableCodingKey {
         case `enum`
         case `default`
         case description
+        case extended(String)
+
+        static var allBuiltinKeys: [CodingKeys] {
+            return [
+                .enum,
+                .default,
+                .description
+            ]
+        }
+
+        static func extendedKey(for value: String) -> CodingKeys {
+            return .extended(value)
+        }
+
+        init?(stringValue: String) {
+            switch stringValue {
+            case "enum":
+                self = .enum
+            case "default":
+                self = .default
+            case "description":
+                self = .description
+            default:
+                self = .extendedKey(for: stringValue)
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .enum:
+                return "enum"
+            case .default:
+                return "default"
+            case .description:
+                return "description"
+            case .extended(let key):
+                return key
+            }
+        }
     }
 }

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -116,10 +116,6 @@ extension OpenAPI.Server {
             }
         }
 
-        init?(intValue: Int) {
-            return nil
-        }
-
         var stringValue: String {
             switch self {
             case .url:
@@ -131,10 +127,6 @@ extension OpenAPI.Server {
             case .extended(let key):
                 return key
             }
-        }
-
-        var intValue: Int? {
-            return nil
         }
     }
 }

--- a/Tests/OpenAPIKitTests/RequestTests.swift
+++ b/Tests/OpenAPIKitTests/RequestTests.swift
@@ -181,6 +181,49 @@ extension RequestTests {
                                                 content: [:]))
     }
 
+    func test_withDescription_withExtension_encode() {
+        let request = OpenAPI.Request(
+            description: "A request",
+            content: [:],
+            vendorExtensions: [ "x-specialFeature": "ok" ]
+        )
+        let encodedString = try! testStringFromEncoding(of: request)
+
+        assertJSONEquivalent(encodedString,
+"""
+{
+  "content" : {
+
+  },
+  "description" : "A request",
+  "x-specialFeature" : "ok"
+}
+"""
+        )
+    }
+
+    func test_withDescription_withExtension_decode() {
+        let requestData =
+"""
+{
+  "content" : {},
+  "description" : "A request",
+  "x-specialFeature" : "ok"
+}
+""".data(using: .utf8)!
+
+        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+
+        XCTAssertEqual(
+            request,
+            OpenAPI.Request(
+                description: "A request",
+                content: [:],
+                vendorExtensions: [ "x-specialFeature": "ok" ]
+            )
+        )
+    }
+
     func test_withRequired_encode() {
         let request = OpenAPI.Request(content: [:],
                                       required: true)

--- a/Tests/OpenAPIKitTests/SecuritySchemeTests.swift
+++ b/Tests/OpenAPIKitTests/SecuritySchemeTests.swift
@@ -292,4 +292,49 @@ extension SecuritySchemeTests {
             OpenAPI.SecurityScheme.openIdConnect(url: URL(string: "http://google.com")!)
         )
     }
+
+    func test_openIdConnect_withExtension_encode() throws {
+        let openIdConnect = OpenAPI.SecurityScheme(
+            type: .openIdConnect(
+                openIdConnectUrl: URL(string: "http://google.com")!
+            ),
+            vendorExtensions: [ "x-specialFeature": "hello" ]
+        )
+
+        let encodedOpenIdConnect = try testStringFromEncoding(of: openIdConnect)
+
+        assertJSONEquivalent(
+            encodedOpenIdConnect,
+"""
+{
+  "openIdConnectUrl" : "http:\\/\\/google.com",
+  "type" : "openIdConnect",
+  "x-specialFeature" : "hello"
+}
+"""
+        )
+    }
+
+    func test_openIdConnect_withExtension_decode() throws {
+        let openIdConnectData =
+"""
+{
+  "openIdConnectUrl" : "http:\\/\\/google.com",
+  "type" : "openIdConnect",
+  "x-specialFeature" : "hello"
+}
+""".data(using: .utf8)!
+
+        let openIdConnect = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: openIdConnectData)
+
+        XCTAssertEqual(
+            openIdConnect,
+            OpenAPI.SecurityScheme(
+                type: .openIdConnect(
+                    openIdConnectUrl: URL(string: "http://google.com")!
+                ),
+                vendorExtensions: [ "x-specialFeature": "hello" ]
+            )
+        )
+    }
 }

--- a/Tests/OpenAPIKitTests/ServerTests.swift
+++ b/Tests/OpenAPIKitTests/ServerTests.swift
@@ -85,7 +85,8 @@ extension ServerTests {
         "hello": {
             "enum": ["hello"],
             "default": "hello",
-            "description": "hello again"
+            "description": "hello again",
+            "x-otherThing": 1234
         }
     },
     "x-specialFeature": [
@@ -103,9 +104,12 @@ extension ServerTests {
                 url: URL(string: "https://hello.com")!,
                 description: "hello world",
                 variables: [
-                    "hello": .init(enum: ["hello"],
-                                   default: "hello",
-                                   description: "hello again")
+                    "hello": .init(
+                        enum: ["hello"],
+                        default: "hello",
+                        description: "hello again",
+                        vendorExtensions: [ "x-otherThing": 1234 ]
+                    )
                 ],
                 vendorExtensions: ["x-specialFeature": ["hello", "world"]]
             )
@@ -117,9 +121,12 @@ extension ServerTests {
             url: URL(string: "https://hello.com")!,
             description: "hello world",
             variables: [
-                "hello": .init(enum: ["hello"],
-                               default: "hello",
-                               description: "hello again")
+                "hello": .init(
+                    enum: ["hello"],
+                    default: "hello",
+                    description: "hello again",
+                    vendorExtensions: [ "x-otherThing": 1234 ]
+                )
             ],
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
@@ -136,7 +143,8 @@ extension ServerTests {
       "description" : "hello again",
       "enum" : [
         "hello"
-      ]
+      ],
+      "x-otherThing" : 1234
     }
   },
   "x-specialFeature" : [

--- a/Tests/OpenAPIKitTests/VendorExtendableTests.swift
+++ b/Tests/OpenAPIKitTests/VendorExtendableTests.swift
@@ -142,12 +142,6 @@ private struct TestStruct: Codable, CodableVendorExtendable {
             default: return nil
             }
         }
-
-        var intValue: Int? { return nil }
-
-        init?(intValue: Int) {
-            return nil
-        }
     }
 
     public let vendorExtensions: Self.VendorExtensions


### PR DESCRIPTION
Add vendor extension support to:
- `OpenAPI.Request`
- `OpenAPI.Response`
- `OpenAPI.SecurityScheme`
- `OpenAPI.Server.Variable`