### PR TITLE
Fix optionality bug

### DIFF
--- a/Sources/OpenAPIKit/Component Object/Components+JSONReference.swift
+++ b/Sources/OpenAPIKit/Component Object/Components+JSONReference.swift
@@ -66,7 +66,7 @@ extension OpenAPI.Components {
     ///
     /// - Important: Dereferencing an external reference (i.e. one that points to another file)
     ///     is not currently supported by OpenAPIKit and will therefore always throw an error.
-    public func forceDereference<ReferenceType: ComponentDictionaryLocatable>(_ maybeReference: Either<JSONReference<ReferenceType>, ReferenceType>) throws -> ReferenceType? {
+    public func forceDereference<ReferenceType: ComponentDictionaryLocatable>(_ maybeReference: Either<JSONReference<ReferenceType>, ReferenceType>) throws -> ReferenceType {
         switch maybeReference {
         case .a(let reference):
             guard case .internal = reference else {


### PR DESCRIPTION
This is unfortunately technically a breaking change, but I am considering it a patch bug fix because the change is very isolated: `forceDereference()` on `OpenAPI.Components` exists specifically to dereference or error out _instead_ of returning an optional value and, in fact, it was not possible for it to return an optional value, but by sheer typo return was in fact marked optional.