### PR TITLE
Fixing urls for non foundation coders

### DIFF
--- a/Sources/OpenAPIKit/Document/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/Document/DocumentInfo.swift
@@ -125,7 +125,7 @@ extension OpenAPI.Document.Info.License: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(name, forKey: .name)
-        try container.encodeIfPresent(url, forKey: .url)
+        try container.encodeIfPresent(url?.absoluteString, forKey: .url)
 
         try encodeExtensions(to: &container)
     }
@@ -137,7 +137,7 @@ extension OpenAPI.Document.Info.License: Decodable {
 
         name = try container.decode(String.self, forKey: .name)
 
-        url = try container.decodeIfPresent(URL.self, forKey: .url)
+        url = try container.decodeURLAsStringIfPresent(forKey: .url)
 
         vendorExtensions = try Self.extensions(from: decoder)
     }
@@ -190,7 +190,7 @@ extension OpenAPI.Document.Info.Contact: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encodeIfPresent(name, forKey: .name)
-        try container.encodeIfPresent(url, forKey: .url)
+        try container.encodeIfPresent(url?.absoluteString, forKey: .url)
         try container.encodeIfPresent(email, forKey: .email)
 
         try encodeExtensions(to: &container)
@@ -202,7 +202,7 @@ extension OpenAPI.Document.Info.Contact: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         name = try container.decodeIfPresent(String.self, forKey: .name)
-        url = try container.decodeIfPresent(URL.self, forKey: .url)
+        url = try container.decodeURLAsStringIfPresent(forKey: .url)
         email = try container.decodeIfPresent(String.self, forKey: .email)
 
         vendorExtensions = try Self.extensions(from: decoder)
@@ -278,22 +278,10 @@ extension OpenAPI.Document.Info: Decodable {
 
         title = try container.decode(String.self, forKey: .title)
         description = try container.decodeIfPresent(String.self, forKey: .description)
+        termsOfService = try container.decodeURLAsStringIfPresent(forKey: .termsOfService)
         contact = try container.decodeIfPresent(Contact.self, forKey: .contact)
         license = try container.decodeIfPresent(License.self, forKey: .license)
         version = try container.decode(String.self, forKey: .version)
-
-        if let termsOfServiceString = try container.decodeIfPresent(String.self, forKey: .termsOfService) {
-            guard let url = URL(string: termsOfServiceString) else {
-                throw InconsistencyError(
-                    subjectName: "termsOfService",
-                    details: "If specified, the Terms of Service must be a valid URL",
-                    codingPath: container.codingPath
-                )
-            }
-            termsOfService = url
-        } else {
-            termsOfService = nil
-        }
 
         vendorExtensions = try Self.extensions(from: decoder)
     }

--- a/Sources/OpenAPIKit/Document/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/Document/DocumentInfo.swift
@@ -263,7 +263,7 @@ extension OpenAPI.Document.Info: Encodable {
 
         try container.encode(title, forKey: .title)
         try container.encodeIfPresent(description, forKey: .description)
-        try container.encodeIfPresent(termsOfService, forKey: .termsOfService)
+        try container.encodeIfPresent(termsOfService?.absoluteString, forKey: .termsOfService)
         try container.encodeIfPresent(contact, forKey: .contact)
         try container.encodeIfPresent(license, forKey: .license)
         try container.encode(version, forKey: .version)
@@ -278,10 +278,22 @@ extension OpenAPI.Document.Info: Decodable {
 
         title = try container.decode(String.self, forKey: .title)
         description = try container.decodeIfPresent(String.self, forKey: .description)
-        termsOfService = try container.decodeIfPresent(URL.self, forKey: .termsOfService)
         contact = try container.decodeIfPresent(Contact.self, forKey: .contact)
         license = try container.decodeIfPresent(License.self, forKey: .license)
         version = try container.decode(String.self, forKey: .version)
+
+        if let termsOfServiceString = try container.decodeIfPresent(String.self, forKey: .termsOfService) {
+            guard let url = URL(string: termsOfServiceString) else {
+                throw InconsistencyError(
+                    subjectName: "termsOfService",
+                    details: "If specified, the Terms of Service must be a valid URL",
+                    codingPath: container.codingPath
+                )
+            }
+            termsOfService = url
+        } else {
+            termsOfService = nil
+        }
 
         vendorExtensions = try Self.extensions(from: decoder)
     }

--- a/Sources/OpenAPIKit/ExternalDocumentation.swift
+++ b/Sources/OpenAPIKit/ExternalDocumentation.swift
@@ -41,7 +41,7 @@ extension OpenAPI.ExternalDocumentation: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encodeIfPresent(description, forKey: .description)
-        try container.encode(url, forKey: .url)
+        try container.encode(url.absoluteString, forKey: .url)
 
         try encodeExtensions(to: &container)
     }
@@ -52,7 +52,7 @@ extension OpenAPI.ExternalDocumentation: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         description = try container.decodeIfPresent(String.self, forKey: .description)
-        url = try container.decode(URL.self, forKey: .url)
+        url = try container.decodeURLAsString(forKey: .url)
 
         vendorExtensions = try Self.extensions(from: decoder)
     }

--- a/Sources/OpenAPIKit/Security/OAuthFlows.swift
+++ b/Sources/OpenAPIKit/Security/OAuthFlows.swift
@@ -171,7 +171,7 @@ extension OpenAPI.OAuthFlows.CommonFields: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encodeIfPresent(refreshUrl, forKey: .refreshUrl)
+        try container.encodeIfPresent(refreshUrl?.absoluteString, forKey: .refreshUrl)
         try container.encode(scopes, forKey: .scopes)
     }
 }
@@ -180,7 +180,7 @@ extension OpenAPI.OAuthFlows.CommonFields: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        refreshUrl = try container.decodeIfPresent(URL.self, forKey: .refreshUrl)
+        refreshUrl = try container.decodeURLAsStringIfPresent(forKey: .refreshUrl)
         scopes = try container.decode(OrderedDictionary<OpenAPI.OAuthFlows.Scope, OpenAPI.OAuthFlows.ScopeDescription>.self, forKey: .scopes)
     }
 }
@@ -191,7 +191,7 @@ extension OpenAPI.OAuthFlows.Implicit: Encodable {
 
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(authorizationUrl, forKey: .authorizationUrl)
+        try container.encode(authorizationUrl.absoluteString, forKey: .authorizationUrl)
     }
 }
 
@@ -201,7 +201,7 @@ extension OpenAPI.OAuthFlows.Implicit: Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        authorizationUrl = try container.decode(URL.self, forKey: .authorizationUrl)
+        authorizationUrl = try container.decodeURLAsString(forKey: .authorizationUrl)
     }
 }
 
@@ -211,7 +211,7 @@ extension OpenAPI.OAuthFlows.Password: Encodable {
 
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(tokenUrl, forKey: .tokenUrl)
+        try container.encode(tokenUrl.absoluteString, forKey: .tokenUrl)
     }
 }
 
@@ -221,7 +221,7 @@ extension OpenAPI.OAuthFlows.Password: Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        tokenUrl = try container.decode(URL.self, forKey: .tokenUrl)
+        tokenUrl = try container.decodeURLAsString(forKey: .tokenUrl)
     }
 }
 
@@ -231,7 +231,7 @@ extension OpenAPI.OAuthFlows.ClientCredentials: Encodable {
 
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(tokenUrl, forKey: .tokenUrl)
+        try container.encode(tokenUrl.absoluteString, forKey: .tokenUrl)
     }
 }
 
@@ -241,7 +241,7 @@ extension OpenAPI.OAuthFlows.ClientCredentials: Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        tokenUrl = try container.decode(URL.self, forKey: .tokenUrl)
+        tokenUrl = try container.decodeURLAsString(forKey: .tokenUrl)
     }
 }
 
@@ -251,8 +251,8 @@ extension OpenAPI.OAuthFlows.AuthorizationCode: Encodable {
 
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(tokenUrl, forKey: .tokenUrl)
-        try container.encode(authorizationUrl, forKey: .authorizationUrl)
+        try container.encode(tokenUrl.absoluteString, forKey: .tokenUrl)
+        try container.encode(authorizationUrl.absoluteString, forKey: .authorizationUrl)
     }
 }
 
@@ -262,7 +262,7 @@ extension OpenAPI.OAuthFlows.AuthorizationCode: Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        tokenUrl = try container.decode(URL.self, forKey: .tokenUrl)
-        authorizationUrl = try container.decode(URL.self, forKey: .authorizationUrl)
+        tokenUrl = try container.decodeURLAsString(forKey: .tokenUrl)
+        authorizationUrl = try container.decodeURLAsString(forKey: .authorizationUrl)
     }
 }

--- a/Sources/OpenAPIKit/Security/SecurityScheme.swift
+++ b/Sources/OpenAPIKit/Security/SecurityScheme.swift
@@ -103,7 +103,7 @@ extension OpenAPI.SecurityScheme: Encodable {
             try container.encodeIfPresent(bearerFormat, forKey: .bearerFormat)
         case .openIdConnect(openIdConnectUrl: let url):
             try container.encode(SecurityType.Name.openIdConnect, forKey: .type)
-            try container.encode(url, forKey: .openIdConnectUrl)
+            try container.encode(url.absoluteString, forKey: .openIdConnectUrl)
         case .oauth2(flows: let flows):
             try container.encode(SecurityType.Name.oauth2, forKey: .type)
             try container.encode(flows, forKey: .flows)
@@ -140,7 +140,7 @@ extension OpenAPI.SecurityScheme: Decodable {
             )
         case .openIdConnect:
             type = .openIdConnect(
-                openIdConnectUrl: try container.decode(URL.self, forKey: .openIdConnectUrl)
+                openIdConnectUrl: try container.decodeURLAsString(forKey: .openIdConnectUrl)
             )
         }
 

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -70,23 +70,11 @@ extension OpenAPI.Server {
 }
 
 // MARK: - Codable
-extension OpenAPI.Server: Decodable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        url = try container.decode(URL.self, forKey: .url)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
-        variables = try container.decodeIfPresent(OrderedDictionary<String, Variable>.self, forKey: .variables) ?? [:]
-
-        vendorExtensions = try Self.extensions(from: decoder)
-    }
-}
-
 extension OpenAPI.Server: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(url, forKey: .url)
+        try container.encode(url.absoluteString, forKey: .url)
 
         try container.encodeIfPresent(description, forKey: .description)
 
@@ -95,6 +83,18 @@ extension OpenAPI.Server: Encodable {
         }
 
         try encodeExtensions(to: &container)
+    }
+}
+
+extension OpenAPI.Server: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        url = try container.decodeURLAsString(forKey: .url)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        variables = try container.decodeIfPresent(OrderedDictionary<String, Variable>.self, forKey: .variables) ?? [:]
+
+        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 

--- a/Sources/OpenAPIKit/Utility/Container+DecodeURLAsString.swift
+++ b/Sources/OpenAPIKit/Utility/Container+DecodeURLAsString.swift
@@ -1,0 +1,37 @@
+//
+//  Container+DecodeURLAsString.swift
+//  
+//
+//  Created by Mathew Polzin on 7/5/20.
+//
+
+import Foundation
+
+extension KeyedDecodingContainerProtocol {
+    internal func decodeURLAsString(forKey key: Self.Key) throws -> URL {
+        let string = try decode(String.self, forKey: key)
+        guard let url = URL(string: string) else {
+            throw InconsistencyError(
+                subjectName: key.stringValue,
+                details: "If specified, must be a valid URL",
+                codingPath: codingPath
+            )
+        }
+        return url
+    }
+
+    internal func decodeURLAsStringIfPresent(forKey key: Self.Key) throws -> URL? {
+        guard let string = try decodeIfPresent(String.self, forKey: key) else  {
+            return nil
+        }
+
+        guard let url = URL(string: string) else {
+            throw InconsistencyError(
+                subjectName: key.stringValue,
+                details: "If specified, must be a valid URL",
+                codingPath: codingPath
+            )
+        }
+        return url
+    }
+}

--- a/Sources/OpenAPIKit/XML.swift
+++ b/Sources/OpenAPIKit/XML.swift
@@ -50,7 +50,7 @@ extension OpenAPI.XML: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encodeIfPresent(name, forKey: .name)
-        try container.encodeIfPresent(namespace, forKey: .namespace)
+        try container.encodeIfPresent(namespace?.absoluteString, forKey: .namespace)
         try container.encodeIfPresent(prefix, forKey: .prefix)
         if attribute {
             try container.encode(true, forKey: .attribute)
@@ -66,7 +66,7 @@ extension OpenAPI.XML: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         name = try container.decodeIfPresent(String.self, forKey: .name)
-        namespace = try container.decodeIfPresent(URL.self, forKey: .namespace)
+        namespace = try container.decodeURLAsStringIfPresent(forKey: .namespace)
         prefix = try container.decodeIfPresent(String.self, forKey: .prefix)
         attribute = try container.decodeIfPresent(Bool.self, forKey: .attribute) ?? false
         wrapped = try container.decodeIfPresent(Bool.self, forKey: .wrapped) ?? false

--- a/Tests/OpenAPIKitCompatibilitySuite/GoogleBooksAPITests.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/GoogleBooksAPITests.swift
@@ -55,6 +55,9 @@ final class GoogleBooksAPICampatibilityTests: XCTestCase {
         // contact name is Google
         XCTAssertEqual(apiDoc.info.contact?.name, "Google")
 
+        // contact URL was parsed as google.com
+        XCTAssertEqual(apiDoc.info.contact?.url, URL(string: "https://google.com")!)
+
         // no contact email is provided
         XCTAssert(apiDoc.info.contact?.email?.isEmpty ?? true)
 

--- a/Tests/OpenAPIKitTests/Document/DocumentInfoTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentInfoTests.swift
@@ -387,6 +387,20 @@ extension DocumentInfoTests {
         )
     }
 
+    func test_info_withTOS_decode_fails() {
+        let infoData =
+"""
+{
+  "termsOfService" : "#$%^&*",
+  "title" : "title",
+  "version" : "1.0"
+}
+""".data(using: .utf8)!
+        XCTAssertThrowsError( try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)) { error in
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `termsOfService`: If specified, must be a valid URL.")
+        }
+    }
+
     func test_info_withContact_encode() throws {
         let info = OpenAPI.Document.Info(
             title: "title",

--- a/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
+++ b/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
@@ -106,15 +106,27 @@ extension ExternalDocumentationTests {
         )
     }
 
-    func test_onlyUrl_decode() {
+    func test_onlyUrl_decode() throws {
         let externalDocsData =
 """
 {
   "url" : "http:\\/\\/google.com"
 }
 """.data(using: .utf8)!
-        let externalDocs = try! testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
+        let externalDocs = try testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
 
         XCTAssertEqual(externalDocs, OpenAPI.ExternalDocumentation(url: URL(string: "http://google.com")!))
+    }
+
+    func test_onlyUrl_decode_fails() {
+        let externalDocsData =
+"""
+{
+  "url" : "#$^&*^#$^"
+}
+""".data(using: .utf8)!
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)) { error in
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `url`: If specified, must be a valid URL.")
+        }
     }
 }

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -351,39 +351,6 @@ final class ValidatorTests: XCTestCase {
         }
     }
 
-    func test_failsParentURL() {
-        let server = OpenAPI.Server(
-            url: URL(string: "https://google.com")!,
-            description: "hello world",
-            variables: [:],
-            vendorExtensions: [
-                "x-string": "hello",
-                "x-int": 2244,
-                "x-double": 10.5,
-                "x-dict": [ "string": "world"],
-                "x-array": AnyCodable(["hello", nil, "world"])
-            ]
-        )
-
-        let document = OpenAPI.Document(
-            info: .init(title: "hello", version: "1.0"),
-            servers: [server],
-            paths: [:],
-            components: .noComponents
-        )
-
-        let validator = Validator()
-            .validating { (context: ValidationContext<URL>) in
-                [ ValidationError(reason: "just because", at: context.codingPath) ]
-        }
-
-        XCTAssertThrowsError(try document.validate(using: validator)) { error in
-            let error = error as? ValidationErrors
-            XCTAssertEqual(error?.values.count, 1)
-            XCTAssertEqual(error?.values.first?.reason, "just because")
-        }
-    }
-
     func test_failsNestedString() {
         let server = OpenAPI.Server(
             url: URL(string: "https://google.com")!,


### PR DESCRIPTION
Many encoding/decoding libraries appear to encode/decode `URL` as a keyed dictionary, which I can only assume is the default offered by `URL` itself. Foundation JSONEncoder/JSONDecoder is smarter somehow and it encodes/decodes URLs as string values.

Nevertheless, to support more encoder/decoder options without any cost to functionality or hardly any cost to complexity, this PR explicitly encodes URLs to string values and decodes them from string values.