### PR TITLE
Pure swift json test coders -- Not for merging

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "pure-swift-json",
+        "repositoryURL": "https://github.com/fabianfett/pure-swift-json",
+        "state": {
+          "branch": null,
+          "revision": "5dc8ec1d857f3b56e3a718a01165ae80c7677d48",
+          "version": "0.4.0"
+        }
+      },
+      {
         "package": "RichJSONParser",
         "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "3.0.0"), // just for tests
-        .package(url: "https://github.com/omochi/FineJSON.git", from: "1.14.0") // just for tests
+        .package(url: "https://github.com/omochi/FineJSON.git", from: "1.14.0"), // just for tests
+        .package(url: "https://github.com/fabianfett/pure-swift-json", from: "0.4.0") // just for tests
     ],
     targets: [
         .target(
@@ -23,7 +24,7 @@ let package = Package(
             dependencies: []),
         .testTarget(
             name: "OpenAPIKitTests",
-            dependencies: ["OpenAPIKit", "Yams", "FineJSON"]),
+            dependencies: ["OpenAPIKit", "Yams", "FineJSON", .product(name: "PureSwiftJSON", package: "pure-swift-json")]),
         .testTarget(
             name: "OpenAPIKitCompatibilitySuite",
             dependencies: ["OpenAPIKit", "Yams"]),

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -72,7 +72,7 @@ extension OpenAPI.Example: Encodable {
 
         switch value {
         case .a(let url):
-            try container.encode(url, forKey: .externalValue)
+            try container.encode(url.absoluteURL, forKey: .externalValue)
         case .b(let example):
             try container.encode(example, forKey: .value)
         }
@@ -93,7 +93,7 @@ extension OpenAPI.Example: Decodable {
             )
         }
 
-        let externalValue = try container.decodeIfPresent(URL.self, forKey: .externalValue)
+        let externalValue = try container.decodeURLAsStringIfPresent(forKey: .externalValue)
 
         summary = try container.decodeIfPresent(String.self, forKey: .summary)
         description = try container.decodeIfPresent(String.self, forKey: .description)

--- a/Tests/OpenAPIKitTests/ComponentsTests.swift
+++ b/Tests/OpenAPIKitTests/ComponentsTests.swift
@@ -196,7 +196,7 @@ extension ComponentsTests {
     func test_minimal_encode() throws {
         let t1 = OpenAPI.Components()
 
-        let encoded = try testStringFromEncoding(of: t1)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t1)
 
         assertJSONEquivalent(
             encoded,
@@ -216,7 +216,7 @@ extension ComponentsTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(OpenAPI.Components.self, from: t1)
+        let decoded = try orderUnstableDecode(OpenAPI.Components.self, from: t1)
 
         XCTAssertEqual(decoded, OpenAPI.Components())
     }
@@ -247,7 +247,7 @@ extension ComponentsTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encoded = try testStringFromEncoding(of: t1)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t1)
 
         assertJSONEquivalent(
             encoded,
@@ -361,7 +361,7 @@ extension ComponentsTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(OpenAPI.Components.self, from: t1)
+        let decoded = try orderUnstableDecode(OpenAPI.Components.self, from: t1)
 
         XCTAssertEqual(
             decoded,
@@ -399,8 +399,8 @@ extension ComponentsTests {
         let t1 = ComponentKeyWrapper(key: "shell0")
         let t2 = ComponentKeyWrapper(key: "hello_world1234-.")
 
-        let encoded1 = try testStringFromEncoding(of: t1)
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded1 = try orderUnstableTestStringFromEncoding(of: t1)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded1,
@@ -436,8 +436,8 @@ extension ComponentsTests {
 }
 """.data(using: .utf8)!
 
-        let decoded1 = try testDecoder.decode(ComponentKeyWrapper.self, from: t1)
-        let decoded2 = try testDecoder.decode(ComponentKeyWrapper.self, from: t2)
+        let decoded1 = try orderUnstableDecode(ComponentKeyWrapper.self, from: t1)
+        let decoded2 = try orderUnstableDecode(ComponentKeyWrapper.self, from: t2)
 
         XCTAssertEqual(decoded1.key, "shell0")
         XCTAssertEqual(decoded2.key, "1234-_.")
@@ -447,8 +447,8 @@ extension ComponentsTests {
         let t1 = ComponentKeyWrapper(key: "$hell0")
         let t2 = ComponentKeyWrapper(key: "hello world")
 
-        XCTAssertThrowsError(try testEncoder.encode(t1))
-        XCTAssertThrowsError(try testEncoder.encode(t2))
+        XCTAssertThrowsError(try orderUnstableEncode(t1))
+        XCTAssertThrowsError(try orderUnstableEncode(t2))
     }
 
     func test_unacceptableKeys_decode() {
@@ -466,8 +466,8 @@ extension ComponentsTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(ComponentKeyWrapper.self, from: t1))
-        XCTAssertThrowsError(try testDecoder.decode(ComponentKeyWrapper.self, from: t2))
+        XCTAssertThrowsError(try orderUnstableDecode(ComponentKeyWrapper.self, from: t1))
+        XCTAssertThrowsError(try orderUnstableDecode(ComponentKeyWrapper.self, from: t2))
     }
 }
 

--- a/Tests/OpenAPIKitTests/Content/ContentTests.swift
+++ b/Tests/OpenAPIKitTests/Content/ContentTests.swift
@@ -161,7 +161,7 @@ final class ContentTests: XCTestCase {
 extension ContentTests {
     func test_referenceContent_encode() {
         let content = OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!)))
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -183,14 +183,14 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content, OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!))))
     }
 
     func test_schemaContent_encode() {
         let content = OpenAPI.Content(schema: .init(.string))
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -212,7 +212,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content, OpenAPI.Content(schema: .init(.string(required: false))))
     }
@@ -220,7 +220,7 @@ extension ContentTests {
     func test_exampleAndSchemaContent_encode() {
         let content = OpenAPI.Content(schema: .init(.object(properties: ["hello": .string])),
                                       example: [ "hello": "world" ])
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -264,7 +264,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content.schema, .init(.object(required: false, properties: ["hello": .string])))
 
@@ -274,7 +274,7 @@ extension ContentTests {
     func test_examplesAndSchemaContent_encode() {
         let content = OpenAPI.Content(schema: .init(.object(properties: ["hello": .string])),
                                       examples: ["hello": .b(OpenAPI.Example(value: .init([ "hello": "world" ])))])
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -326,7 +326,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content.schema, .init(.object(required: false, properties: ["hello": .string])))
 
@@ -361,13 +361,13 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Content.self, from: contentData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
     }
 
     func test_encodingAndSchema_encode() {
         let content = OpenAPI.Content(schema: .init(.string),
                                       encoding: ["json": .init(contentType: .json)])
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -400,7 +400,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content, OpenAPI.Content(schema: .init(.string(required: false)),
                                                 encoding: ["json": .init(contentType: .json)]))
@@ -410,7 +410,7 @@ extension ContentTests {
         let content = OpenAPI.Content(schema: .init(.string),
                                       vendorExtensions: [ "x-hello": [ "world": 123 ] ])
 
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -430,7 +430,7 @@ extension ContentTests {
         let content = OpenAPI.Content(schema: .init(.string),
                                       vendorExtensions: [ "hello": [ "world": 123 ] ])
 
-        let encodedContent = try! testStringFromEncoding(of: content)
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
         assertJSONEquivalent(encodedContent,
 """
@@ -458,7 +458,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let content = try! testDecoder.decode(OpenAPI.Content.self, from: contentData)
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         let contentToMatch = OpenAPI.Content(schema: .init(.string(required: false)),
                                              vendorExtensions: ["x-hello": AnyCodable(["world": 123])])
@@ -487,7 +487,7 @@ extension ContentTests {
   10: "hello"
 }
 """.data(using: .utf8)!
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Content.self, from: contentData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
     }
 }
 
@@ -517,7 +517,7 @@ extension ContentTests {
     func test_encoding_minimal_encode() throws {
         let encoding = OpenAPI.Content.Encoding()
 
-        let encodedEncoding = try! testStringFromEncoding(of: encoding)
+        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -533,7 +533,7 @@ extension ContentTests {
 """
 {}
 """.data(using: .utf8)!
-        let encoding = try! testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(encoding, OpenAPI.Content.Encoding())
     }
@@ -541,7 +541,7 @@ extension ContentTests {
     func test_encoding_contentType_encode() throws {
         let encoding = OpenAPI.Content.Encoding(contentType: .csv)
 
-        let encodedEncoding = try! testStringFromEncoding(of: encoding)
+        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -559,7 +559,7 @@ extension ContentTests {
     "contentType": "text/csv"
 }
 """.data(using: .utf8)!
-        let encoding = try! testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(encoding, OpenAPI.Content.Encoding(contentType: .csv))
     }
@@ -569,7 +569,7 @@ extension ContentTests {
             "X-CustomThing": .init(OpenAPI.Header(schema: .string))
         ])
 
-        let encodedEncoding = try! testStringFromEncoding(of: encoding)
+        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -599,7 +599,7 @@ extension ContentTests {
   }
 }
 """.data(using: .utf8)!
-        let encoding = try testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(
             encoding,
@@ -612,7 +612,7 @@ extension ContentTests {
     func test_encoding_style_encode() throws {
         let encoding = OpenAPI.Content.Encoding(style: .pipeDelimited)
 
-        let encodedEncoding = try testStringFromEncoding(of: encoding)
+        let encodedEncoding = try orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -630,7 +630,7 @@ extension ContentTests {
   "style" : "pipeDelimited"
 }
 """.data(using: .utf8)!
-        let encoding = try! testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(
             encoding,
@@ -641,7 +641,7 @@ extension ContentTests {
     func test_encoding_explode_encode() throws {
         let encoding = OpenAPI.Content.Encoding(explode: false)
 
-        let encodedEncoding = try! testStringFromEncoding(of: encoding)
+        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -659,7 +659,7 @@ extension ContentTests {
   "explode" : false
 }
 """.data(using: .utf8)!
-        let encoding = try! testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(
             encoding,
@@ -670,7 +670,7 @@ extension ContentTests {
     func test_encoding_allowReserved_encode() throws {
         let encoding = OpenAPI.Content.Encoding(allowReserved: true)
 
-        let encodedEncoding = try! testStringFromEncoding(of: encoding)
+        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
         assertJSONEquivalent(encodedEncoding,
 """
@@ -688,7 +688,7 @@ extension ContentTests {
   "allowReserved" : true
 }
 """.data(using: .utf8)!
-        let encoding = try! testDecoder.decode(OpenAPI.Content.Encoding.self, from: encodingData)
+        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
         XCTAssertEqual(
             encoding,

--- a/Tests/OpenAPIKitTests/DiscriminatorTests.swift
+++ b/Tests/OpenAPIKitTests/DiscriminatorTests.swift
@@ -26,7 +26,7 @@ final class DiscriminatorTests: XCTestCase {
 extension DiscriminatorTests {
     func test_noMapping_encode() {
         let discriminator = OpenAPI.Discriminator(propertyName: "hello")
-        let encodedDiscriminator = try! testStringFromEncoding(of: discriminator)
+        let encodedDiscriminator = try! orderUnstableTestStringFromEncoding(of: discriminator)
 
         assertJSONEquivalent(encodedDiscriminator,
 """
@@ -44,7 +44,7 @@ extension DiscriminatorTests {
     "propertyName": "hello"
 }
 """.data(using: .utf8)!
-        let discriminator = try! testDecoder.decode(OpenAPI.Discriminator.self, from: discriminatorData)
+        let discriminator = try! orderUnstableDecode(OpenAPI.Discriminator.self, from: discriminatorData)
 
         XCTAssertEqual(discriminator, OpenAPI.Discriminator(propertyName: "hello"))
     }
@@ -52,7 +52,7 @@ extension DiscriminatorTests {
     func test_withMapping_encode() {
         let discriminator = OpenAPI.Discriminator(propertyName: "hello",
                                                   mapping: ["hello": "world"])
-        let encodedDiscriminator = try! testStringFromEncoding(of: discriminator)
+        let encodedDiscriminator = try! orderUnstableTestStringFromEncoding(of: discriminator)
 
         assertJSONEquivalent(encodedDiscriminator,
 """
@@ -76,7 +76,7 @@ extension DiscriminatorTests {
     }
 }
 """.data(using: .utf8)!
-        let discriminator = try! testDecoder.decode(OpenAPI.Discriminator.self, from: discriminatorData)
+        let discriminator = try! orderUnstableDecode(OpenAPI.Discriminator.self, from: discriminatorData)
 
         XCTAssertEqual(discriminator, OpenAPI.Discriminator(propertyName: "hello",
                                                             mapping: [ "hello": "world"]))

--- a/Tests/OpenAPIKitTests/Document/DocumentInfoTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentInfoTests.swift
@@ -38,7 +38,7 @@ extension DocumentInfoTests {
     func test_license_encode() throws {
         let license = OpenAPI.Document.Info.License.MIT
 
-        let encodedLicense = try testStringFromEncoding(of: license)
+        let encodedLicense = try orderUnstableTestStringFromEncoding(of: license)
 
         assertJSONEquivalent(encodedLicense,
 """
@@ -58,7 +58,7 @@ extension DocumentInfoTests {
   "url" : "https:\\/\\/www.mit.edu\\/~amini\\/LICENSE.md"
 }
 """.data(using: .utf8)!
-        let license = try testDecoder.decode(OpenAPI.Document.Info.License.self, from: licenseData)
+        let license = try orderUnstableDecode(OpenAPI.Document.Info.License.self, from: licenseData)
 
         XCTAssertEqual(
             license,
@@ -69,7 +69,7 @@ extension DocumentInfoTests {
     func test_license_withUrl_encode() throws {
         let license = OpenAPI.Document.Info.License.MIT(url: URL(string: "http://google.com")!)
 
-        let encodedLicense = try testStringFromEncoding(of: license)
+        let encodedLicense = try orderUnstableTestStringFromEncoding(of: license)
 
         assertJSONEquivalent(encodedLicense,
 """
@@ -89,7 +89,7 @@ extension DocumentInfoTests {
   "url" : "http://google.com"
 }
 """.data(using: .utf8)!
-        let license = try testDecoder.decode(OpenAPI.Document.Info.License.self, from: licenseData)
+        let license = try orderUnstableDecode(OpenAPI.Document.Info.License.self, from: licenseData)
 
         XCTAssertEqual(
             license,
@@ -104,7 +104,7 @@ extension DocumentInfoTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encodedLicense = try testStringFromEncoding(of: license)
+        let encodedLicense = try orderUnstableTestStringFromEncoding(of: license)
 
         assertJSONEquivalent(encodedLicense,
 """
@@ -132,7 +132,7 @@ extension DocumentInfoTests {
   ]
 }
 """.data(using: .utf8)!
-        let license = try testDecoder.decode(OpenAPI.Document.Info.License.self, from: licenseData)
+        let license = try orderUnstableDecode(OpenAPI.Document.Info.License.self, from: licenseData)
 
         XCTAssertEqual(
             license,
@@ -147,7 +147,7 @@ extension DocumentInfoTests {
     func test_contact_name_encode() throws {
         let contact = OpenAPI.Document.Info.Contact(name: "contact")
 
-        let encodedContact = try testStringFromEncoding(of: contact)
+        let encodedContact = try orderUnstableTestStringFromEncoding(of: contact)
 
         assertJSONEquivalent(encodedContact,
 """
@@ -165,7 +165,7 @@ extension DocumentInfoTests {
   "name" : "contact"
 }
 """.data(using: .utf8)!
-        let contact = try testDecoder.decode(OpenAPI.Document.Info.Contact.self, from: contactData)
+        let contact = try orderUnstableDecode(OpenAPI.Document.Info.Contact.self, from: contactData)
 
         XCTAssertEqual(
             contact,
@@ -176,7 +176,7 @@ extension DocumentInfoTests {
     func test_contact_url_encode() throws {
         let contact = OpenAPI.Document.Info.Contact(url: URL(string: "http://google.com")!)
 
-        let encodedContact = try testStringFromEncoding(of: contact)
+        let encodedContact = try orderUnstableTestStringFromEncoding(of: contact)
 
         assertJSONEquivalent(encodedContact,
 """
@@ -194,7 +194,7 @@ extension DocumentInfoTests {
   "url" : "http://google.com"
 }
 """.data(using: .utf8)!
-        let contact = try testDecoder.decode(OpenAPI.Document.Info.Contact.self, from: contactData)
+        let contact = try orderUnstableDecode(OpenAPI.Document.Info.Contact.self, from: contactData)
 
         XCTAssertEqual(
             contact,
@@ -205,7 +205,7 @@ extension DocumentInfoTests {
     func test_contact_email_encode() throws {
         let contact = OpenAPI.Document.Info.Contact(email: "email")
 
-        let encodedContact = try testStringFromEncoding(of: contact)
+        let encodedContact = try orderUnstableTestStringFromEncoding(of: contact)
 
         assertJSONEquivalent(encodedContact,
 """
@@ -223,7 +223,7 @@ extension DocumentInfoTests {
   "email" : "email"
 }
 """.data(using: .utf8)!
-        let contact = try testDecoder.decode(OpenAPI.Document.Info.Contact.self, from: contactData)
+        let contact = try orderUnstableDecode(OpenAPI.Document.Info.Contact.self, from: contactData)
 
         XCTAssertEqual(
             contact,
@@ -237,7 +237,7 @@ extension DocumentInfoTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encodedContact = try testStringFromEncoding(of: contact)
+        let encodedContact = try orderUnstableTestStringFromEncoding(of: contact)
 
         assertJSONEquivalent(encodedContact,
  """
@@ -263,7 +263,7 @@ extension DocumentInfoTests {
   ]
 }
 """.data(using: .utf8)!
-        let contact = try testDecoder.decode(OpenAPI.Document.Info.Contact.self, from: contactData)
+        let contact = try orderUnstableDecode(OpenAPI.Document.Info.Contact.self, from: contactData)
 
         XCTAssertEqual(
             contact,
@@ -277,7 +277,7 @@ extension DocumentInfoTests {
     func test_info_minimal_encode() throws {
         let info = OpenAPI.Document.Info(title: "title", version: "1.0")
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
 """
@@ -297,7 +297,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,
@@ -312,7 +312,7 @@ extension DocumentInfoTests {
             version: "1.0"
         )
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
 """
@@ -334,7 +334,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,
@@ -353,7 +353,7 @@ extension DocumentInfoTests {
             version: "1.0"
         )
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
 """
@@ -375,7 +375,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,
@@ -396,7 +396,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        XCTAssertThrowsError( try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)) { error in
+        XCTAssertThrowsError( try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)) { error in
             XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `termsOfService`: If specified, must be a valid URL.")
         }
     }
@@ -408,7 +408,7 @@ extension DocumentInfoTests {
             version: "1.0"
         )
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
                        """
@@ -434,7 +434,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,
@@ -453,7 +453,7 @@ extension DocumentInfoTests {
             version: "1.0"
         )
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
 """
@@ -479,7 +479,7 @@ extension DocumentInfoTests {
   "version" : "1.0"
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,
@@ -499,7 +499,7 @@ extension DocumentInfoTests {
             vendorExtensions: ["x-speacialFeature": ["hello", "world"]]
         )
 
-        let encodedInfo = try testStringFromEncoding(of: info)
+        let encodedInfo = try orderUnstableTestStringFromEncoding(of: info)
 
         assertJSONEquivalent(encodedInfo,
 """
@@ -533,7 +533,7 @@ extension DocumentInfoTests {
   ]
 }
 """.data(using: .utf8)!
-        let info = try testDecoder.decode(OpenAPI.Document.Info.self, from: infoData)
+        let info = try orderUnstableDecode(OpenAPI.Document.Info.self, from: infoData)
 
         XCTAssertEqual(
             info,

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -368,7 +368,7 @@ final class DocumentTests: XCTestCase {
 }
 """.data(using: .utf8)!
 
-        XCTAssertNoThrow(try JSONDecoder().decode(OpenAPI.Document.self, from: docData))
+        XCTAssertNoThrow(try orderUnstableDecode(OpenAPI.Document.self, from: docData))
     }
 }
 
@@ -381,7 +381,7 @@ extension DocumentTests {
             paths: [:],
             components: .noComponents
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -414,7 +414,7 @@ extension DocumentTests {
   }
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -435,7 +435,7 @@ extension DocumentTests {
             paths: [:],
             components: .noComponents
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -468,7 +468,7 @@ extension DocumentTests {
   }
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -489,7 +489,7 @@ extension DocumentTests {
             paths: [:],
             components: .noComponents
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -532,7 +532,7 @@ extension DocumentTests {
   ]
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -552,7 +552,7 @@ extension DocumentTests {
             paths: ["test": .init(summary: "hi")],
             components: .noComponents
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -589,7 +589,7 @@ extension DocumentTests {
   }
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -616,7 +616,7 @@ extension DocumentTests {
                               securitySchemes: ["security": .init(type: .apiKey(name: "key", location: .header))]),
             security: [[.component( named: "security"):[]]]
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -681,7 +681,7 @@ extension DocumentTests {
   ]
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -709,7 +709,7 @@ extension DocumentTests {
             components: .noComponents,
             tags: [.init(name: "hi")]
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -752,7 +752,7 @@ extension DocumentTests {
   ]
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -774,7 +774,7 @@ extension DocumentTests {
             components: .noComponents,
             externalDocs: .init(url: URL(string: "http://google.com")!)
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -813,7 +813,7 @@ extension DocumentTests {
   }
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,
@@ -836,7 +836,7 @@ extension DocumentTests {
             externalDocs: .init(url: URL(string: "http://google.com")!),
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
-        let encodedDocument = try testStringFromEncoding(of: document)
+        let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
 
         assertJSONEquivalent(
             encodedDocument,
@@ -883,7 +883,7 @@ extension DocumentTests {
   ]
 }
 """.data(using: .utf8)!
-        let document = try testDecoder.decode(OpenAPI.Document.self, from: documentData)
+        let document = try orderUnstableDecode(OpenAPI.Document.self, from: documentData)
 
         XCTAssertEqual(
             document,

--- a/Tests/OpenAPIKitTests/ExampleTests.swift
+++ b/Tests/OpenAPIKitTests/ExampleTests.swift
@@ -56,7 +56,7 @@ extension ExampleTests {
         )
     }
 
-    func test_summaryAndExternalExample_decode() {
+    func test_summaryAndExternalExample_decode() throws {
         let exampleData =
 """
 {
@@ -64,17 +64,17 @@ extension ExampleTests {
     "summary": "hello"
 }
 """.data(using: .utf8)!
-        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
+        let example = try orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(summary: "hello",
                                                 value: .init(URL(string: "https://google.com")!)))
         XCTAssertEqual(example.value.urlValue, URL(string: "https://google.com")!)
     }
 
-    func test_descriptionAndInternalExample_encode() {
+    func test_descriptionAndInternalExample_encode() throws {
         let example = OpenAPI.Example(description: "hello",
                                       value: .init("world"))
-        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
+        let encodedExample = try orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
 """
@@ -86,7 +86,7 @@ extension ExampleTests {
         )
     }
 
-    func test_descriptionAndInternalExample_decode() {
+    func test_descriptionAndInternalExample_decode() throws {
         let exampleData =
 """
 {
@@ -94,16 +94,16 @@ extension ExampleTests {
   "value" : "world"
 }
 """.data(using: .utf8)!
-        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
+        let example = try orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(description: "hello",
                                                 value: .init("world")))
     }
 
-    func test_vendorExtensionAndInternalExample_encode() {
+    func test_vendorExtensionAndInternalExample_encode() throws {
         let example = OpenAPI.Example(value: .init("world"),
                                       vendorExtensions: ["x-hello": 10])
-        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
+        let encodedExample = try orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
                        """
@@ -142,21 +142,21 @@ extension ExampleTests {
         )
     }
 
-    func test_internalExample_decode() {
+    func test_internalExample_decode() throws {
         let exampleData =
             """
 {
   "value" : "world"
 }
 """.data(using: .utf8)!
-        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
+        let example = try orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(value: .init("world")))
     }
 
-    func test_externalExample_encode() {
+    func test_externalExample_encode() throws {
         let example = OpenAPI.Example(value: .init(URL(string: "https://google.com")!))
-        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
+        let encodedExample = try orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
 """
@@ -167,14 +167,14 @@ extension ExampleTests {
         )
     }
 
-    func test_externalExample_decode() {
+    func test_externalExample_decode() throws {
         let exampleData =
 """
 {
   "externalValue" : "https://google.com"
 }
 """.data(using: .utf8)!
-        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
+        let example = try orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(value: .init(URL(string: "https://google.com")!)))
     }

--- a/Tests/OpenAPIKitTests/ExampleTests.swift
+++ b/Tests/OpenAPIKitTests/ExampleTests.swift
@@ -44,7 +44,7 @@ extension ExampleTests {
     func test_summaryAndExternalExample_encode() {
         let example = OpenAPI.Example(summary: "hello",
                                       value: .init(URL(string: "https://google.com")!))
-        let encodedExample = try! testStringFromEncoding(of: example)
+        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
 """
@@ -64,7 +64,7 @@ extension ExampleTests {
     "summary": "hello"
 }
 """.data(using: .utf8)!
-        let example = try! testDecoder.decode(OpenAPI.Example.self, from: exampleData)
+        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(summary: "hello",
                                                 value: .init(URL(string: "https://google.com")!)))
@@ -74,7 +74,7 @@ extension ExampleTests {
     func test_descriptionAndInternalExample_encode() {
         let example = OpenAPI.Example(description: "hello",
                                       value: .init("world"))
-        let encodedExample = try! testStringFromEncoding(of: example)
+        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
 """
@@ -94,7 +94,7 @@ extension ExampleTests {
   "value" : "world"
 }
 """.data(using: .utf8)!
-        let example = try! testDecoder.decode(OpenAPI.Example.self, from: exampleData)
+        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(description: "hello",
                                                 value: .init("world")))
@@ -103,7 +103,7 @@ extension ExampleTests {
     func test_vendorExtensionAndInternalExample_encode() {
         let example = OpenAPI.Example(value: .init("world"),
                                       vendorExtensions: ["x-hello": 10])
-        let encodedExample = try! testStringFromEncoding(of: example)
+        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
                        """
@@ -123,7 +123,7 @@ extension ExampleTests {
   "x-hello" : 10
 }
 """.data(using: .utf8)!
-        let example = try! testDecoder.decode(OpenAPI.Example.self, from: exampleData)
+        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(value: .init("world"),
                                                 vendorExtensions: ["x-hello": 10]))
@@ -131,7 +131,7 @@ extension ExampleTests {
 
     func test_internalExample_encode() {
         let example = OpenAPI.Example(value: .init("world"))
-        let encodedExample = try! testStringFromEncoding(of: example)
+        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
                        """
@@ -149,14 +149,14 @@ extension ExampleTests {
   "value" : "world"
 }
 """.data(using: .utf8)!
-        let example = try! testDecoder.decode(OpenAPI.Example.self, from: exampleData)
+        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(value: .init("world")))
     }
 
     func test_externalExample_encode() {
         let example = OpenAPI.Example(value: .init(URL(string: "https://google.com")!))
-        let encodedExample = try! testStringFromEncoding(of: example)
+        let encodedExample = try! orderUnstableTestStringFromEncoding(of: example)
 
         assertJSONEquivalent(encodedExample,
 """
@@ -174,7 +174,7 @@ extension ExampleTests {
   "externalValue" : "https://google.com"
 }
 """.data(using: .utf8)!
-        let example = try! testDecoder.decode(OpenAPI.Example.self, from: exampleData)
+        let example = try! orderUnstableDecode(OpenAPI.Example.self, from: exampleData)
 
         XCTAssertEqual(example, OpenAPI.Example(value: .init(URL(string: "https://google.com")!)))
     }
@@ -188,6 +188,6 @@ extension ExampleTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Example.self, from: exampleData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Example.self, from: exampleData))
     }
 }

--- a/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
+++ b/Tests/OpenAPIKitTests/ExternalDocumentationTests.swift
@@ -28,7 +28,7 @@ extension ExternalDocumentationTests {
             vendorExtensions: [ "x-specialFeature": "hi" ]
         )
 
-        let encodedExternalDoc = try! testStringFromEncoding(of: externalDoc)
+        let encodedExternalDoc = try! orderUnstableTestStringFromEncoding(of: externalDoc)
 
         assertJSONEquivalent(encodedExternalDoc,
 """
@@ -50,7 +50,7 @@ extension ExternalDocumentationTests {
   "x-specialFeature" : "hi"
 }
 """.data(using: .utf8)!
-        let externalDocs = try! testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
+        let externalDocs = try! orderUnstableDecode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
 
         XCTAssertEqual(
             externalDocs,
@@ -66,7 +66,7 @@ extension ExternalDocumentationTests {
         let externalDoc = OpenAPI.ExternalDocumentation(description: "hello world",
                                               url: URL(string: "http://google.com")!)
 
-        let encodedExternalDoc = try! testStringFromEncoding(of: externalDoc)
+        let encodedExternalDoc = try! orderUnstableTestStringFromEncoding(of: externalDoc)
 
         assertJSONEquivalent(encodedExternalDoc,
 """
@@ -86,7 +86,7 @@ extension ExternalDocumentationTests {
   "url" : "http:\\/\\/google.com"
 }
 """.data(using: .utf8)!
-        let externalDocs = try! testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
+        let externalDocs = try! orderUnstableDecode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
 
         XCTAssertEqual(externalDocs, OpenAPI.ExternalDocumentation(description: "hello world",
                                                 url: URL(string: "http://google.com")!))
@@ -95,7 +95,7 @@ extension ExternalDocumentationTests {
     func test_onlyUrl_encode() {
         let externalDoc = OpenAPI.ExternalDocumentation(url: URL(string: "http://google.com")!)
 
-        let encodedExternalDoc = try! testStringFromEncoding(of: externalDoc)
+        let encodedExternalDoc = try! orderUnstableTestStringFromEncoding(of: externalDoc)
 
         assertJSONEquivalent(encodedExternalDoc,
 """
@@ -113,7 +113,7 @@ extension ExternalDocumentationTests {
   "url" : "http:\\/\\/google.com"
 }
 """.data(using: .utf8)!
-        let externalDocs = try testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
+        let externalDocs = try orderUnstableDecode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)
 
         XCTAssertEqual(externalDocs, OpenAPI.ExternalDocumentation(url: URL(string: "http://google.com")!))
     }
@@ -125,7 +125,7 @@ extension ExternalDocumentationTests {
   "url" : "#$^&*^#$^"
 }
 """.data(using: .utf8)!
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)) { error in
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.ExternalDocumentation.self, from: externalDocsData)) { error in
             XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `url`: If specified, must be a valid URL.")
         }
     }

--- a/Tests/OpenAPIKitTests/Header/HeaderTests.swift
+++ b/Tests/OpenAPIKitTests/Header/HeaderTests.swift
@@ -67,7 +67,7 @@ extension HeaderTests {
             .json: .init(schema: .string)
         ])
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -97,7 +97,7 @@ extension HeaderTests {
   }
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -110,7 +110,7 @@ extension HeaderTests {
     func test_header_schema_encode() throws {
         let header = OpenAPI.Header(schema: .string)
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -132,7 +132,7 @@ extension HeaderTests {
   }
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -143,7 +143,7 @@ extension HeaderTests {
     func test_header_schema_withExntesion_encode() throws {
         let header = OpenAPI.Header(schema: .string, vendorExtensions: ["x-hello": "hi"])
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -167,7 +167,7 @@ extension HeaderTests {
   "x-hello" : "hi"
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -183,7 +183,7 @@ extension HeaderTests {
             required: true
         )
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -215,7 +215,7 @@ extension HeaderTests {
   "required" : true
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -236,7 +236,7 @@ extension HeaderTests {
             description: "hello"
         )
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -268,7 +268,7 @@ extension HeaderTests {
   "description" : "hello"
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -289,7 +289,7 @@ extension HeaderTests {
             deprecated: true
         )
 
-        let headerEncoding = try testStringFromEncoding(of: header)
+        let headerEncoding = try orderUnstableTestStringFromEncoding(of: header)
 
         assertJSONEquivalent(headerEncoding,
 """
@@ -321,7 +321,7 @@ extension HeaderTests {
   "deprecated" : true
 }
 """.data(using: .utf8)!
-        let header = try testDecoder.decode(OpenAPI.Header.self, from: headerData)
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
 
         XCTAssertEqual(
             header,
@@ -351,6 +351,6 @@ extension HeaderTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Header.self, from: headerData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Header.self, from: headerData))
     }
 }

--- a/Tests/OpenAPIKitTests/JSONReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/JSONReferenceTests.swift
@@ -133,7 +133,7 @@ extension JSONReferenceTests {
     func test_externalFileOnly_encode() throws {
         let test = ReferenceWrapper(reference: .external(URL(string: "hello.json")!))
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encoded,
@@ -157,7 +157,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(ReferenceWrapper.self, from: test)
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
 
         XCTAssertEqual(
             decoded,
@@ -168,7 +168,7 @@ extension JSONReferenceTests {
     func test_external_encode() throws {
         let test = ReferenceWrapper(reference: .external(URL(string: "hello.json#/hello/world")!))
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encoded,
@@ -192,7 +192,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(ReferenceWrapper.self, from: test)
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
 
         XCTAssertEqual(
             decoded,
@@ -203,7 +203,7 @@ extension JSONReferenceTests {
     func test_validComponent_encode() throws {
         let test = ReferenceWrapper(reference: .component(named: "hello"))
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encoded,
@@ -227,7 +227,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(ReferenceWrapper.self, from: test)
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
 
         XCTAssertEqual(
             decoded,
@@ -238,7 +238,7 @@ extension JSONReferenceTests {
     func test_nonComponentLocal_encode() throws {
         let test = ReferenceWrapper(reference: .internal(path: "/hello/world"))
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encoded,
@@ -262,7 +262,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(ReferenceWrapper.self, from: test)
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
 
         XCTAssertEqual(
             decoded,
@@ -273,7 +273,7 @@ extension JSONReferenceTests {
     func test_nonComponentSpecialCharacterLocal_encode() throws {
         let test = ReferenceWrapper(reference: .internal(path: "/hello~1to/the~0~1world"))
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encoded,
@@ -297,7 +297,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(ReferenceWrapper.self, from: test)
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
 
         XCTAssertEqual(
             decoded,
@@ -316,7 +316,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(ReferenceWrapper.self, from: test))
+        XCTAssertThrowsError(try orderUnstableDecode(ReferenceWrapper.self, from: test))
     }
 
     func test_emptyStringFailure_decode() {
@@ -329,7 +329,7 @@ extension JSONReferenceTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(ReferenceWrapper.self, from: test))
+        XCTAssertThrowsError(try orderUnstableDecode(ReferenceWrapper.self, from: test))
     }
 }
 

--- a/Tests/OpenAPIKitTests/Operation/OperationTests.swift
+++ b/Tests/OpenAPIKitTests/Operation/OperationTests.swift
@@ -8,7 +8,6 @@
 import XCTest
 import OpenAPIKit
 import Yams
-import FineJSON
 
 final class OperationTests: XCTestCase {
     func test_init() {
@@ -66,7 +65,7 @@ extension OperationTests {
             responses: [:]
         )
 
-        let encodedOperation = try testStringFromEncoding(of: operation)
+        let encodedOperation = try orderUnstableTestStringFromEncoding(of: operation)
 
         assertJSONEquivalent(
             encodedOperation,
@@ -88,7 +87,7 @@ extension OperationTests {
 }
 """.data(using: .utf8)!
 
-        let operation = try testDecoder.decode(OpenAPI.Operation.self, from: operationData)
+        let operation = try orderUnstableDecode(OpenAPI.Operation.self, from: operationData)
 
         XCTAssertEqual(
             operation,
@@ -114,7 +113,7 @@ extension OperationTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encodedOperation = try testStringFromEncoding(of: operation)
+        let encodedOperation = try orderUnstableTestStringFromEncoding(of: operation)
 
         assertJSONEquivalent(
             encodedOperation,
@@ -224,7 +223,7 @@ extension OperationTests {
 }
 """.data(using: .utf8)!
 
-        let operation = try testDecoder.decode(OpenAPI.Operation.self, from: operationData)
+        let operation = try orderUnstableDecode(OpenAPI.Operation.self, from: operationData)
 
         XCTAssertEqual(
             operation,
@@ -261,7 +260,7 @@ extension OperationTests {
         )
 
         let encodedOperation = String(
-            data: try FineJSONEncoder().encode(operation),
+            data: try orderStableEncode(operation),
             encoding: .utf8
         )!
 
@@ -289,7 +288,7 @@ extension OperationTests {
         )
 
         let encodedOperation2 = String(
-            data: try FineJSONEncoder().encode(operation2),
+            data: try orderStableEncode(operation2),
             encoding: .utf8
             )!
 

--- a/Tests/OpenAPIKitTests/Parameter/ParameterSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Parameter/ParameterSchemaTests.swift
@@ -220,7 +220,7 @@ extension ParameterSchemaTests {
             style: .default(for: .path)
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -250,7 +250,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,
@@ -268,7 +268,7 @@ extension ParameterSchemaTests {
             example: "hello"
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -300,7 +300,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,
@@ -321,7 +321,7 @@ extension ParameterSchemaTests {
             ]
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -361,7 +361,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,
@@ -381,7 +381,7 @@ extension ParameterSchemaTests {
             style: .form
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -413,7 +413,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,
@@ -431,7 +431,7 @@ extension ParameterSchemaTests {
             explode: true
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -463,7 +463,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,
@@ -482,7 +482,7 @@ extension ParameterSchemaTests {
             allowReserved: true
         )
 
-        let encodedSchema = try testStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
+        let encodedSchema = try orderUnstableTestStringFromEncoding(of: SchemaWrapper(location: .path, schema: schema))
 
         assertJSONEquivalent(
             encodedSchema,
@@ -514,7 +514,7 @@ extension ParameterSchemaTests {
 }
 """.data(using: .utf8)!
 
-        let schema = try testDecoder.decode(SchemaWrapper.self, from: schemaData).schema
+        let schema = try orderUnstableDecode(SchemaWrapper.self, from: schemaData).schema
 
         XCTAssertEqual(
             schema,

--- a/Tests/OpenAPIKitTests/Parameter/ParameterTests.swift
+++ b/Tests/OpenAPIKitTests/Parameter/ParameterTests.swift
@@ -133,7 +133,7 @@ extension ParameterTests {
             content: [ .json: .init(schema: .string)]
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -171,7 +171,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -191,7 +191,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -221,7 +221,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -240,7 +240,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -268,7 +268,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(parameter.location, .query)
         XCTAssertEqual(
@@ -293,7 +293,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -323,7 +323,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -342,7 +342,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -372,7 +372,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -391,7 +391,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -419,7 +419,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(parameter.location, .header)
         XCTAssertEqual(
@@ -439,7 +439,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -469,7 +469,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -488,7 +488,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -516,7 +516,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(parameter.location, .cookie)
         XCTAssertEqual(
@@ -536,7 +536,7 @@ extension ParameterTests {
             schema: .string
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -566,7 +566,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -586,7 +586,7 @@ extension ParameterTests {
             deprecated: true
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -618,7 +618,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(
             parameter,
@@ -639,7 +639,7 @@ extension ParameterTests {
             description: "world"
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -671,7 +671,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(parameter.location, .path)
         XCTAssertEqual(
@@ -694,7 +694,7 @@ extension ParameterTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encodedParameter = try testStringFromEncoding(of: parameter)
+        let encodedParameter = try orderUnstableTestStringFromEncoding(of: parameter)
 
         assertJSONEquivalent(
             encodedParameter,
@@ -734,7 +734,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        let parameter = try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData)
+        let parameter = try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData)
 
         XCTAssertEqual(parameter.location, .path)
         XCTAssertEqual(
@@ -769,7 +769,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData))
     }
 
     func test_decodeNonRequiredPathParam_throws() {
@@ -785,7 +785,7 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData))
 
         let parameterData2 =
 """
@@ -798,6 +798,6 @@ extension ParameterTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Parameter.self, from: parameterData2))
+        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Parameter.self, from: parameterData2))
     }
 }

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -7,7 +7,6 @@
 
 import XCTest
 import OpenAPIKit
-import FineJSON
 
 final class PathItemTests: XCTestCase {
     func test_initializePathComponents() {
@@ -140,7 +139,7 @@ extension PathItemTests {
     func test_minimal_encode() throws {
         let pathItem = OpenAPI.PathItem()
 
-        let encodedPathItem = try testStringFromEncoding(of: pathItem)
+        let encodedPathItem = try orderUnstableTestStringFromEncoding(of: pathItem)
 
         assertJSONEquivalent(
             encodedPathItem,
@@ -160,7 +159,7 @@ extension PathItemTests {
 }
 """.data(using: .utf8)!
 
-        let pathItem = try testDecoder.decode(OpenAPI.PathItem.self, from: pathItemData)
+        let pathItem = try orderUnstableDecode(OpenAPI.PathItem.self, from: pathItemData)
 
         XCTAssertEqual(pathItem, OpenAPI.PathItem())
     }
@@ -174,7 +173,7 @@ extension PathItemTests {
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
-        let encodedPathItem = try testStringFromEncoding(of: pathItem)
+        let encodedPathItem = try orderUnstableTestStringFromEncoding(of: pathItem)
 
         assertJSONEquivalent(
             encodedPathItem,
@@ -232,7 +231,7 @@ extension PathItemTests {
 }
 """.data(using: .utf8)!
 
-        let pathItem = try testDecoder.decode(OpenAPI.PathItem.self, from: pathItemData)
+        let pathItem = try orderUnstableDecode(OpenAPI.PathItem.self, from: pathItemData)
 
         XCTAssertEqual(
             pathItem,
@@ -260,7 +259,7 @@ extension PathItemTests {
             trace: op
         )
 
-        let encodedPathItem = try testStringFromEncoding(of: pathItem)
+        let encodedPathItem = try orderUnstableTestStringFromEncoding(of: pathItem)
 
         assertJSONEquivalent(
             encodedPathItem,
@@ -358,7 +357,7 @@ extension PathItemTests {
 }
 """.data(using: .utf8)!
 
-        let pathItem = try testDecoder.decode(OpenAPI.PathItem.self, from: pathItemData)
+        let pathItem = try orderUnstableDecode(OpenAPI.PathItem.self, from: pathItemData)
 
         let op = OpenAPI.Operation(responses: [:])
 
@@ -380,7 +379,7 @@ extension PathItemTests {
     func test_pathComponents_encode() throws {
         let test: [OpenAPI.Path] = ["/hello/world", "hi/there"]
 
-        let encodedTest = try testStringFromEncoding(of: test)
+        let encodedTest = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(
             encodedTest,
@@ -402,7 +401,7 @@ extension PathItemTests {
 ]
 """.data(using: .utf8)!
 
-        let test = try testDecoder.decode([OpenAPI.Path].self, from: testData)
+        let test = try orderUnstableDecode([OpenAPI.Path].self, from: testData)
 
         XCTAssertEqual(
             test,
@@ -419,7 +418,7 @@ extension PathItemTests {
             "hi/there": .init()
         ]
 
-        let encodedMap = try testStringFromEncoding(of: map)
+        let encodedMap = try orderUnstableTestStringFromEncoding(of: map)
 
         assertJSONEquivalent(
             encodedMap,
@@ -449,7 +448,7 @@ extension PathItemTests {
 }
 """.data(using: .utf8)!
 
-        let map = try FineJSONDecoder().decode(OpenAPI.PathItem.Map.self, from: mapData)
+        let map = try orderStableDecode(OpenAPI.PathItem.Map.self, from: mapData)
 
         XCTAssertEqual(
             map,

--- a/Tests/OpenAPIKitTests/Request/RequestTests.swift
+++ b/Tests/OpenAPIKitTests/Request/RequestTests.swift
@@ -47,14 +47,14 @@ extension RequestTests {
     func test_onlyEmptyContent_encode() {
         let content: OpenAPI.Content.Map = [:]
         let request = OpenAPI.Request(content: content)
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString, "{\n  \"content\" : {\n\n  }\n}")
     }
 
     func test_onlyEmptyContent_decode() {
         let requestData = #"{ "content": {} }"#.data(using: .utf8)!
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [:]))
     }
@@ -63,7 +63,7 @@ extension RequestTests {
         let request = OpenAPI.Request(content: [
             .json: .init(schema: .init(.external(URL(string: "hello.json#/world")!)))
             ])
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
 """
@@ -82,7 +82,7 @@ extension RequestTests {
 
     func test_onlyReferenceContent_decode() {
         let requestData = #"{ "content": { "application/json": { "schema": { "$ref": "hello.json#/world" } } } }"#.data(using: .utf8)!
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [
             .json : .init(schema: .init(.external(URL(string: "hello.json#/world")!)))
@@ -98,7 +98,7 @@ extension RequestTests {
         let request = OpenAPI.Request(content: [
             .json: .init(schema: .init(schema))
         ])
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
 """
@@ -139,7 +139,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [
             .json : .init(schema: .init(
@@ -152,7 +152,7 @@ extension RequestTests {
     func test_withDescription_encode() {
         let request = OpenAPI.Request(description: "A request",
                                       content: [:])
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
 """
@@ -175,7 +175,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(description: "A request",
                                                 content: [:]))
@@ -187,7 +187,7 @@ extension RequestTests {
             content: [:],
             vendorExtensions: [ "x-specialFeature": "ok" ]
         )
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
 """
@@ -212,7 +212,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(
             request,
@@ -227,7 +227,7 @@ extension RequestTests {
     func test_withRequired_encode() {
         let request = OpenAPI.Request(content: [:],
                                       required: true)
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
 """
@@ -250,7 +250,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [:],
                                                 required: true))
@@ -268,7 +268,7 @@ extension RequestTests {
         let request = OpenAPI.Request(content: [
             .xml: .init(schema: .init(schema))
             ])
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
                        """
@@ -309,7 +309,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [
             .xml : .init(schema: .init(
@@ -328,7 +328,7 @@ extension RequestTests {
         let request = OpenAPI.Request(content: [
             .form: .init(schema: .init(schema))
             ])
-        let encodedString = try! testStringFromEncoding(of: request)
+        let encodedString = try! orderUnstableTestStringFromEncoding(of: request)
 
         assertJSONEquivalent(encodedString,
                        """
@@ -369,7 +369,7 @@ extension RequestTests {
 }
 """.data(using: .utf8)!
 
-        let request = try! testDecoder.decode(OpenAPI.Request.self, from: requestData)
+        let request = try! orderUnstableDecode(OpenAPI.Request.self, from: requestData)
 
         XCTAssertEqual(request, OpenAPI.Request(content: [
             .form : .init(schema: .init(

--- a/Tests/OpenAPIKitTests/Response/ResponseTests.swift
+++ b/Tests/OpenAPIKitTests/Response/ResponseTests.swift
@@ -93,7 +93,7 @@ extension ResponseTests {
 extension ResponseTests {
     func test_emptyDescriptionEmptyContent_encode() {
         let response = OpenAPI.Response(description: "", content: [:])
-        let encodedResponse = try! testStringFromEncoding(of: response)
+        let encodedResponse = try! orderUnstableTestStringFromEncoding(of: response)
 
         assertJSONEquivalent(encodedResponse,
 """
@@ -104,7 +104,7 @@ extension ResponseTests {
                        )
 
         let response2 = OpenAPI.Response(description: "", headers: [:], content: [:])
-        let encodedResponse2 = try! testStringFromEncoding(of: response2)
+        let encodedResponse2 = try! orderUnstableTestStringFromEncoding(of: response2)
 
         assertJSONEquivalent(encodedResponse2,
 """
@@ -125,7 +125,7 @@ extension ResponseTests {
   "description" : ""
 }
 """.data(using: .utf8)!
-        let response = try! testDecoder.decode(OpenAPI.Response.self, from: responseData)
+        let response = try! orderUnstableDecode(OpenAPI.Response.self, from: responseData)
 
         XCTAssertEqual(response, OpenAPI.Response(description: "", content: [:]))
 
@@ -136,7 +136,7 @@ extension ResponseTests {
   "description" : ""
 }
 """.data(using: .utf8)!
-        let response2 = try! testDecoder.decode(OpenAPI.Response.self, from: responseData2)
+        let response2 = try! orderUnstableDecode(OpenAPI.Response.self, from: responseData2)
 
         XCTAssertEqual(response2, OpenAPI.Response(description: "", content: [:]))
 
@@ -148,7 +148,7 @@ extension ResponseTests {
   "headers": {}
 }
 """.data(using: .utf8)!
-        let response3 = try! testDecoder.decode(OpenAPI.Response.self, from: responseData3)
+        let response3 = try! orderUnstableDecode(OpenAPI.Response.self, from: responseData3)
 
         XCTAssertEqual(response3, OpenAPI.Response(description: "", headers: [:], content: [:]))
     }
@@ -160,7 +160,7 @@ extension ResponseTests {
                                         headers: ["hello": .init(header)],
                                         content: [.json: content])
 
-        let encodedResponse = try! testStringFromEncoding(of: response)
+        let encodedResponse = try! orderUnstableTestStringFromEncoding(of: response)
 
         assertJSONEquivalent(encodedResponse,
 """
@@ -197,7 +197,7 @@ extension ResponseTests {
 }
 """.data(using: .utf8)!
 
-        let response = try testDecoder.decode(OpenAPI.Response.self, from: responseData)
+        let response = try orderUnstableDecode(OpenAPI.Response.self, from: responseData)
 
         let content = OpenAPI.Content(schema: .init(.string(required: false)))
         let header = OpenAPI.Header(schemaOrContent: .init(.header(.string(required: false))))
@@ -216,7 +216,7 @@ extension ResponseTests {
             vendorExtensions: [ "x-specialFeature": true ]
         )
 
-        let encodedResponse = try! testStringFromEncoding(of: response)
+        let encodedResponse = try! orderUnstableTestStringFromEncoding(of: response)
 
         assertJSONEquivalent(encodedResponse,
 """
@@ -255,7 +255,7 @@ extension ResponseTests {
 }
 """.data(using: .utf8)!
 
-        let response = try testDecoder.decode(OpenAPI.Response.self, from: responseData)
+        let response = try orderUnstableDecode(OpenAPI.Response.self, from: responseData)
 
         let content = OpenAPI.Content(schema: .init(.string(required: false)))
         let header = OpenAPI.Header(schemaOrContent: .init(.header(.string(required: false))))
@@ -280,7 +280,7 @@ extension ResponseTests {
 
     func test_defaultStatusCode_encode() throws {
         let status = StatusCodeWrapper(status: .default)
-        let encodedStatus = try testStringFromEncoding(of: status)
+        let encodedStatus = try orderUnstableTestStringFromEncoding(of: status)
 
         assertJSONEquivalent(encodedStatus,
 """
@@ -299,12 +299,12 @@ extension ResponseTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertEqual(try testDecoder.decode(StatusCodeWrapper.self, from: statusCodeData), StatusCodeWrapper(status: .default))
+        XCTAssertEqual(try orderUnstableDecode(StatusCodeWrapper.self, from: statusCodeData), StatusCodeWrapper(status: .default))
     }
 
     func test_numberStatusCode_encode() throws {
         let status = StatusCodeWrapper(status: 123)
-        let encodedStatus = try testStringFromEncoding(of: status)
+        let encodedStatus = try orderUnstableTestStringFromEncoding(of: status)
 
         assertJSONEquivalent(encodedStatus,
 """
@@ -323,7 +323,7 @@ extension ResponseTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertEqual(try testDecoder.decode(StatusCodeWrapper.self, from: statusCodeData), StatusCodeWrapper(status: 123))
+        XCTAssertEqual(try orderUnstableDecode(StatusCodeWrapper.self, from: statusCodeData), StatusCodeWrapper(status: 123))
     }
 
     func test_nonesenseStatusCode_decode_throws() {
@@ -334,6 +334,6 @@ extension ResponseTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(StatusCodeWrapper.self, from: statusCodeData))
+        XCTAssertThrowsError(try orderUnstableDecode(StatusCodeWrapper.self, from: statusCodeData))
     }
 }

--- a/Tests/OpenAPIKitTests/Schema Conformances/SwiftPrimitiveTypes+OpenAPITests.swift
+++ b/Tests/OpenAPIKitTests/Schema Conformances/SwiftPrimitiveTypes+OpenAPITests.swift
@@ -114,6 +114,4 @@ class SwiftPrimitiveTypesTests: XCTestCase {
 
         XCTAssertEqual([String: String?].openAPISchema, .object(additionalProperties: .schema(.string(required: false))))
     }
-
-    static let localTestEncoder = JSONEncoder()
 }

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -128,7 +128,7 @@ extension SchemaFragmentTests {
     func test_decodeFailsWithNoProperties() {
         let t = "{}".data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t))
     }
 
     func test_decodeFailsWithConflictingProperties() {
@@ -144,7 +144,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t))
     }
 
     func test_decodeFailsWithTypeAndPropertyConflict() {
@@ -158,7 +158,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t))
     }
 
     func test_decodeFailsWithIntegerWithFloatingPointMin() {
@@ -170,13 +170,13 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t))
     }
 
     func test_generalEncode() throws {
         let t = JSONSchemaFragment.general(.init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -189,7 +189,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.general(.init(format: "date", title: "creation date", readOnly: true))
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -213,7 +213,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(
             decoded,
@@ -224,7 +224,7 @@ extension SchemaFragmentTests {
     func test_booleanEncode() throws {
         let t = JSONSchemaFragment.boolean(.init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -237,7 +237,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.boolean(.init(description: "hello"))
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -258,7 +258,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.boolean(.init()))
 
@@ -270,7 +270,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.boolean(.init(description: "hello world")))
     }
@@ -278,7 +278,7 @@ extension SchemaFragmentTests {
     func test_integerEncode() throws {
         let t = JSONSchemaFragment.integer(.init(), .init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -291,7 +291,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.integer(.init(title: "hi"), .init())
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -305,7 +305,7 @@ extension SchemaFragmentTests {
 
         let t3 = JSONSchemaFragment.integer(.init(), .init(minimum: 10))
 
-        let encoded3 = try testStringFromEncoding(of: t3)
+        let encoded3 = try orderUnstableTestStringFromEncoding(of: t3)
 
         assertJSONEquivalent(
             encoded3,
@@ -326,7 +326,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.integer(.init(), .init()))
 
@@ -338,7 +338,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.integer(.init(title: "hi"), .init()))
 
@@ -350,7 +350,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+        let decoded3 = try orderUnstableDecode(JSONSchemaFragment.self, from: t3)
 
         XCTAssertEqual(decoded3, JSONSchemaFragment.integer(.init(), .init(minimum: 10)))
     }
@@ -358,7 +358,7 @@ extension SchemaFragmentTests {
     func test_numberEncode() throws {
         let t = JSONSchemaFragment.number(.init(), .init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -371,7 +371,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.number(.init(title: "hi"), .init())
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -385,7 +385,7 @@ extension SchemaFragmentTests {
 
         let t3 = JSONSchemaFragment.number(.init(), .init(minimum: 10))
 
-        let encoded3 = try testStringFromEncoding(of: t3)
+        let encoded3 = try orderUnstableTestStringFromEncoding(of: t3)
 
         assertJSONEquivalent(
             encoded3,
@@ -406,7 +406,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.number(.init(), .init()))
 
@@ -418,7 +418,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.number(.init(title: "hi"), .init()))
 
@@ -430,7 +430,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+        let decoded3 = try orderUnstableDecode(JSONSchemaFragment.self, from: t3)
 
         XCTAssertEqual(decoded3, JSONSchemaFragment.number(.init(), .init(minimum: 10)))
 
@@ -441,7 +441,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+        let decoded4 = try orderUnstableDecode(JSONSchemaFragment.self, from: t4)
 
         XCTAssertEqual(decoded4, JSONSchemaFragment.number(.init(), .init(minimum: 10.5)))
     }
@@ -449,7 +449,7 @@ extension SchemaFragmentTests {
     func test_stringEncode() throws {
         let t = JSONSchemaFragment.string(.init(), .init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -462,7 +462,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.string(.init(writeOnly: false), .init())
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -476,7 +476,7 @@ extension SchemaFragmentTests {
 
         let t3 = JSONSchemaFragment.string(.init(), .init(maxLength: 3))
 
-        let encoded3 = try testStringFromEncoding(of: t3)
+        let encoded3 = try orderUnstableTestStringFromEncoding(of: t3)
 
         assertJSONEquivalent(
             encoded3,
@@ -497,7 +497,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.string(.init(), .init()))
 
@@ -509,7 +509,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.string(.init(writeOnly: false), .init()))
 
@@ -521,7 +521,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+        let decoded3 = try orderUnstableDecode(JSONSchemaFragment.self, from: t3)
 
         XCTAssertEqual(decoded3, JSONSchemaFragment.string(.init(), .init(maxLength: 3)))
 
@@ -532,7 +532,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+        let decoded4 = try orderUnstableDecode(JSONSchemaFragment.self, from: t4)
 
         XCTAssertEqual(decoded4, JSONSchemaFragment.string(.init(), .init(minLength: 7)))
     }
@@ -540,7 +540,7 @@ extension SchemaFragmentTests {
     func test_arrayEncode() throws {
         let t = JSONSchemaFragment.array(.init(), .init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -553,7 +553,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.array(.init(writeOnly: true), .init())
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -567,7 +567,7 @@ extension SchemaFragmentTests {
 
         let t3 = JSONSchemaFragment.array(.init(), .init(uniqueItems: true))
 
-        let encoded3 = try testStringFromEncoding(of: t3)
+        let encoded3 = try orderUnstableTestStringFromEncoding(of: t3)
 
         assertJSONEquivalent(
             encoded3,
@@ -581,7 +581,7 @@ extension SchemaFragmentTests {
 
         let t4 = JSONSchemaFragment.array(.init(), .init(items: .string))
 
-        let encoded4 = try testStringFromEncoding(of: t4)
+        let encoded4 = try orderUnstableTestStringFromEncoding(of: t4)
 
         assertJSONEquivalent(
             encoded4,
@@ -604,7 +604,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.array(.init(), .init()))
 
@@ -616,7 +616,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.array(.init(writeOnly: true), .init()))
 
@@ -628,7 +628,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+        let decoded3 = try orderUnstableDecode(JSONSchemaFragment.self, from: t3)
 
         XCTAssertEqual(decoded3, JSONSchemaFragment.array(.init(), .init(maxItems: 3)))
 
@@ -639,7 +639,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+        let decoded4 = try orderUnstableDecode(JSONSchemaFragment.self, from: t4)
 
         XCTAssertEqual(decoded4, JSONSchemaFragment.array(.init(), .init(minItems: 7)))
 
@@ -652,7 +652,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded5 = try testDecoder.decode(JSONSchemaFragment.self, from: t5)
+        let decoded5 = try orderUnstableDecode(JSONSchemaFragment.self, from: t5)
 
         XCTAssertEqual(decoded5, JSONSchemaFragment.array(.init(), .init(items: .string(required: false))))
     }
@@ -660,7 +660,7 @@ extension SchemaFragmentTests {
     func test_objectEncode() throws {
         let t = JSONSchemaFragment.object(.init(), .init())
 
-        let encoded = try testStringFromEncoding(of: t)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t)
 
         assertJSONEquivalent(
             encoded,
@@ -673,7 +673,7 @@ extension SchemaFragmentTests {
 
         let t2 = JSONSchemaFragment.object(.init(writeOnly: true), .init())
 
-        let encoded2 = try testStringFromEncoding(of: t2)
+        let encoded2 = try orderUnstableTestStringFromEncoding(of: t2)
 
         assertJSONEquivalent(
             encoded2,
@@ -687,7 +687,7 @@ extension SchemaFragmentTests {
 
         let t3 = JSONSchemaFragment.object(.init(), .init(required: ["hello"]))
 
-        let encoded3 = try testStringFromEncoding(of: t3)
+        let encoded3 = try orderUnstableTestStringFromEncoding(of: t3)
 
         assertJSONEquivalent(
             encoded3,
@@ -703,7 +703,7 @@ extension SchemaFragmentTests {
 
         let t4 = JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string]))
 
-        let encoded4 = try testStringFromEncoding(of: t4)
+        let encoded4 = try orderUnstableTestStringFromEncoding(of: t4)
 
         assertJSONEquivalent(
             encoded4,
@@ -728,7 +728,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t)
 
         XCTAssertEqual(decoded, JSONSchemaFragment.object(.init(), .init()))
 
@@ -740,7 +740,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded2 = try testDecoder.decode(JSONSchemaFragment.self, from: t2)
+        let decoded2 = try orderUnstableDecode(JSONSchemaFragment.self, from: t2)
 
         XCTAssertEqual(decoded2, JSONSchemaFragment.object(.init(writeOnly: true), .init()))
 
@@ -754,7 +754,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded3 = try testDecoder.decode(JSONSchemaFragment.self, from: t3)
+        let decoded3 = try orderUnstableDecode(JSONSchemaFragment.self, from: t3)
 
         XCTAssertEqual(decoded3, JSONSchemaFragment.object(.init(), .init(required: ["hello"])))
 
@@ -770,7 +770,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded4 = try testDecoder.decode(JSONSchemaFragment.self, from: t4)
+        let decoded4 = try orderUnstableDecode(JSONSchemaFragment.self, from: t4)
 
         XCTAssertEqual(decoded4, JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string(required: false)])))
 
@@ -785,7 +785,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded5 = try testDecoder.decode(JSONSchemaFragment.self, from: t5)
+        let decoded5 = try orderUnstableDecode(JSONSchemaFragment.self, from: t5)
 
         XCTAssertEqual(decoded5, JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string(required: false)])))
     }

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaObjectTests.swift
@@ -956,7 +956,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchema.self, from: oneOfData))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: oneOfData))
     }
 
     func test_decodingFailsForReadOnlyAndWriteOnly() {
@@ -968,7 +968,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchema.self, from: readOnlyWriteOnlyData))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: readOnlyWriteOnlyData))
     }
 
     func test_decodingFailsForNoIdentifyingProperties() {
@@ -978,7 +978,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchema.self, from: badSchema))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: badSchema))
     }
 
     func test_decodingFailsForTypeAndPropertyConflict() {
@@ -992,7 +992,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchema.self, from: badSchema))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: badSchema))
     }
 
     func test_decodeUndefined() throws {
@@ -1000,7 +1000,7 @@ extension SchemaObjectTests {
         {}
         """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: undefinedData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: undefinedData)
 
         XCTAssertEqual(decoded, .undefined(description: nil))
     }
@@ -1008,7 +1008,7 @@ extension SchemaObjectTests {
     func test_encodeUndefined() throws {
         let undefined = JSONSchema.undefined(description: nil)
 
-        let encoded = try testStringFromEncoding(of: undefined)
+        let encoded = try orderUnstableTestStringFromEncoding(of: undefined)
 
         assertJSONEquivalent(
             encoded,
@@ -1027,7 +1027,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: undefinedWithDescriptionData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: undefinedWithDescriptionData)
 
         XCTAssertEqual(decoded, .undefined(description: "hello world"))
     }
@@ -1035,7 +1035,7 @@ extension SchemaObjectTests {
     func test_encodeUndefinedWithDescription() throws {
         let undefinedWithDescription = JSONSchema.undefined(description: "hello world")
 
-        let encoded = try testStringFromEncoding(of: undefinedWithDescription)
+        let encoded = try orderUnstableTestStringFromEncoding(of: undefinedWithDescription)
 
         assertJSONEquivalent(
             encoded,
@@ -1086,13 +1086,13 @@ extension SchemaObjectTests {
         let allowedValueBooleanData = #"{"type": "boolean", "enum": [false]}"#.data(using: .utf8)!
         let discriminatorBooleanData = #"{"type": "boolean", "discriminator": { "propertyName": "hello" }}"#.data(using: .utf8)!
 
-        let boolean = try testDecoder.decode(JSONSchema.self, from: booleanData)
-        let nullableBoolean = try testDecoder.decode(JSONSchema.self, from: nullableBooleanData)
-        let readOnlyBoolean = try testDecoder.decode(JSONSchema.self, from: readOnlyBooleanData)
-        let writeOnlyBoolean = try testDecoder.decode(JSONSchema.self, from: writeOnlyBooleanData)
-        let deprecatedBoolean = try testDecoder.decode(JSONSchema.self, from: deprecatedBooleanData)
-        let allowedValueBoolean = try testDecoder.decode(JSONSchema.self, from: allowedValueBooleanData)
-        let discriminatorBoolean = try testDecoder.decode(JSONSchema.self, from: discriminatorBooleanData)
+        let boolean = try orderUnstableDecode(JSONSchema.self, from: booleanData)
+        let nullableBoolean = try orderUnstableDecode(JSONSchema.self, from: nullableBooleanData)
+        let readOnlyBoolean = try orderUnstableDecode(JSONSchema.self, from: readOnlyBooleanData)
+        let writeOnlyBoolean = try orderUnstableDecode(JSONSchema.self, from: writeOnlyBooleanData)
+        let deprecatedBoolean = try orderUnstableDecode(JSONSchema.self, from: deprecatedBooleanData)
+        let allowedValueBoolean = try orderUnstableDecode(JSONSchema.self, from: allowedValueBooleanData)
+        let discriminatorBoolean = try orderUnstableDecode(JSONSchema.self, from: discriminatorBooleanData)
 
         XCTAssertEqual(boolean, JSONSchema.boolean(.init(format: .generic, required: false)))
         XCTAssertEqual(nullableBoolean, JSONSchema.boolean(.init(format: .generic, required: false, nullable: true)))
@@ -1278,13 +1278,13 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let readOnlyObject = try testDecoder.decode(JSONSchema.self, from: readOnlyObjectData)
-        let writeOnlyObject = try testDecoder.decode(JSONSchema.self, from: writeOnlyObjectData)
-        let deprecatedObject = try testDecoder.decode(JSONSchema.self, from: deprecatedObjectData)
-        let allowedValueObject = try testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
-        let discriminatorObject = try testDecoder.decode(JSONSchema.self, from: discriminatorObjectData)
+        let object = try orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let readOnlyObject = try orderUnstableDecode(JSONSchema.self, from: readOnlyObjectData)
+        let writeOnlyObject = try orderUnstableDecode(JSONSchema.self, from: writeOnlyObjectData)
+        let deprecatedObject = try orderUnstableDecode(JSONSchema.self, from: deprecatedObjectData)
+        let allowedValueObject = try orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
+        let discriminatorObject = try orderUnstableDecode(JSONSchema.self, from: discriminatorObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: [:])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: [:])))
@@ -1314,7 +1314,7 @@ extension SchemaObjectTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: objectData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: objectData)
 
         XCTAssertEqual(
             decoded,
@@ -1413,9 +1413,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false, title: "hello"), .init(properties: [:])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true, title: "hello"), .init(properties: [:])))
@@ -1521,9 +1521,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false, description: "hello"), .init(properties: [:])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true, description: "hello"), .init(properties: [:])))
@@ -1637,9 +1637,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false, externalDocs: .init(url: URL(string: "http://google.com")!)), .init(properties: [:])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true, externalDocs: .init(url: URL(string: "http://google.com")!)), .init(properties: [:])))
@@ -1745,9 +1745,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: [:], maxProperties: 1)))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: [:], maxProperties: 1)))
@@ -1852,9 +1852,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: [:], minProperties: 1)))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: [:], minProperties: 1)))
@@ -1959,9 +1959,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: [:], additionalProperties: .init(true))))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: [:], additionalProperties: .init(true))))
@@ -2075,9 +2075,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: [:], additionalProperties: .init(.string(required: false)))))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: [:], additionalProperties: .init(.string(required: false)))))
@@ -2219,10 +2219,10 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let string = try testDecoder.decode(JSONSchema.self, from: stringData)
-        let object = try testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let string = try orderUnstableDecode(JSONSchema.self, from: stringData)
+        let object = try orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .unspecified, required: false, example: "hello"), .init()))
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false, example: AnyCodable(["hello": true])), .init(properties: [:])))
@@ -2396,9 +2396,9 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let object = try! testDecoder.decode(JSONSchema.self, from: objectData)
-        let nullableObject = try! testDecoder.decode(JSONSchema.self, from: nullableObjectData)
-        let allowedValueObject = try! testDecoder.decode(JSONSchema.self, from: allowedValueObjectData)
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+        let nullableObject = try! orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
+        let allowedValueObject = try! orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic, required: false), .init(properties: ["hello": .boolean(.init(format: .generic, required: true))])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, required: false, nullable: true), .init(properties: ["hello": .boolean(.init(format: .generic, required: true))])))
@@ -2451,13 +2451,13 @@ extension SchemaObjectTests {
         let allowedValueArrayData = #"{"type": "array", "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
         let discriminatorArrayData = #"{"type": "array", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
 
-        let array = try testDecoder.decode(JSONSchema.self, from: arrayData)
-        let nullableArray = try testDecoder.decode(JSONSchema.self, from: nullableArrayData)
-        let readOnlyArray = try testDecoder.decode(JSONSchema.self, from: readOnlyArrayData)
-        let writeOnlyArray = try testDecoder.decode(JSONSchema.self, from: writeOnlyArrayData)
-        let deprecatedArray = try testDecoder.decode(JSONSchema.self, from: deprecatedArrayData)
-        let allowedValueArray = try testDecoder.decode(JSONSchema.self, from: allowedValueArrayData)
-        let discriminatorArray = try testDecoder.decode(JSONSchema.self, from: discriminatorArrayData)
+        let array = try orderUnstableDecode(JSONSchema.self, from: arrayData)
+        let nullableArray = try orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
+        let readOnlyArray = try orderUnstableDecode(JSONSchema.self, from: readOnlyArrayData)
+        let writeOnlyArray = try orderUnstableDecode(JSONSchema.self, from: writeOnlyArrayData)
+        let deprecatedArray = try orderUnstableDecode(JSONSchema.self, from: deprecatedArrayData)
+        let allowedValueArray = try orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
+        let discriminatorArray = try orderUnstableDecode(JSONSchema.self, from: discriminatorArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic, required: false), .init()))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, required: false, nullable: true), .init()))
@@ -2484,7 +2484,7 @@ extension SchemaObjectTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: objectData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: objectData)
 
         XCTAssertEqual(
             decoded,
@@ -2543,9 +2543,9 @@ extension SchemaObjectTests {
         let nullableArrayData = #"{"type": "array", "items": { "type": "boolean" }, "nullable": true}"#.data(using: .utf8)!
         let allowedValueArrayData = #"{"type": "array", "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
 
-        let array = try! testDecoder.decode(JSONSchema.self, from: arrayData)
-        let nullableArray = try! testDecoder.decode(JSONSchema.self, from: nullableArrayData)
-        let allowedValueArray = try! testDecoder.decode(JSONSchema.self, from: allowedValueArrayData)
+        let array = try! orderUnstableDecode(JSONSchema.self, from: arrayData)
+        let nullableArray = try! orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
+        let allowedValueArray = try! orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic, required: false), .init(items: .boolean(.init(format: .generic, required: false)))))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, required: false, nullable: true), .init(items: .boolean(.init(format: .generic, required: false)))))
@@ -2613,9 +2613,9 @@ extension SchemaObjectTests {
         let nullableArrayData = #"{"type": "array", "uniqueItems": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueArrayData = #"{"type": "array", "uniqueItems": true, "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
 
-        let array = try! testDecoder.decode(JSONSchema.self, from: arrayData)
-        let nullableArray = try! testDecoder.decode(JSONSchema.self, from: nullableArrayData)
-        let allowedValueArray = try! testDecoder.decode(JSONSchema.self, from: allowedValueArrayData)
+        let array = try! orderUnstableDecode(JSONSchema.self, from: arrayData)
+        let nullableArray = try! orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
+        let allowedValueArray = try! orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic, required: false), .init(uniqueItems: true)))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, required: false, nullable: true), .init(uniqueItems: true)))
@@ -2671,9 +2671,9 @@ extension SchemaObjectTests {
         let nullableArrayData = #"{"type": "array", "maxItems": 3, "nullable": true}"#.data(using: .utf8)!
         let allowedValueArrayData = #"{"type": "array", "maxItems": 3, "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
 
-        let array = try! testDecoder.decode(JSONSchema.self, from: arrayData)
-        let nullableArray = try! testDecoder.decode(JSONSchema.self, from: nullableArrayData)
-        let allowedValueArray = try! testDecoder.decode(JSONSchema.self, from: allowedValueArrayData)
+        let array = try! orderUnstableDecode(JSONSchema.self, from: arrayData)
+        let nullableArray = try! orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
+        let allowedValueArray = try! orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic, required: false), .init(maxItems: 3)))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, required: false, nullable: true), .init(maxItems: 3)))
@@ -2729,9 +2729,9 @@ extension SchemaObjectTests {
         let nullableArrayData = #"{"type": "array", "minItems": 2, "nullable": true}"#.data(using: .utf8)!
         let allowedValueArrayData = #"{"type": "array", "minItems": 2, "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
 
-        let array = try! testDecoder.decode(JSONSchema.self, from: arrayData)
-        let nullableArray = try! testDecoder.decode(JSONSchema.self, from: nullableArrayData)
-        let allowedValueArray = try! testDecoder.decode(JSONSchema.self, from: allowedValueArrayData)
+        let array = try! orderUnstableDecode(JSONSchema.self, from: arrayData)
+        let nullableArray = try! orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
+        let allowedValueArray = try! orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic, required: false), .init(minItems: 2)))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, required: false, nullable: true), .init(minItems: 2)))
@@ -2783,13 +2783,13 @@ extension SchemaObjectTests {
         let allowedValueNumberData = #"{"type": "number", "enum": [1, 2]}"#.data(using: .utf8)!
         let discriminatorNumberData = #"{"type": "number", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
 
-        let number = try testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let readOnlyNumber = try testDecoder.decode(JSONSchema.self, from: readOnlyNumberData)
-        let writeOnlyNumber = try testDecoder.decode(JSONSchema.self, from: writeOnlyNumberData)
-        let deprecatedNumber = try testDecoder.decode(JSONSchema.self, from: deprecatedNumberData)
-        let allowedValueNumber = try testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
-        let discriminatorNumber = try testDecoder.decode(JSONSchema.self, from: discriminatorNumberData)
+        let number = try orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let readOnlyNumber = try orderUnstableDecode(JSONSchema.self, from: readOnlyNumberData)
+        let writeOnlyNumber = try orderUnstableDecode(JSONSchema.self, from: writeOnlyNumberData)
+        let deprecatedNumber = try orderUnstableDecode(JSONSchema.self, from: deprecatedNumberData)
+        let allowedValueNumber = try orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
+        let discriminatorNumber = try orderUnstableDecode(JSONSchema.self, from: discriminatorNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init()))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init()))
@@ -2808,7 +2808,7 @@ extension SchemaObjectTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: objectData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: objectData)
 
         XCTAssertEqual(
             decoded,
@@ -2843,9 +2843,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "format": "float", "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "format": "float", "enum": [1, 2.5]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .float, required: false), .init()))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .float, required: false, nullable: true), .init()))
@@ -2879,9 +2879,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "format": "double", "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "format": "double", "enum": [1, 2]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .double, required: false), .init()))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .double, required: false, nullable: true), .init()))
@@ -2929,9 +2929,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "multipleOf": 2.2, "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "multipleOf": 2.2, "enum": [2.2, 4.4]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init(multipleOf: 2.2)))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init(multipleOf: 2.2)))
@@ -2979,9 +2979,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "maximum": 2.2, "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "maximum": 2.2, "enum": [2.2, 1.2]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init(maximum: (2.2, exclusive:false))))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init(maximum: (2.2, exclusive:false))))
@@ -3033,9 +3033,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "maximum": 2.2, "exclusiveMaximum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "maximum": 2.2, "exclusiveMaximum": true, "enum": [2.1, 1.2]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init(maximum: (2.2, exclusive:true))))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init(maximum: (2.2, exclusive:true))))
@@ -3083,9 +3083,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "minimum": 1.1, "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "minimum": 1.1, "enum": [2.1, 1.2]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init(minimum: (1.1, exclusive:false))))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init(minimum: (1.1, exclusive:false))))
@@ -3137,9 +3137,9 @@ extension SchemaObjectTests {
         let nullableNumberData = #"{"type": "number", "minimum": 1.1, "exclusiveMinimum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueNumberData = #"{"type": "number", "minimum": 1.1, "exclusiveMinimum": true, "enum": [2.1, 1.2]}"#.data(using: .utf8)!
 
-        let number = try! testDecoder.decode(JSONSchema.self, from: numberData)
-        let nullableNumber = try! testDecoder.decode(JSONSchema.self, from: nullableNumberData)
-        let allowedValueNumber = try! testDecoder.decode(JSONSchema.self, from: allowedValueNumberData)
+        let number = try! orderUnstableDecode(JSONSchema.self, from: numberData)
+        let nullableNumber = try! orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
+        let allowedValueNumber = try! orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic, required: false), .init(minimum: (1.1, exclusive:true))))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, required: false, nullable: true), .init(minimum: (1.1, exclusive:true))))
@@ -3185,13 +3185,13 @@ extension SchemaObjectTests {
         let allowedValueIntegerData = #"{"type": "integer", "enum": [1, 2]}"#.data(using: .utf8)!
         let discriminatorIntegerData = #"{"type": "integer", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
 
-        let integer = try testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let readOnlyInteger = try testDecoder.decode(JSONSchema.self, from: readOnlyIntegerData)
-        let writeOnlyInteger = try testDecoder.decode(JSONSchema.self, from: writeOnlyIntegerData)
-        let deprecatedInteger = try testDecoder.decode(JSONSchema.self, from: deprecatedIntegerData)
-        let allowedValueInteger = try testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
-        let discriminatorInteger = try testDecoder.decode(JSONSchema.self, from: discriminatorIntegerData)
+        let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let readOnlyInteger = try orderUnstableDecode(JSONSchema.self, from: readOnlyIntegerData)
+        let writeOnlyInteger = try orderUnstableDecode(JSONSchema.self, from: writeOnlyIntegerData)
+        let deprecatedInteger = try orderUnstableDecode(JSONSchema.self, from: deprecatedIntegerData)
+        let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let discriminatorInteger = try orderUnstableDecode(JSONSchema.self, from: discriminatorIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init()))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init()))
@@ -3229,9 +3229,9 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "format": "int32", "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "format": "int32", "enum": [1, 2]}"#.data(using: .utf8)!
 
-        let integer = try! testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .int32, required: false), .init()))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .int32, required: false, nullable: true), .init()))
@@ -3265,9 +3265,9 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "format": "int64", "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "format": "int64", "enum": [1, 2]}"#.data(using: .utf8)!
 
-        let integer = try! testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .int64, required: false), .init()))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .int64, required: false, nullable: true), .init()))
@@ -3315,9 +3315,9 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "multipleOf": 2, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "multipleOf": 2, "enum": [4]}"#.data(using: .utf8)!
 
-        let integer = try! testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init(multipleOf: 2)))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init(multipleOf: 2)))
@@ -3366,10 +3366,10 @@ extension SchemaObjectTests {
         let allowedValueIntegerData = #"{"type": "integer", "maximum": 2, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "maximum": 1.0}"#.data(using: .utf8)!
 
-        let integer = try testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
-        let integerWithWholeNumberFloat = try testDecoder.decode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init(maximum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init(maximum: (1, exclusive:false))))
@@ -3422,9 +3422,9 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "maximum": 1, "exclusiveMaximum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "maximum": 5, "exclusiveMaximum": true, "enum": [2, 3]}"#.data(using: .utf8)!
 
-        let integer = try! testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init(maximum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init(maximum: (1, exclusive:true))))
@@ -3473,10 +3473,10 @@ extension SchemaObjectTests {
         let allowedValueIntegerData = #"{"type": "integer", "minimum": 1, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "minimum": 1.0}"#.data(using: .utf8)!
 
-        let integer = try testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
-        let integerWithWholeNumberFloat = try testDecoder.decode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init(minimum: (1, exclusive:false))))
@@ -3529,9 +3529,9 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "minimum": 1, "exclusiveMinimum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "minimum": 1, "exclusiveMinimum": true, "enum": [2, 3]}"#.data(using: .utf8)!
 
-        let integer = try! testDecoder.decode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! testDecoder.decode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! testDecoder.decode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic, required: false), .init(minimum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, required: false, nullable: true), .init(minimum: (1, exclusive:true))))
@@ -3577,13 +3577,13 @@ extension SchemaObjectTests {
         let allowedValueStringData = #"{"type": "string", "enum": ["hello"]}"#.data(using: .utf8)!
         let discriminatorStringData = #"{"type": "string", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
 
-        let string = try testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let readOnlyString = try testDecoder.decode(JSONSchema.self, from: readOnlyStringData)
-        let writeOnlyString = try testDecoder.decode(JSONSchema.self, from: writeOnlyStringData)
-        let deprecatedString = try testDecoder.decode(JSONSchema.self, from: deprecatedStringData)
-        let allowedValueString = try testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
-        let discriminatorString = try testDecoder.decode(JSONSchema.self, from: discriminatorStringData)
+        let string = try orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let readOnlyString = try orderUnstableDecode(JSONSchema.self, from: readOnlyStringData)
+        let writeOnlyString = try orderUnstableDecode(JSONSchema.self, from: writeOnlyStringData)
+        let deprecatedString = try orderUnstableDecode(JSONSchema.self, from: deprecatedStringData)
+        let allowedValueString = try orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
+        let discriminatorString = try orderUnstableDecode(JSONSchema.self, from: discriminatorStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .generic, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .generic, required: false, nullable: true), .init()))
@@ -3602,7 +3602,7 @@ extension SchemaObjectTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchema.self, from: objectData)
+        let decoded = try orderUnstableDecode(JSONSchema.self, from: objectData)
 
         XCTAssertEqual(
             decoded,
@@ -3637,9 +3637,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "format": "byte", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "format": "byte", "enum": ["hello"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .byte, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .byte, required: false, nullable: true), .init()))
@@ -3673,9 +3673,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "format": "binary", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "format": "binary", "enum": ["hello"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .binary, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .binary, required: false, nullable: true), .init()))
@@ -3709,9 +3709,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "format": "date", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "format": "date", "enum": ["hello"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .date, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .date, required: false, nullable: true), .init()))
@@ -3745,9 +3745,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "format": "date-time", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "format": "date-time", "enum": ["hello"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .dateTime, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .dateTime, required: false, nullable: true), .init()))
@@ -3781,9 +3781,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "format": "password", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "format": "password", "enum": ["hello"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .password, required: false), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .password, required: false, nullable: true), .init()))
@@ -3831,9 +3831,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "maxLength": 5, "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "maxLength": 5, "enum": ["hello", "world"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .generic, required: false), .init(maxLength: 5)))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .generic, required: false, nullable: true), .init(maxLength: 5)))
@@ -3881,9 +3881,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "minLength": 3, "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "minLength": 3, "enum": ["hello", "world"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .generic, required: false), .init(minLength: 3)))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .generic, required: false, nullable: true), .init(minLength: 3)))
@@ -3931,9 +3931,9 @@ extension SchemaObjectTests {
         let nullableStringData = #"{"type": "string", "pattern": ".*", "nullable": true}"#.data(using: .utf8)!
         let allowedValueStringData = #"{"type": "string", "pattern": ".*", "enum": ["hello", "world"]}"#.data(using: .utf8)!
 
-        let string = try! testDecoder.decode(JSONSchema.self, from: stringData)
-        let nullableString = try! testDecoder.decode(JSONSchema.self, from: nullableStringData)
-        let allowedValueString = try! testDecoder.decode(JSONSchema.self, from: allowedValueStringData)
+        let string = try! orderUnstableDecode(JSONSchema.self, from: stringData)
+        let nullableString = try! orderUnstableDecode(JSONSchema.self, from: nullableStringData)
+        let allowedValueString = try! orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .generic, required: false), .init(pattern: ".*")))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .generic, required: false, nullable: true), .init(pattern: ".*")))
@@ -4009,8 +4009,8 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let all = try testDecoder.decode(JSONSchema.self, from: allData)
-        let allWithDiscriminator = try testDecoder.decode(JSONSchema.self, from: allWithDiscriminatorData)
+        let all = try orderUnstableDecode(JSONSchema.self, from: allData)
+        let allWithDiscriminator = try orderUnstableDecode(JSONSchema.self, from: allWithDiscriminatorData)
 
         XCTAssertEqual(
             all,
@@ -4122,8 +4122,8 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let one = try testDecoder.decode(JSONSchema.self, from: oneData)
-        let oneWithDiscriminator = try testDecoder.decode(JSONSchema.self, from: oneWithDiscriminatorData)
+        let one = try orderUnstableDecode(JSONSchema.self, from: oneData)
+        let oneWithDiscriminator = try orderUnstableDecode(JSONSchema.self, from: oneWithDiscriminatorData)
 
         XCTAssertEqual(
             one,
@@ -4235,8 +4235,8 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let any = try testDecoder.decode(JSONSchema.self, from: anyData)
-        let anyWithDiscriminator = try testDecoder.decode(JSONSchema.self, from: anyWithDiscriminatorData)
+        let any = try orderUnstableDecode(JSONSchema.self, from: anyData)
+        let anyWithDiscriminator = try orderUnstableDecode(JSONSchema.self, from: anyWithDiscriminatorData)
 
         XCTAssertEqual(
             any,
@@ -4284,7 +4284,7 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        let not = try testDecoder.decode(JSONSchema.self, from: notData)
+        let not = try orderUnstableDecode(JSONSchema.self, from: notData)
 
         XCTAssertEqual(not, JSONSchema.not(.boolean(.init(format: .generic, required: false))))
     }
@@ -4300,7 +4300,7 @@ extension SchemaObjectTests {
     func test_decodeFileReference() throws {
         let fileRefData = #"{ "$ref": "./other_file.json#/hello" }"#.data(using: .utf8)!
 
-        let fileRef = try testDecoder.decode(JSONSchema.self, from: fileRefData)
+        let fileRef = try orderUnstableDecode(JSONSchema.self, from: fileRefData)
 
         XCTAssertEqual(fileRef, JSONSchema.reference(.external(URL(string: "./other_file.json#/hello")!)))
     }
@@ -4316,7 +4316,7 @@ extension SchemaObjectTests {
     func test_decodeNodeReference() throws {
         let nodeRefData = ##"{ "$ref": "#/components/schemas/requiredBool" }"##.data(using: .utf8)!
 
-        let nodeRef = try testDecoder.decode(JSONSchema.self, from: nodeRefData)
+        let nodeRef = try orderUnstableDecode(JSONSchema.self, from: nodeRefData)
 
         XCTAssertEqual(
             nodeRef,
@@ -4332,7 +4332,7 @@ private func testEncodingPropertyLines<T: Encodable>(entity: T, propertyLines: [
     }
     expectedString += "}"
 
-    assertJSONEquivalent(try? testStringFromEncoding(of: entity), expectedString, file: file, line: line)
+    assertJSONEquivalent(try? orderUnstableTestStringFromEncoding(of: entity), expectedString, file: file, line: line)
 }
 
 private func testAllSharedSimpleContextEncoding<T: Encodable>(

--- a/Tests/OpenAPIKitTests/Security/OauthFlowsTests.swift
+++ b/Tests/OpenAPIKitTests/Security/OauthFlowsTests.swift
@@ -79,7 +79,7 @@ extension OAuthFlowsTests {
     func test_minimal_encode() throws {
         let oauthFlows = OpenAPI.OAuthFlows()
 
-        let encodedFlows = try testStringFromEncoding(of: oauthFlows)
+        let encodedFlows = try orderUnstableTestStringFromEncoding(of: oauthFlows)
 
         assertJSONEquivalent(
             encodedFlows,
@@ -97,7 +97,7 @@ extension OAuthFlowsTests {
 {}
 """.data(using: .utf8)!
 
-        let oauthFlows = try testDecoder.decode(OpenAPI.OAuthFlows.self, from: oauthFlowsData)
+        let oauthFlows = try orderUnstableDecode(OpenAPI.OAuthFlows.self, from: oauthFlowsData)
 
         XCTAssertEqual(oauthFlows, OpenAPI.OAuthFlows())
     }
@@ -132,7 +132,7 @@ extension OAuthFlowsTests {
             )
         )
 
-        let encodedFlows = try testStringFromEncoding(of: oauthFlows)
+        let encodedFlows = try orderUnstableTestStringFromEncoding(of: oauthFlows)
 
         assertJSONEquivalent(
             encodedFlows,
@@ -216,7 +216,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let oauthFlows = try testDecoder.decode(OpenAPI.OAuthFlows.self, from: oauthFlowsData)
+        let oauthFlows = try orderUnstableDecode(OpenAPI.OAuthFlows.self, from: oauthFlowsData)
 
         // can't compare whole object because of ordering of the ordered dictionary
 
@@ -249,7 +249,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow1 = try testStringFromEncoding(of: implicitFlow1)
+        let encodedFlow1 = try orderUnstableTestStringFromEncoding(of: implicitFlow1)
 
         assertJSONEquivalent(
             encodedFlow1,
@@ -269,7 +269,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow2 = try testStringFromEncoding(of: implicitFlow2)
+        let encodedFlow2 = try orderUnstableTestStringFromEncoding(of: implicitFlow2)
 
         assertJSONEquivalent(
             encodedFlow2,
@@ -296,7 +296,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let implicitFlow1 = try testDecoder.decode(OpenAPI.OAuthFlows.Implicit.self, from: implicitFlow1Data)
+        let implicitFlow1 = try orderUnstableDecode(OpenAPI.OAuthFlows.Implicit.self, from: implicitFlow1Data)
 
         XCTAssertEqual(
             implicitFlow1,
@@ -313,7 +313,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let implicitFlow2 = try testDecoder.decode(OpenAPI.OAuthFlows.Implicit.self, from: implicitFlow2Data)
+        let implicitFlow2 = try orderUnstableDecode(OpenAPI.OAuthFlows.Implicit.self, from: implicitFlow2Data)
 
         XCTAssertEqual(
             implicitFlow2,
@@ -328,7 +328,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow1 = try testStringFromEncoding(of: passwordFlow1)
+        let encodedFlow1 = try orderUnstableTestStringFromEncoding(of: passwordFlow1)
 
         assertJSONEquivalent(
             encodedFlow1,
@@ -348,7 +348,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow2 = try testStringFromEncoding(of: passwordFlow2)
+        let encodedFlow2 = try orderUnstableTestStringFromEncoding(of: passwordFlow2)
 
         assertJSONEquivalent(
             encodedFlow2,
@@ -375,7 +375,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let passwordFlow1 = try testDecoder.decode(OpenAPI.OAuthFlows.Password.self, from: passwordFlow1Data)
+        let passwordFlow1 = try orderUnstableDecode(OpenAPI.OAuthFlows.Password.self, from: passwordFlow1Data)
 
         XCTAssertEqual(
             passwordFlow1,
@@ -392,7 +392,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let passwordFlow2 = try testDecoder.decode(OpenAPI.OAuthFlows.Password.self, from: passwordFlow2Data)
+        let passwordFlow2 = try orderUnstableDecode(OpenAPI.OAuthFlows.Password.self, from: passwordFlow2Data)
 
         XCTAssertEqual(
             passwordFlow2,
@@ -407,7 +407,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow1 = try testStringFromEncoding(of: credentialsFlow1)
+        let encodedFlow1 = try orderUnstableTestStringFromEncoding(of: credentialsFlow1)
 
         assertJSONEquivalent(
             encodedFlow1,
@@ -427,7 +427,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow2 = try testStringFromEncoding(of: credentialsFlow2)
+        let encodedFlow2 = try orderUnstableTestStringFromEncoding(of: credentialsFlow2)
 
         assertJSONEquivalent(
             encodedFlow2,
@@ -454,7 +454,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let credentialsFlow1 = try testDecoder.decode(OpenAPI.OAuthFlows.ClientCredentials.self, from: credentialsFlow1Data)
+        let credentialsFlow1 = try orderUnstableDecode(OpenAPI.OAuthFlows.ClientCredentials.self, from: credentialsFlow1Data)
 
         XCTAssertEqual(
             credentialsFlow1,
@@ -471,7 +471,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let credentialsFlow2 = try testDecoder.decode(OpenAPI.OAuthFlows.ClientCredentials.self, from: credentialsFlow2Data)
+        let credentialsFlow2 = try orderUnstableDecode(OpenAPI.OAuthFlows.ClientCredentials.self, from: credentialsFlow2Data)
 
         XCTAssertEqual(
             credentialsFlow2,
@@ -487,7 +487,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow1 = try testStringFromEncoding(of: authorizationCodeFlow1)
+        let encodedFlow1 = try orderUnstableTestStringFromEncoding(of: authorizationCodeFlow1)
 
         assertJSONEquivalent(
             encodedFlow1,
@@ -509,7 +509,7 @@ extension OAuthFlowsTests {
             scopes: [:]
         )
 
-        let encodedFlow2 = try testStringFromEncoding(of: authorizationCodeFlow2)
+        let encodedFlow2 = try orderUnstableTestStringFromEncoding(of: authorizationCodeFlow2)
 
         assertJSONEquivalent(
             encodedFlow2,
@@ -538,7 +538,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let authorizationCodeFlow1 = try testDecoder.decode(OpenAPI.OAuthFlows.AuthorizationCode.self, from: authorizationCodeFlow1Data)
+        let authorizationCodeFlow1 = try orderUnstableDecode(OpenAPI.OAuthFlows.AuthorizationCode.self, from: authorizationCodeFlow1Data)
 
         XCTAssertEqual(
             authorizationCodeFlow1,
@@ -556,7 +556,7 @@ extension OAuthFlowsTests {
 }
 """.data(using: .utf8)!
 
-        let authorizationCodeFlow2 = try testDecoder.decode(OpenAPI.OAuthFlows.AuthorizationCode.self, from: authorizationCodeFlow2Data)
+        let authorizationCodeFlow2 = try orderUnstableDecode(OpenAPI.OAuthFlows.AuthorizationCode.self, from: authorizationCodeFlow2Data)
 
         XCTAssertEqual(
             authorizationCodeFlow2,

--- a/Tests/OpenAPIKitTests/Security/SecuritySchemeTests.swift
+++ b/Tests/OpenAPIKitTests/Security/SecuritySchemeTests.swift
@@ -62,7 +62,7 @@ extension SecuritySchemeTests {
     func test_apiKeyWithoutDescription_encode() throws {
         let apiKey = OpenAPI.SecurityScheme.apiKey(name: "hi", location: .header)
 
-        let encodedApiKey = try testStringFromEncoding(of: apiKey)
+        let encodedApiKey = try orderUnstableTestStringFromEncoding(of: apiKey)
 
         assertJSONEquivalent(
             encodedApiKey,
@@ -86,7 +86,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let apiKey = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: apiKeyData)
+        let apiKey = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: apiKeyData)
 
         XCTAssertEqual(
             apiKey,
@@ -97,7 +97,7 @@ extension SecuritySchemeTests {
     func test_apiKeyWithDescription_encode() throws {
         let apiKey = OpenAPI.SecurityScheme.apiKey(name: "hi", location: .header, description: "hello")
 
-        let encodedApiKey = try testStringFromEncoding(of: apiKey)
+        let encodedApiKey = try orderUnstableTestStringFromEncoding(of: apiKey)
 
         assertJSONEquivalent(
             encodedApiKey,
@@ -123,7 +123,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let apiKey = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: apiKeyData)
+        let apiKey = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: apiKeyData)
 
         XCTAssertEqual(
             apiKey,
@@ -134,7 +134,7 @@ extension SecuritySchemeTests {
     func test_http_encode() throws {
         let http = OpenAPI.SecurityScheme.http(scheme: "hi")
 
-        let encodedHttp = try testStringFromEncoding(of: http)
+        let encodedHttp = try orderUnstableTestStringFromEncoding(of: http)
 
         assertJSONEquivalent(
             encodedHttp,
@@ -156,7 +156,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let http = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: httpData)
+        let http = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: httpData)
 
         XCTAssertEqual(
             http,
@@ -167,7 +167,7 @@ extension SecuritySchemeTests {
     func test_httpWithBearer_encode() throws {
         let http = OpenAPI.SecurityScheme.http(scheme: "hi", bearerFormat: "hello")
 
-        let encodedHttp = try testStringFromEncoding(of: http)
+        let encodedHttp = try orderUnstableTestStringFromEncoding(of: http)
 
         assertJSONEquivalent(
             encodedHttp,
@@ -191,7 +191,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let http = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: httpData)
+        let http = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: httpData)
 
         XCTAssertEqual(
             http,
@@ -209,7 +209,7 @@ extension SecuritySchemeTests {
             )
         )
 
-        let encodedOAuth = try testStringFromEncoding(of: oauth)
+        let encodedOAuth = try orderUnstableTestStringFromEncoding(of: oauth)
 
         assertJSONEquivalent(
             encodedOAuth,
@@ -245,7 +245,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let oauth = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: oauthData)
+        let oauth = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: oauthData)
 
         XCTAssertEqual(
             oauth,
@@ -263,7 +263,7 @@ extension SecuritySchemeTests {
     func test_openIdConnect_encode() throws {
         let openIdConnect = OpenAPI.SecurityScheme.openIdConnect(url: URL(string: "http://google.com")!)
 
-        let encodedOpenIdConnect = try testStringFromEncoding(of: openIdConnect)
+        let encodedOpenIdConnect = try orderUnstableTestStringFromEncoding(of: openIdConnect)
 
         assertJSONEquivalent(
             encodedOpenIdConnect,
@@ -285,7 +285,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let openIdConnect = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: openIdConnectData)
+        let openIdConnect = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: openIdConnectData)
 
         XCTAssertEqual(
             openIdConnect,
@@ -301,7 +301,7 @@ extension SecuritySchemeTests {
             vendorExtensions: [ "x-specialFeature": "hello" ]
         )
 
-        let encodedOpenIdConnect = try testStringFromEncoding(of: openIdConnect)
+        let encodedOpenIdConnect = try orderUnstableTestStringFromEncoding(of: openIdConnect)
 
         assertJSONEquivalent(
             encodedOpenIdConnect,
@@ -325,7 +325,7 @@ extension SecuritySchemeTests {
 }
 """.data(using: .utf8)!
 
-        let openIdConnect = try testDecoder.decode(OpenAPI.SecurityScheme.self, from: openIdConnectData)
+        let openIdConnect = try orderUnstableDecode(OpenAPI.SecurityScheme.self, from: openIdConnectData)
 
         XCTAssertEqual(
             openIdConnect,

--- a/Tests/OpenAPIKitTests/ServerTests.swift
+++ b/Tests/OpenAPIKitTests/ServerTests.swift
@@ -57,14 +57,14 @@ extension ServerTests {
 }
 """.data(using: .utf8)!
 
-        let serverDecoded = try! testDecoder.decode(Server.self, from: serverData)
+        let serverDecoded = try! orderUnstableDecode(Server.self, from: serverData)
 
         XCTAssertEqual(serverDecoded, Server(url: URL(string: "https://hello.com")!))
     }
 
     func test_minimalServer_encode() {
         let server = Server(url: URL(string: "https://hello.com")!)
-        let encodedServer = try! testStringFromEncoding(of: server)
+        let encodedServer = try! orderUnstableTestStringFromEncoding(of: server)
 
         assertJSONEquivalent(encodedServer,
 """
@@ -96,7 +96,7 @@ extension ServerTests {
 }
 """.data(using: .utf8)!
 
-        let serverDecoded = try! testDecoder.decode(Server.self, from: serverData)
+        let serverDecoded = try! orderUnstableDecode(Server.self, from: serverData)
 
         XCTAssertEqual(
             serverDecoded,
@@ -130,7 +130,7 @@ extension ServerTests {
             ],
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
-        let encodedServer = try! testStringFromEncoding(of: server)
+        let encodedServer = try! orderUnstableTestStringFromEncoding(of: server)
 
         assertJSONEquivalent(encodedServer,
 """

--- a/Tests/OpenAPIKitTests/TagTests.swift
+++ b/Tests/OpenAPIKitTests/TagTests.swift
@@ -30,7 +30,7 @@ final class TagTests: XCTestCase {
 extension TagTests {
     func test_onlyName_encode() {
         let tag = OpenAPI.Tag(name: "hello")
-        let encodedTag = try! testStringFromEncoding(of: tag)
+        let encodedTag = try! orderUnstableTestStringFromEncoding(of: tag)
 
         assertJSONEquivalent(encodedTag,
 """
@@ -48,7 +48,7 @@ extension TagTests {
     "name": "hello"
 }
 """.data(using: .utf8)!
-        let tag = try! testDecoder.decode(OpenAPI.Tag.self, from: tagData)
+        let tag = try! orderUnstableDecode(OpenAPI.Tag.self, from: tagData)
 
         XCTAssertEqual(tag, OpenAPI.Tag(name: "hello"))
     }
@@ -56,7 +56,7 @@ extension TagTests {
     func test_nameAndDescription_encode() {
         let tag = OpenAPI.Tag(name: "hello",
                               description: "world")
-        let encodedTag = try! testStringFromEncoding(of: tag)
+        let encodedTag = try! orderUnstableTestStringFromEncoding(of: tag)
 
         assertJSONEquivalent(encodedTag,
 """
@@ -76,7 +76,7 @@ extension TagTests {
     "description": "world"
 }
 """.data(using: .utf8)!
-        let tag = try! testDecoder.decode(OpenAPI.Tag.self, from: tagData)
+        let tag = try! orderUnstableDecode(OpenAPI.Tag.self, from: tagData)
 
         XCTAssertEqual(tag, OpenAPI.Tag(name: "hello", description: "world"))
     }
@@ -90,7 +90,7 @@ extension TagTests {
             ),
             vendorExtensions: ["x-specialFeature": false]
         )
-        let encodedTag = try! testStringFromEncoding(of: tag)
+        let encodedTag = try! orderUnstableTestStringFromEncoding(of: tag)
 
         assertJSONEquivalent(encodedTag,
 """
@@ -118,7 +118,7 @@ extension TagTests {
     "x-specialFeature" : false
 }
 """.data(using: .utf8)!
-        let tag = try! testDecoder.decode(OpenAPI.Tag.self, from: tagData)
+        let tag = try! orderUnstableDecode(OpenAPI.Tag.self, from: tagData)
 
         XCTAssertEqual(
             tag,

--- a/Tests/OpenAPIKitTests/TestHelpers.swift
+++ b/Tests/OpenAPIKitTests/TestHelpers.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import FineJSON
 import XCTest
 
-let testEncoder = { () -> JSONEncoder in
+fileprivate let foundationTestEncoder = { () -> JSONEncoder in
     let encoder = JSONEncoder()
     if #available(macOS 10.13, *) {
         encoder.dateEncodingStrategy = .iso8601
@@ -23,11 +24,23 @@ let testEncoder = { () -> JSONEncoder in
     return encoder
 }()
 
-func testStringFromEncoding<T: Encodable>(of entity: T) throws -> String? {
-    return String(data: try testEncoder.encode(entity), encoding: .utf8)
+func orderUnstableEncode<T: Encodable>(_ value: T) throws -> Data {
+    return try foundationTestEncoder.encode(value)
 }
 
-let testDecoder = { () -> JSONDecoder in
+func orderUnstableTestStringFromEncoding<T: Encodable>(of entity: T) throws -> String? {
+    return String(data: try orderUnstableEncode(entity), encoding: .utf8)
+}
+
+fileprivate let fineJSONTestEncoder = { () -> FineJSONEncoder in
+    return FineJSONEncoder()
+}()
+
+func orderStableEncode<T: Encodable>(_ value: T) throws -> Data {
+    return try fineJSONTestEncoder.encode(value)
+}
+
+fileprivate let foundationTestDecoder = { () -> JSONDecoder in
     let decoder = JSONDecoder()
     if #available(macOS 10.12, *) {
         decoder.dateDecodingStrategy = .iso8601
@@ -39,6 +52,18 @@ let testDecoder = { () -> JSONDecoder in
     #endif
     return decoder
 }()
+
+func orderUnstableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    return try foundationTestDecoder.decode(T.self, from: data)
+}
+
+fileprivate let fineJSONTestDecoder = { () -> FineJSONDecoder in
+    return FineJSONDecoder()
+}()
+
+func orderStableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+    return try fineJSONTestDecoder.decode(T.self, from: data)
+}
 
 func assertJSONEquivalent(_ str1: String?, _ str2: String?, file: StaticString = #file, line: UInt = #line) {
 

--- a/Tests/OpenAPIKitTests/TestHelpers.swift
+++ b/Tests/OpenAPIKitTests/TestHelpers.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 import FineJSON
+import PureSwiftJSON
 import XCTest
 
+// MARK: - Order-instable Encoder
 fileprivate let foundationTestEncoder = { () -> JSONEncoder in
     let encoder = JSONEncoder()
     if #available(macOS 10.13, *) {
@@ -24,14 +26,20 @@ fileprivate let foundationTestEncoder = { () -> JSONEncoder in
     return encoder
 }()
 
+fileprivate let pureSwiftTestEncoder = { () -> PSJSONEncoder in
+    return PSJSONEncoder()
+}()
+
 func orderUnstableEncode<T: Encodable>(_ value: T) throws -> Data {
-    return try foundationTestEncoder.encode(value)
+//    return try foundationTestEncoder.encode(value)
+    return try Data(pureSwiftTestEncoder.encode(value))
 }
 
 func orderUnstableTestStringFromEncoding<T: Encodable>(of entity: T) throws -> String? {
     return String(data: try orderUnstableEncode(entity), encoding: .utf8)
 }
 
+// MARK: - Order-stable Encoder
 fileprivate let fineJSONTestEncoder = { () -> FineJSONEncoder in
     return FineJSONEncoder()
 }()
@@ -40,6 +48,7 @@ func orderStableEncode<T: Encodable>(_ value: T) throws -> Data {
     return try fineJSONTestEncoder.encode(value)
 }
 
+// MARK: - Order-unstable Decoder
 fileprivate let foundationTestDecoder = { () -> JSONDecoder in
     let decoder = JSONDecoder()
     if #available(macOS 10.12, *) {
@@ -53,10 +62,16 @@ fileprivate let foundationTestDecoder = { () -> JSONDecoder in
     return decoder
 }()
 
+fileprivate let pureSwiftTestDecoder = { () -> PSJSONDecoder in
+    return PSJSONDecoder()
+}()
+
 func orderUnstableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
-    return try foundationTestDecoder.decode(T.self, from: data)
+//    return try foundationTestDecoder.decode(T.self, from: data)
+    return try pureSwiftTestDecoder.decode(T.self, from: data)
 }
 
+// MARK: - Order-stable Decoder
 fileprivate let fineJSONTestDecoder = { () -> FineJSONDecoder in
     return FineJSONDecoder()
 }()
@@ -65,6 +80,7 @@ func orderStableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -> 
     return try fineJSONTestDecoder.decode(T.self, from: data)
 }
 
+// MARK: - JSON equivalency
 func assertJSONEquivalent(_ str1: String?, _ str2: String?, file: StaticString = #file, line: UInt = #line) {
 
     // when testing on Linux, pretty printing has slightly different

--- a/Tests/OpenAPIKitTests/VendorExtendableTests.swift
+++ b/Tests/OpenAPIKitTests/VendorExtendableTests.swift
@@ -23,7 +23,7 @@ final class VendorExtendableTests: XCTestCase {
 }
 """.data(using: .utf8)!
 
-        let test = try JSONDecoder().decode(TestStruct.self, from: data)
+        let test = try orderUnstableDecode(TestStruct.self, from: data)
         XCTAssertEqual(test.vendorExtensions.count, 3)
 
         XCTAssertEqual(test.vendorExtensions["x-tension"]?.value as? String, "hello")
@@ -60,7 +60,7 @@ final class VendorExtendableTests: XCTestCase {
 ]
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try JSONDecoder().decode(TestStruct.self, from: data)) { error in
+        XCTAssertThrowsError(try orderUnstableDecode(TestStruct.self, from: data)) { error in
             XCTAssertEqual(error as? VendorExtensionDecodingError, VendorExtensionDecodingError.selfIsArrayNotDict)
             XCTAssertEqual(String(describing: error), "Tried to get vendor extensions on a list. Vendor extensions are necessarily keyed and therefore can only be retrieved from hashes.")
         }
@@ -75,7 +75,7 @@ final class VendorExtendableTests: XCTestCase {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try JSONDecoder().decode(TestStruct.self, from: data)) { error in
+        XCTAssertThrowsError(try orderUnstableDecode(TestStruct.self, from: data)) { error in
             XCTAssertNotNil(error as? InconsistencyError)
         }
     }
@@ -94,7 +94,7 @@ extension VendorExtendableTests {
             ]
         ])
 
-        let encoded = try testStringFromEncoding(of: test)
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
 
         assertJSONEquivalent(encoded,
 """

--- a/Tests/OpenAPIKitTests/XMLTests.swift
+++ b/Tests/OpenAPIKitTests/XMLTests.swift
@@ -25,7 +25,7 @@ final class XMLTests: XCTestCase {
 extension XMLTests {
     func test_empty_encode() throws {
         let xml = OpenAPI.XML()
-        let encodedXML = try testStringFromEncoding(of: xml)
+        let encodedXML = try orderUnstableTestStringFromEncoding(of: xml)
 
         assertJSONEquivalent(
             encodedXML,
@@ -45,7 +45,7 @@ extension XMLTests {
 }
 """.data(using: .utf8)!
 
-        let xml = try testDecoder.decode(OpenAPI.XML.self, from: xmlData)
+        let xml = try orderUnstableDecode(OpenAPI.XML.self, from: xmlData)
 
         XCTAssertEqual(
             xml,
@@ -61,7 +61,7 @@ extension XMLTests {
             attribute: true,
             wrapped: true
         )
-        let encodedXML = try testStringFromEncoding(of: xml)
+        let encodedXML = try orderUnstableTestStringFromEncoding(of: xml)
 
         assertJSONEquivalent(
             encodedXML,
@@ -89,7 +89,7 @@ extension XMLTests {
 }
 """.data(using: .utf8)!
 
-        let xml = try testDecoder.decode(OpenAPI.XML.self, from: xmlData)
+        let xml = try orderUnstableDecode(OpenAPI.XML.self, from: xmlData)
 
         XCTAssertEqual(
             xml,


### PR DESCRIPTION
Do not merge this PR, it would add a new dependency to the package.

Swapping out the Foundation JSONEncoder/JSONDecoder for the PureSwift PSJOSNEncoder/PSJSONDecoder as a test case for that encoder/decoder implementation.