### PR TITLE
Get all routes

### DIFF
--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -52,6 +52,31 @@ extension OpenAPI {
     }
 }
 
+extension OpenAPI.Document {
+    /// A `Route` is the combination of a path (where the route lives)
+    /// and a path item (the definition of the route).
+    public struct Route: Equatable {
+        public let path: OpenAPI.Path
+        public let pathItem: OpenAPI.PathItem
+
+        public init(
+            path: OpenAPI.Path,
+            pathItem: OpenAPI.PathItem
+        ) {
+            self.path = path
+            self.pathItem = pathItem
+        }
+    }
+
+    /// Get all routes for this document.
+    ///
+    /// - Returns: An Array of `Routes` with the path
+    ///     and the definition of the route.
+    public var routes: [Route] {
+        return paths.map { (path, pathItem) in .init(path: path, pathItem: pathItem) }
+    }
+}
+
 extension OpenAPI {
     /// If the security scheme is of type "oauth2" or "openIdConnect",
     /// then the value is a list of scope names required for the execution.

--- a/Sources/OpenAPIKit/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/DocumentInfo.swift
@@ -26,13 +26,15 @@ extension OpenAPI.Document {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(title: String,
-                    description: String? = nil,
-                    termsOfService: URL? = nil,
-                    contact: Contact? = nil,
-                    license: License? = nil,
-                    version: String,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            title: String,
+            description: String? = nil,
+            termsOfService: URL? = nil,
+            contact: Contact? = nil,
+            license: License? = nil,
+            version: String,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.title = title
             self.description = description
             self.termsOfService = termsOfService
@@ -57,10 +59,12 @@ extension OpenAPI.Document {
             /// where the values are anything codable.
             public var vendorExtensions: [String: AnyCodable]
 
-            public init(name: String? = nil,
-                        url: URL? = nil,
-                        email: String? = nil,
-                        vendorExtensions: [String: AnyCodable] = [:]) {
+            public init(
+                name: String? = nil,
+                url: URL? = nil,
+                email: String? = nil,
+                vendorExtensions: [String: AnyCodable] = [:]
+            ) {
                 self.name = name
                 self.url = url
                 self.email = email
@@ -82,9 +86,11 @@ extension OpenAPI.Document {
             /// where the values are anything codable.
             public var vendorExtensions: [String: AnyCodable]
 
-            public init(name: String,
-                        url: URL? = nil,
-                        vendorExtensions: [String: AnyCodable] = [:]) {
+            public init(
+                name: String,
+                url: URL? = nil,
+                vendorExtensions: [String: AnyCodable] = [:]
+            ) {
                 self.name = name
                 self.url = url
                 self.vendorExtensions = vendorExtensions

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -25,10 +25,12 @@ extension OpenAPI {
         /// where the values are anything codable.
         public let vendorExtensions: [String: AnyCodable]
 
-        public init(summary: String? = nil,
-                    description: String? = nil,
-                    value: Either<URL, AnyCodable>,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            summary: String? = nil,
+            description: String? = nil,
+            value: Either<URL, AnyCodable>,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.summary = summary
             self.description = description
             self.value = value

--- a/Sources/OpenAPIKit/Operation.swift
+++ b/Sources/OpenAPIKit/Operation.swift
@@ -32,18 +32,20 @@ extension OpenAPI {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(tags: [String]? = nil,
-                    summary: String? = nil,
-                    description: String? = nil,
-                    externalDocs: OpenAPI.ExternalDocumentation? = nil,
-                    operationId: String? = nil,
-                    parameters: Parameter.Array = [],
-                    requestBody: OpenAPI.Request? = nil,
-                    responses: OpenAPI.Response.Map,
-                    deprecated: Bool = false,
-                    security: [OpenAPI.SecurityRequirement]? = nil,
-                    servers: [OpenAPI.Server]? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            tags: [String]? = nil,
+            summary: String? = nil,
+            description: String? = nil,
+            externalDocs: OpenAPI.ExternalDocumentation? = nil,
+            operationId: String? = nil,
+            parameters: Parameter.Array = [],
+            requestBody: OpenAPI.Request? = nil,
+            responses: OpenAPI.Response.Map,
+            deprecated: Bool = false,
+            security: [OpenAPI.SecurityRequirement]? = nil,
+            servers: [OpenAPI.Server]? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.tags = tags
             self.summary = summary
             self.description = description
@@ -59,18 +61,20 @@ extension OpenAPI {
         }
 
         // variadic tags
-        public init(tags: String...,
-                    summary: String? = nil,
-                    description: String? = nil,
-                    externalDocs: OpenAPI.ExternalDocumentation? = nil,
-                    operationId: String? = nil,
-                    parameters: Parameter.Array = [],
-                    requestBody: OpenAPI.Request? = nil,
-                    responses: OpenAPI.Response.Map,
-                    deprecated: Bool = false,
-                    security: [OpenAPI.SecurityRequirement]? = nil,
-                    servers: [OpenAPI.Server]? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            tags: String...,
+            summary: String? = nil,
+            description: String? = nil,
+            externalDocs: OpenAPI.ExternalDocumentation? = nil,
+            operationId: String? = nil,
+            parameters: Parameter.Array = [],
+            requestBody: OpenAPI.Request? = nil,
+            responses: OpenAPI.Response.Map,
+            deprecated: Bool = false,
+            security: [OpenAPI.SecurityRequirement]? = nil,
+            servers: [OpenAPI.Server]? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.init(
                 tags: tags,
                 summary: summary,

--- a/Sources/OpenAPIKit/PathItem.swift
+++ b/Sources/OpenAPIKit/PathItem.swift
@@ -64,19 +64,21 @@ extension OpenAPI {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(summary: String? = nil,
-                    description: String? = nil,
-                    servers: [OpenAPI.Server]? = nil,
-                    parameters: Parameter.Array = [],
-                    get: Operation? = nil,
-                    put: Operation? = nil,
-                    post: Operation? = nil,
-                    delete: Operation? = nil,
-                    options: Operation? = nil,
-                    head: Operation? = nil,
-                    patch: Operation? = nil,
-                    trace: Operation? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            summary: String? = nil,
+            description: String? = nil,
+            servers: [OpenAPI.Server]? = nil,
+            parameters: Parameter.Array = [],
+            get: Operation? = nil,
+            put: Operation? = nil,
+            post: Operation? = nil,
+            delete: Operation? = nil,
+            options: Operation? = nil,
+            head: Operation? = nil,
+            patch: Operation? = nil,
+            trace: Operation? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.summary = summary
             self.description = description
             self.servers = servers

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -23,10 +23,12 @@ extension OpenAPI {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(url: URL,
-                    description: String? = nil,
-                    variables: OrderedDictionary<String, Variable> = [:],
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        public init(
+            url: URL,
+            description: String? = nil,
+            variables: OrderedDictionary<String, Variable> = [:],
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.url = url
             self.description = description
             self.variables = variables

--- a/Tests/OpenAPIKitTests/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/DocumentTests.swift
@@ -41,6 +41,43 @@ final class DocumentTests: XCTestCase {
         )
     }
 
+    func test_getRoutes() {
+        let pi1 = OpenAPI.PathItem(
+            parameters: [],
+            get: .init(
+                tags: "hi",
+                parameters: [],
+                responses: [:]
+            )
+        )
+
+        let pi2 = OpenAPI.PathItem(
+            get: .init(
+                responses: [:]
+            )
+        )
+
+        let test = OpenAPI.Document(
+            info: .init(title: "hi", version: "1.0"),
+            servers: [
+                .init(url: URL(string: "https://google.com")!)
+            ],
+            paths: [
+                "/hi/there": pi1,
+                "/hi": pi2
+            ],
+            components: .init(schemas: ["hello": .string])
+        )
+
+        XCTAssertEqual(
+            test.routes,
+            [
+                .init(path: "/hi/there", pathItem: pi1),
+                .init(path: "/hi", pathItem: pi2)
+            ]
+        )
+    }
+
     func test_existingSecuritySchemeSuccess() {
         let docData =
 """


### PR DESCRIPTION
- Adds `routes` accessor on `OpenAPI.Document` to retrieve an array of pairings of `Path` and `PathItem`.
- Changes remaining places where initializers used default Xcode indentation.