### PR TITLE
Add vendor extensions to external documentation, header, and tag types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
 ### External Document Object (`OpenAPI.ExternalDocumentation`)
 - [x] description
 - [x] url
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Parameter Object (`OpenAPI.Parameter`)
 - [x] name
@@ -404,13 +404,13 @@ See [**A note on dictionary ordering**](#a-note-on-dictionary-ordering) before d
     - [x] allowReserved
     - [x] example
     - [x] examples
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Tag Object (`OpenAPI.Tag`)
 - [x] name
 - [x] description
 - [x] externalDocs
-- [ ] specification extensions
+- [x] specification extensions (`vendorExtensions`)
 
 ### Reference Object (`JSONReference`)
 - [x] $ref

--- a/Sources/OpenAPIKit/Tag.swift
+++ b/Sources/OpenAPIKit/Tag.swift
@@ -11,17 +11,28 @@ extension OpenAPI {
     /// OpenAPI Spec "Tag Object"
     ///
     /// See [OpenAPI Tag Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#tag-object).
-    public struct Tag: Equatable {
+    public struct Tag: Equatable, CodableVendorExtendable {
         public let name: String
         public let description: String?
         public let externalDocs: ExternalDocumentation?
 
-        public init(name: String,
-                    description: String? = nil,
-                    externalDocs: ExternalDocumentation? = nil) {
+        /// Dictionary of vendor extensions.
+        ///
+        /// These should be of the form:
+        /// `[ "x-extensionKey": <anything>]`
+        /// where the values are anything codable.
+        public var vendorExtensions: [String: AnyCodable]
+
+        public init(
+            name: String,
+            description: String? = nil,
+            externalDocs: ExternalDocumentation? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.name = name
             self.description = description
             self.externalDocs = externalDocs
+            self.vendorExtensions = vendorExtensions
         }
     }
 }
@@ -43,6 +54,8 @@ extension OpenAPI.Tag: Encodable {
         try container.encodeIfPresent(description, forKey: .description)
 
         try container.encodeIfPresent(externalDocs, forKey: .externalDocs)
+
+        try encodeExtensions(to: &container)
     }
 }
 
@@ -55,13 +68,54 @@ extension OpenAPI.Tag: Decodable {
         description = try container.decodeIfPresent(String.self, forKey: .description)
 
         externalDocs = try container.decodeIfPresent(OpenAPI.ExternalDocumentation.self, forKey: .externalDocs)
+
+        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 
 extension OpenAPI.Tag {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: ExtendableCodingKey {
         case name
         case description
         case externalDocs
+        case extended(String)
+
+        static var allBuiltinKeys: [CodingKeys] {
+            return [
+                .name,
+                .description,
+                .externalDocs
+            ]
+        }
+
+        static func extendedKey(for value: String) -> CodingKeys {
+            return .extended(value)
+        }
+
+        init?(stringValue: String) {
+            switch stringValue {
+            case "name":
+                self = .name
+            case "description":
+                self = .description
+            case "externalDocs":
+                self = .externalDocs
+            default:
+                self = .extendedKey(for: stringValue)
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .name:
+                return "name"
+            case .description:
+                return "description"
+            case .externalDocs:
+                return "externalDocs"
+            case .extended(let key):
+                return key
+            }
+        }
     }
 }

--- a/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
+++ b/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ExternalDocTests.swift
+//  ExternalDocumentationTests.swift
 //  OpenAPIKitTests
 //
 //  Created by Mathew Polzin on 10/18/19.
@@ -8,7 +8,7 @@
 import XCTest
 import OpenAPIKit
 
-final class ExternalDocTests: XCTestCase {
+final class ExternalDocumentationTests: XCTestCase {
     func test_init() {
         let t1 = OpenAPI.ExternalDocumentation(url: URL(string: "http://google.com")!)
         XCTAssertNil(t1.description)
@@ -20,7 +20,48 @@ final class ExternalDocTests: XCTestCase {
 }
 
 // MARK: - Codable
-extension ExternalDocTests {
+extension ExternalDocumentationTests {
+    func test_descriptionAndUrlAndExtension_encode() {
+        let externalDoc = OpenAPI.ExternalDocumentation(
+            description: "hello world",
+            url: URL(string: "http://google.com")!,
+            vendorExtensions: [ "x-specialFeature": "hi" ]
+        )
+
+        let encodedExternalDoc = try! testStringFromEncoding(of: externalDoc)
+
+        assertJSONEquivalent(encodedExternalDoc,
+"""
+{
+  "description" : "hello world",
+  "url" : "http:\\/\\/google.com",
+  "x-specialFeature" : "hi"
+}
+"""
+        )
+    }
+
+    func test_descriptionAndUrlAndExtension_decode() {
+        let externalDocsData =
+"""
+{
+  "description" : "hello world",
+  "url" : "http:\\/\\/google.com",
+  "x-specialFeature" : "hi"
+}
+""".data(using: .utf8)!
+        let externalDocs = try! testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
+
+        XCTAssertEqual(
+            externalDocs,
+            OpenAPI.ExternalDocumentation(
+                description: "hello world",
+                url: URL(string: "http://google.com")!,
+                vendorExtensions: [ "x-specialFeature": "hi" ]
+            )
+        )
+    }
+
     func test_descriptionAndUrl_encode() {
         let externalDoc = OpenAPI.ExternalDocumentation(description: "hello world",
                                               url: URL(string: "http://google.com")!)

--- a/Tests/OpenAPIKitTests/HeaderTests.swift
+++ b/Tests/OpenAPIKitTests/HeaderTests.swift
@@ -140,6 +140,41 @@ extension HeaderTests {
         )
     }
 
+    func test_header_schema_withExntesion_encode() throws {
+        let header = OpenAPI.Header(schema: .string, vendorExtensions: ["x-hello": "hi"])
+
+        let headerEncoding = try testStringFromEncoding(of: header)
+
+        assertJSONEquivalent(headerEncoding,
+"""
+{
+  "schema" : {
+    "type" : "string"
+  },
+  "x-hello" : "hi"
+}
+"""
+        )
+    }
+
+    func test_header_schema_withExtension_decode() throws {
+        let headerData =
+"""
+{
+  "schema" : {
+    "type" : "string"
+  },
+  "x-hello" : "hi"
+}
+""".data(using: .utf8)!
+        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+
+        XCTAssertEqual(
+            header,
+            OpenAPI.Header(schema: .string(required: false), vendorExtensions: ["x-hello": "hi"])
+        )
+    }
+
     func test_header_required_encode() throws {
         let header = OpenAPI.Header(
             content: [

--- a/Tests/OpenAPIKitTests/TagTests.swift
+++ b/Tests/OpenAPIKitTests/TagTests.swift
@@ -82,9 +82,14 @@ extension TagTests {
     }
 
     func test_allFields_encode() {
-        let tag = OpenAPI.Tag(name: "hello",
-                              description: "world",
-                              externalDocs: .init(url: URL(string: "http://google.com")!))
+        let tag = OpenAPI.Tag(
+            name: "hello",
+            description: "world",
+            externalDocs: .init(
+                url: URL(string: "http://google.com")!
+            ),
+            vendorExtensions: ["x-specialFeature": false]
+        )
         let encodedTag = try! testStringFromEncoding(of: tag)
 
         assertJSONEquivalent(encodedTag,
@@ -94,7 +99,8 @@ extension TagTests {
   "externalDocs" : {
     "url" : "http:\\/\\/google.com"
   },
-  "name" : "hello"
+  "name" : "hello",
+  "x-specialFeature" : false
 }
 """
         )
@@ -108,13 +114,20 @@ extension TagTests {
     "description": "world",
     "externalDocs": {
         "url": "http://google.com"
-    }
+    },
+    "x-specialFeature" : false
 }
 """.data(using: .utf8)!
         let tag = try! testDecoder.decode(OpenAPI.Tag.self, from: tagData)
 
-        XCTAssertEqual(tag, OpenAPI.Tag(name: "hello",
-                                        description: "world",
-                                        externalDocs: .init(url: URL(string: "http://google.com")!)))
+        XCTAssertEqual(
+            tag,
+            OpenAPI.Tag(
+                name: "hello",
+                description: "world",
+                externalDocs: .init(url: URL(string: "http://google.com")!),
+                vendorExtensions: ["x-specialFeature": false]
+            )
+        )
     }
 }


### PR DESCRIPTION
Add vendor extension support to:
- `OpenAPI.ExternalDocumentation`
- `OpenAPI.Header`
- `OpenAPI.Tag`