### PR TITLE
Improve error for invalid vendor extensions

### DIFF
--- a/Sources/OpenAPIKit/CodableVendorExtendable.swift
+++ b/Sources/OpenAPIKit/CodableVendorExtendable.swift
@@ -86,10 +86,12 @@ extension CodableVendorExtendable {
             return !CodingKeys.allBuiltinKeys.contains(key)
         }
 
-        guard extensions.keys.allSatisfy({ $0.lowercased().starts(with: "x-") }) else {
+        let invalidKeys = extensions.keys.filter { !$0.lowercased().starts(with: "x-") }
+        if !invalidKeys.isEmpty {
+            let invalidKeysList = "[ " + invalidKeys.joined(separator: ", ") + " ]"
             throw InconsistencyError(
                 subjectName: "Vendor Extension",
-                details: "Found a vendor extension property that does not begin with the required 'x-' prefix",
+                details: "Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: \(invalidKeysList)",
                 codingPath: decoder.codingPath
             )
         }

--- a/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
@@ -140,7 +140,7 @@ paths:
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Inconsistency encountered when parsing `Vendor Extension` in .content['application/json'] for the request body of the **GET** endpoint under `/hello/world`: Found a vendor extension property that does not begin with the required 'x-' prefix.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Inconsistency encountered when parsing `Vendor Extension` in .content['application/json'] for the request body of the **GET** endpoint under `/hello/world`: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ invalid ].")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
                 "/hello/world",


### PR DESCRIPTION
Invalid vendor extensions result in an `InconsistencyError`. The error previously just stated that _some_ vendor extension did not begin with the "x-" prefix but now it will print a list of invalid property names.