### PR TITLE
Get all servers

### DIFF
--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -92,18 +92,6 @@ extension OpenAPI {
         /// Additional external documentation.
         public var externalDocs: ExternalDocumentation?
 
-        /// Retrieve an array of all Operation Ids defined by
-        /// this API. These Ids are guaranteed to be unique by
-        /// the OpenAPI Specification.
-        ///
-        /// See [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operation-object) in the specifcation.
-        ///
-        public var allOperationIds: [String] {
-            return paths.values
-                .flatMap { $0.endpoints }
-                .compactMap { $0.operation.operationId }
-        }
-
         /// Dictionary of vendor extensions.
         ///
         /// These should be of the form:
@@ -157,6 +145,93 @@ extension OpenAPI.Document {
     ///     and the definition of the route.
     public var routes: [Route] {
         return paths.map { (path, pathItem) in .init(path: path, pathItem: pathItem) }
+    }
+
+    /// Retrieve an array of all Operation Ids defined by
+    /// this API. These Ids are guaranteed to be unique by
+    /// the OpenAPI Specification.
+    ///
+    /// The ordering is not necessarily significant, but it will
+    /// be the order in which each operation is occurred within
+    /// each path, traversed in the order the paths appear in
+    /// the document.
+    ///
+    /// See [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operation-object) in the specifcation.
+    ///
+    public var allOperationIds: [String] {
+        return paths.values
+            .flatMap { $0.endpoints }
+            .compactMap { $0.operation.operationId }
+    }
+
+    /// All servers referenced anywhere in the whole document.
+    ///
+    /// The `servers` property on `OpenAPI.Document` contains
+    /// servers that are applicable to all paths and operations that
+    /// do not define their own `serves` array that overrides the root
+    /// array.
+    ///
+    /// This property contains all servers defined at any level the document
+    /// and therefore may or may not contain servers not found in the
+    /// root servers array.
+    ///
+    /// - Important: For the purposes of returning one of each `Server`,
+    ///     two servers are considered identical if they have the same `url`
+    ///     and `variables`. Differing `description` properties for
+    ///     otherwise identical servers are considered to be two ways to
+    ///     describe the same server. `vendorExtensions` are also
+    ///     ignored when determining server uniqueness.
+    ///
+    ///     The first `Server` encountered will be used, so if the only
+    ///     difference between a server at the root document level and
+    ///     one in an `Operation`'s override of the servers array is the
+    ///     description, the description of the `Server` returned by this
+    ///     property will be that of the root document definition.
+    ///
+    public var allServers: [OpenAPI.Server] {
+        // We hash `Variable` without its
+        // `description` or `vendorExtensions`.
+        func hash(variable: OpenAPI.Server.Variable, into hasher: inout Hasher) {
+            hasher.combine(variable.enum)
+            hasher.combine(variable.default)
+        }
+
+        // We hash `Server` without its `description` or
+        // `vendorExtensions`.
+        func hash(server: OpenAPI.Server, into hasher: inout Hasher) {
+            hasher.combine(server.url)
+            for (key, value) in server.variables {
+                hasher.combine(key)
+                hash(variable: value, into: &hasher)
+            }
+        }
+
+        func hash(for server: OpenAPI.Server) -> Int {
+            var hasher = Hasher()
+            hash(server: server, into: &hasher)
+            return hasher.finalize()
+        }
+
+        var seenHashes = Set<Int>()
+        var returnValues = servers
+
+        func insertUniquely(server: OpenAPI.Server) {
+            let serverHash = hash(for: server)
+            if !seenHashes.contains(serverHash) {
+                seenHashes.insert(serverHash)
+                returnValues.append(server)
+            }
+        }
+
+        for pathItem in paths.values {
+            let pathItemServers = pathItem.servers ?? []
+            pathItemServers.forEach(insertUniquely)
+
+            let endpointServers = pathItem.endpoints.flatMap { $0.operation.servers ?? [] }
+            endpointServers.forEach(insertUniquely)
+        }
+
+        return returnValues
     }
 }
 

--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -39,6 +39,11 @@ extension OpenAPI {
         /// If the servers property is not provided, or is an
         /// empty array, the default value is a Server Object with a url value of
         /// "/".
+        ///
+        /// - Important: If you want to get all servers mentioned anywhere in
+        ///     the whole document (including servers that appear in path items
+        ///     or operations but not at the root document level), use the
+        ///     `allServers` property instead.
         public var servers: [Server]
 
         /// All routes supported by this API. This property maps the path of each
@@ -166,14 +171,13 @@ extension OpenAPI.Document {
 
     /// All servers referenced anywhere in the whole document.
     ///
-    /// The `servers` property on `OpenAPI.Document` contains
-    /// servers that are applicable to all paths and operations that
-    /// do not define their own `serves` array that overrides the root
-    /// array.
-    ///
     /// This property contains all servers defined at any level the document
     /// and therefore may or may not contain servers not found in the
     /// root servers array.
+    ///
+    /// The `servers` property on `OpenAPI.Document`, by contrast, contains
+    /// servers that are applicable to all paths and operations that
+    /// do not define their own `serves` array to override the root array.
     ///
     /// - Important: For the purposes of returning one of each `Server`,
     ///     two servers are considered identical if they have the same `url`

--- a/Sources/OpenAPIKit/Document.swift
+++ b/Sources/OpenAPIKit/Document.swift
@@ -212,14 +212,14 @@ extension OpenAPI.Document {
             return hasher.finalize()
         }
 
-        var seenHashes = Set<Int>()
-        var returnValues = servers
+        var collectedServers = servers
+        var seenHashes = Set(servers.map(hash(for:)))
 
         func insertUniquely(server: OpenAPI.Server) {
             let serverHash = hash(for: server)
             if !seenHashes.contains(serverHash) {
                 seenHashes.insert(serverHash)
-                returnValues.append(server)
+                collectedServers.append(server)
             }
         }
 
@@ -231,7 +231,7 @@ extension OpenAPI.Document {
             endpointServers.forEach(insertUniquely)
         }
 
-        return returnValues
+        return collectedServers
     }
 }
 

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -11,6 +11,7 @@ extension OpenAPI {
     /// OpenAPI Spec "Server Object"
     ///
     /// See [OpenAPI Server Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#server-object).
+    ///
     public struct Server: Equatable, CodableVendorExtendable {
         public let url: URL
         public let description: String?
@@ -41,6 +42,7 @@ extension OpenAPI.Server {
     /// OpenAPI Spec "Server Variable Object"
     ///
     /// See [OpenAPI Server Variable Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#server-variable-object).
+    ///
     public struct Variable: Equatable, CodableVendorExtendable {
         public var `enum`: [String]
         public var `default`: String


### PR DESCRIPTION
Adds an accessor on `OpenAPI.Document` that collects all servers from anywhere in the document.