### PR TITLE
Bugfix/reference schema fragments

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaFragment.swift
@@ -43,6 +43,8 @@ public enum JSONSchemaFragment: Equatable {
         GeneralContext,
         ObjectContext
     )
+
+    case reference(JSONReference<JSONSchema>)
 }
 
 extension JSONSchemaFragment {
@@ -223,6 +225,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.format
+        case .reference:
+            return nil
         }
     }
 
@@ -236,6 +240,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.description
+        case .reference:
+            return nil
         }
     }
 
@@ -249,6 +255,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.title
+        case .reference:
+            return nil
         }
     }
 
@@ -262,6 +270,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.nullable
+        case .reference:
+            return nil
         }
     }
 
@@ -275,6 +285,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.deprecated
+        case .reference:
+            return nil
         }
     }
 
@@ -288,6 +300,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.externalDocs
+        case .reference:
+            return nil
         }
     }
 
@@ -301,6 +315,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.allowedValues
+        case .reference:
+            return nil
         }
     }
 
@@ -314,6 +330,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.example
+        case .reference:
+            return nil
         }
     }
 
@@ -327,6 +345,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.readOnly
+        case .reference:
+            return nil
         }
     }
 
@@ -340,6 +360,8 @@ extension JSONSchemaFragment: JSONSchemaFragmentContext {
              .array(let generalContext, _),
              .object(let generalContext, _):
             return generalContext.writeOnly
+        case .reference:
+            return nil
         }
     }
 }
@@ -428,6 +450,10 @@ extension JSONSchemaFragment: Encodable {
             try container.encodeIfPresent(objectContext.properties, forKey: .properties)
             try container.encodeIfPresent(objectContext.additionalProperties, forKey: .additionalProperties)
             try container.encodeIfPresent(objectContext.required, forKey: .required)
+        case .reference(let reference):
+            var container = encoder.singleValueContainer()
+
+            try container.encode(reference)
         }
     }
 }
@@ -508,6 +534,13 @@ extension JSONSchemaFragment.ObjectContext: Decodable {
 
 extension JSONSchemaFragment: Decodable {
     public init(from decoder: Decoder) throws {
+
+        if let singleValueContainer = try? decoder.singleValueContainer() {
+            if let ref = try? singleValueContainer.decode(JSONReference<JSONSchema>.self) {
+                self = .reference(ref)
+                return
+            }
+        }
 
         let generalContext = try GeneralContext(from: decoder)
 

--- a/Tests/OpenAPIKitCompatibilitySuite/SwaggerDocSamplesTests.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/SwaggerDocSamplesTests.swift
@@ -1,0 +1,307 @@
+//
+//  SwaggerDocSamplesTests.swift
+//  
+//
+//  Created by Mathew Polzin on 7/25/20.
+//
+
+import Foundation
+import XCTest
+import OpenAPIKit
+import Yams
+
+final class SwaggerDocSamplesTests: XCTestCase {
+    func test_allOfExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+    /pets:
+        patch:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            oneOf:
+                                - $ref: '#/components/schemas/Cat'
+                                - $ref: '#/components/schemas/Dog'
+                            discriminator:
+                                propertyName: pet_type
+            responses:
+                '200':
+                    description: Updated
+components:
+    schemas:
+        Pet:
+            type: object
+            required:
+                - pet_type
+            properties: #3
+                pet_type:
+                    type: string
+            discriminator:
+                propertyName: pet_type
+        Dog:
+            allOf:
+                - $ref: '#/components/schemas/Pet'
+                - type: object
+                  properties:
+                        bark:
+                            type: boolean
+                        breed:
+                            type: string
+                            enum: [Dingo, Husky, Retriever, Shepherd]
+        Cat:
+            allOf:
+                - $ref: '#/components/schemas/Pet'
+                - type: object
+                  properties:
+                        hunts:
+                            type: boolean
+                        age:
+                            type: integer
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+
+    func test_oneOfExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Cat'
+                - $ref: '#/components/schemas/Dog'
+      responses:
+        '200':
+          description: Updated
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        bark:
+          type: boolean
+        breed:
+          type: string
+          enum: [Dingo, Husky, Retriever, Shepherd]
+    Cat:
+      type: object
+      properties:
+        hunts:
+          type: boolean
+        age:
+          type: integer
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+
+    func test_anyOfExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: '#/components/schemas/PetByAge'
+                - $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Updated
+components:
+  schemas:
+    PetByAge:
+      type: object
+      properties:
+        age:
+          type: integer
+        nickname:
+          type: string
+      required:
+        - age
+
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          type: string
+          enum: [Cat, Dog]
+        hunts:
+          type: boolean
+      required:
+        - pet_type
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+
+    func test_notExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetByType'
+      responses:
+        '200':
+          description: Updated
+components:
+  schemas:
+    PetByType:
+      type: object
+      properties:
+        pet_type:
+          not:
+            type: integer
+      required:
+        - pet_type
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+
+    func test_enumsExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+  /items:
+    get:
+      parameters:
+        - in: query
+          name: sort
+          description: Sort order
+          schema:
+            type: string
+            enum: [asc, desc]
+      responses:
+        '200':
+          description: OK
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+
+    func test_reusableEnumsExample() throws {
+        let docString = commonBaseDocument + """
+paths:
+  /products:
+    get:
+      parameters:
+      - in: query
+        name: color
+        required: true
+        schema:
+          $ref: '#/components/schemas/Color'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Color:
+      type: string
+      enum:
+        - black
+        - white
+        - red
+        - green
+        - blue
+"""
+
+        // test decoding
+        do {
+            let doc = try YAMLDecoder().decode(OpenAPI.Document.self, from: docString)
+
+            // test validating
+            try doc.validate()
+
+            // test dereferencing and resolving
+            _ = try doc.locallyDereferenced().resolved()
+        } catch let error {
+            let friendlyError = OpenAPI.Error(from: error)
+            throw friendlyError
+        }
+    }
+}
+
+fileprivate let commonBaseDocument = """
+openapi: 3.0.0
+info:
+    title: Sample API
+    description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+    version: 0.1.9
+servers:
+    - url: http://api.example.com/v1
+      description: Optional server description, e.g. Main (production) server
+    - url: http://staging-api.example.com
+      description: Optional server description, e.g. Internal staging server for testing
+
+"""

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -190,9 +190,9 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t1))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t1))
 
-        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t2))
+        XCTAssertThrowsError(try orderUnstableDecode(JSONSchemaFragment.self, from: t2))
     }
 
     func test_generalEncode() throws {
@@ -815,7 +815,7 @@ extension SchemaFragmentTests {
     func test_referenceEncode() throws {
         let t1 = JSONSchemaFragment.reference(.component(named: "test"))
 
-        let encoded = try testStringFromEncoding(of: t1)
+        let encoded = try orderUnstableTestStringFromEncoding(of: t1)
 
         assertJSONEquivalent(
             encoded,
@@ -835,7 +835,7 @@ extension SchemaFragmentTests {
 }
 """.data(using: .utf8)!
 
-        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t1)
+        let decoded = try orderUnstableDecode(JSONSchemaFragment.self, from: t1)
 
         XCTAssertEqual(decoded, .reference(.component(named: "test")))
     }

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -30,6 +30,7 @@ final class SchemaFragmentTests: XCTestCase {
         assertNoGeneralProperties(JSONSchemaFragment.number(.init(), .init()))
         assertNoGeneralProperties(JSONSchemaFragment.array(.init(), .init()))
         assertNoGeneralProperties(JSONSchemaFragment.object(.init(), .init()))
+        assertNoGeneralProperties(JSONSchemaFragment.reference(.component(named: "test")))
 
         func assertSameGeneralProperties(_ fragment: JSONSchemaFragment, as properties: JSONSchemaFragment.GeneralContext, file: StaticString = #file, line: UInt = #line) {
             XCTAssertEqual(fragment.allowedValues, properties.allowedValues, file: file, line: line)
@@ -171,6 +172,27 @@ extension SchemaFragmentTests {
 """.data(using: .utf8)!
 
         XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t))
+    }
+
+    func test_decodeFailsWithInvalidReference() {
+        let t1 =
+"""
+{
+    "$ref": "not a ref !@#$%%^"
+}
+""".data(using: .utf8)!
+
+        // should be a schema reference, not a response reference.
+        let t2 =
+"""
+{
+    "$ref": "#/components/responses/test"
+}
+""".data(using: .utf8)!
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t1))
+
+        XCTAssertThrowsError(try testDecoder.decode(JSONSchemaFragment.self, from: t2))
     }
 
     func test_generalEncode() throws {
@@ -788,5 +810,33 @@ extension SchemaFragmentTests {
         let decoded5 = try testDecoder.decode(JSONSchemaFragment.self, from: t5)
 
         XCTAssertEqual(decoded5, JSONSchemaFragment.object(.init(), .init(properties: ["hello": .string(required: false)])))
+    }
+
+    func test_referenceEncode() throws {
+        let t1 = JSONSchemaFragment.reference(.component(named: "test"))
+
+        let encoded = try testStringFromEncoding(of: t1)
+
+        assertJSONEquivalent(
+            encoded,
+"""
+{
+  "$ref" : "#\\/components\\/schemas\\/test"
+}
+"""
+        )
+    }
+
+    func test_referenceDecode() throws {
+        let t1 =
+"""
+{
+  "$ref": "#/components/schemas/test"
+}
+""".data(using: .utf8)!
+
+        let decoded = try testDecoder.decode(JSONSchemaFragment.self, from: t1)
+
+        XCTAssertEqual(decoded, .reference(.component(named: "test")))
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/OpenAPIKit/issues/98.

- Add `.reference` case to `JSONSchemaFragment` type (fixes hole in representation of valid OpenAPI `allOf` schema objects).

⚠️ Breaking Changes ⚠️ 
For the very small amount of code that might be switching on the `JSONSchemaFragment` enum, this bug fix will break source code. This should be a very very uncommon breakage and the bug cannot be fixed without it.