### PR TITLE
Make the Content type (aka Media Item Object) schema property not required

### DIFF
--- a/Sources/OpenAPIKit/Content/Content.swift
+++ b/Sources/OpenAPIKit/Content/Content.swift
@@ -10,7 +10,7 @@ extension OpenAPI {
     /// 
     /// See [OpenAPI Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#media-type-object).
     public struct Content: Equatable, CodableVendorExtendable {
-        public var schema: Either<JSONReference<JSONSchema>, JSONSchema>
+        public var schema: Either<JSONReference<JSONSchema>, JSONSchema>?
         public var example: AnyCodable?
         public var examples: Example.Map?
         public var encoding: OrderedDictionary<String, Encoding>?
@@ -22,10 +22,14 @@ extension OpenAPI {
         /// where the values are anything codable.
         public var vendorExtensions: [String: AnyCodable]
 
-        public init(schema: Either<JSONReference<JSONSchema>, JSONSchema>,
-                    example: AnyCodable? = nil,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a schema, a reference to a schema, or no
+        /// schema at all and optionally provide a single example.
+        public init(
+            schema: Either<JSONReference<JSONSchema>, JSONSchema>?,
+            example: AnyCodable? = nil,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = schema
             self.example = example
             self.examples = nil
@@ -33,10 +37,14 @@ extension OpenAPI {
             self.vendorExtensions = vendorExtensions
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
-                    example: AnyCodable? = nil,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a reference to a schema and optionally
+        /// provide a single example.
+        public init(
+            schemaReference: JSONReference<JSONSchema>,
+            example: AnyCodable? = nil,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = .init(schemaReference)
             self.example = example
             self.examples = nil
@@ -44,10 +52,14 @@ extension OpenAPI {
             self.vendorExtensions = vendorExtensions
         }
 
-        public init(schema: JSONSchema,
-                    example: AnyCodable? = nil,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a schema and optionally provide a single
+        /// example.
+        public init(
+            schema: JSONSchema,
+            example: AnyCodable? = nil,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = .init(schema)
             self.example = example
             self.examples = nil
@@ -55,10 +67,14 @@ extension OpenAPI {
             self.vendorExtensions = vendorExtensions
         }
 
-        public init(schema: Either<JSONReference<JSONSchema>, JSONSchema>,
-                    examples: Example.Map?,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a schema, a reference to a schema, or no
+        /// schema at all and optionally provide a map of examples.
+        public init(
+            schema: Either<JSONReference<JSONSchema>, JSONSchema>?,
+            examples: Example.Map?,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = schema
             self.examples = examples
             self.example = examples.flatMap(Self.firstExample(from:))
@@ -66,10 +82,14 @@ extension OpenAPI {
             self.vendorExtensions = vendorExtensions
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
-                    examples: Example.Map?,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a reference to a schema and optionally
+        /// provide a map of examples.
+        public init(
+            schemaReference: JSONReference<JSONSchema>,
+            examples: Example.Map?,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = .init(schemaReference)
             self.examples = examples
             self.example = examples.flatMap(Self.firstExample(from:))
@@ -77,10 +97,14 @@ extension OpenAPI {
             self.vendorExtensions = vendorExtensions
         }
 
-        public init(schema: JSONSchema,
-                    examples: Example.Map?,
-                    encoding: OrderedDictionary<String, Encoding>? = nil,
-                    vendorExtensions: [String: AnyCodable] = [:]) {
+        /// Create `Content` with a schema and optionally provide a map
+        /// of examples.
+        public init(
+            schema: JSONSchema,
+            examples: Example.Map?,
+            encoding: OrderedDictionary<String, Encoding>? = nil,
+            vendorExtensions: [String: AnyCodable] = [:]
+        ) {
             self.schema = .init(schema)
             self.examples = examples
             self.example = examples.flatMap(Self.firstExample(from:))
@@ -123,7 +147,7 @@ extension OpenAPI.Content: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(schema, forKey: .schema)
+        try container.encodeIfPresent(schema, forKey: .schema)
 
         // only encode `examples` if non-nil,
         // otherwise encode `example` if non-nil
@@ -151,7 +175,7 @@ extension OpenAPI.Content: Decodable {
             )
         }
 
-        schema = try container.decode(Either<JSONReference<JSONSchema>, JSONSchema>.self, forKey: .schema)
+        schema = try container.decodeIfPresent(Either<JSONReference<JSONSchema>, JSONSchema>.self, forKey: .schema)
 
         encoding = try container.decodeIfPresent(OrderedDictionary<String, Encoding>.self, forKey: .encoding)
 

--- a/Sources/OpenAPIKit/Content/DereferencedContent.swift
+++ b/Sources/OpenAPIKit/Content/DereferencedContent.swift
@@ -11,7 +11,7 @@
 @dynamicMemberLookup
 public struct DereferencedContent: Equatable {
     public let underlyingContent: OpenAPI.Content
-    public let schema: DereferencedJSONSchema
+    public let schema: DereferencedJSONSchema?
     public let examples: OrderedDictionary<String, OpenAPI.Example>?
     public let example: AnyCodable?
     public let encoding: OrderedDictionary<String, DereferencedContentEncoding>?
@@ -28,7 +28,7 @@ public struct DereferencedContent: Equatable {
     ///     on whether an unresolvable reference points to another file or just points to a
     ///     component in the same file that cannot be found in the Components Object.
     internal init(_ content: OpenAPI.Content, resolvingIn components: OpenAPI.Components) throws {
-        self.schema = try content.schema.dereferenced(in: components)
+        self.schema = try content.schema?.dereferenced(in: components)
         let examples = try content.examples?.mapValues { try components.lookup($0) }
         self.examples = examples
 

--- a/Tests/OpenAPIKitCompatibilitySuite/PetStoreAPITests.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/PetStoreAPITests.swift
@@ -122,7 +122,11 @@ final class PetStoreAPICampatibilityTests: XCTestCase {
         let dereferencedDoc = try apiDoc.locallyDereferenced()
 
         // Pet schema is a $ref to Components Object
-        XCTAssertEqual(dereferencedDoc.paths["/pet"]?.post?.responses[status: 200]?.content[.json]?.schema.objectContext?.properties["name"]?.jsonSchema, try JSONSchema.string.with(example: "doggie"))
+        XCTAssertEqual(
+            dereferencedDoc.paths["/pet"]?.post?.responses[status: 200]?
+                .content[.json]?.schema?.objectContext?.properties["name"]?.jsonSchema,
+            try JSONSchema.string.with(example: "doggie")
+        )
     }
 
     func test_resolveDocument() throws {

--- a/Tests/OpenAPIKitCompatibilitySuite/SwaggerDocSamplesTests.swift
+++ b/Tests/OpenAPIKitCompatibilitySuite/SwaggerDocSamplesTests.swift
@@ -69,7 +69,7 @@ components:
 
             XCTAssertEqual(
                 doc.paths["/pets"]?.patch?.requestBody?.requestValue?
-                    .content[.json]?.schema.schemaValue,
+                    .content[.json]?.schema?.schemaValue,
                 JSONSchema.one(
                     of: .reference(.component(named: "Cat")),
                         .reference(.component(named: "Dog")),
@@ -102,7 +102,7 @@ components:
 
             XCTAssertEqual(
                 resolvedDoc.endpoints[0].requestBody?
-                    .content[.json]?.schema.jsonSchema,
+                    .content[.json]?.schema?.jsonSchema,
                 JSONSchema.one(
                     of: [
                         catSchema,

--- a/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
@@ -51,39 +51,6 @@ final class RequestContentMapErrorTests: XCTestCase {
 //        }
 //    }
 
-    func test_missingSchemaContent() {
-        let documentYML =
-"""
-openapi: "3.0.0"
-info:
-    title: test
-    version: 1.0
-paths:
-    /hello/world:
-        get:
-            requestBody:
-                content:
-                    application/json: {}
-            responses: {}
-"""
-
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
-
-            let openAPIError = OpenAPI.Error(from: error)
-
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find `schema` key in .content['application/json'] for the request body of the **GET** endpoint under `/hello/world` but it is missing.")
-            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
-                "paths",
-                "/hello/world",
-                "get",
-                "requestBody",
-                "content",
-                "application/json"
-            ])
-            XCTAssertEqual(openAPIError.codingPathString, ".paths['/hello/world'].get.requestBody.content['application/json']")
-        }
-    }
-
     func test_wrongTypeContentValue() {
         let documentYML =
 """

--- a/Tests/OpenAPIKitTests/Content/ContentTests.swift
+++ b/Tests/OpenAPIKitTests/Content/ContentTests.swift
@@ -12,16 +12,16 @@ import OpenAPIKit
 final class ContentTests: XCTestCase {
     func test_init() {
         let t1 = OpenAPI.Content(schema: .init(.external(URL(string:"hello.json#/world")!)))
-        XCTAssertNotNil(t1.schema.reference)
-        XCTAssertNil(t1.schema.schemaValue)
+        XCTAssertNotNil(t1.schema?.reference)
+        XCTAssertNil(t1.schema?.schemaValue)
 
         let t2 = OpenAPI.Content(schema: .init(.string))
-        XCTAssertNotNil(t2.schema.schemaValue)
-        XCTAssertNil(t2.schema.reference)
+        XCTAssertNotNil(t2.schema?.schemaValue)
+        XCTAssertNil(t2.schema?.reference)
 
         let t3 = OpenAPI.Content(schemaReference: .external(URL(string: "hello.json#/world")!))
-        XCTAssertNotNil(t3.schema.reference)
-        XCTAssertNil(t3.schema.schemaValue)
+        XCTAssertNotNil(t3.schema?.reference)
+        XCTAssertNil(t3.schema?.schemaValue)
 
         let withExample = OpenAPI.Content(
             schema: .init(.string),
@@ -51,15 +51,15 @@ final class ContentTests: XCTestCase {
             schemaReference: .external(URL(string: "hello.json#/world")!),
             examples: nil
         )
-        XCTAssertNotNil(t4.schema.reference)
-        XCTAssertNil(t4.schema.schemaValue)
+        XCTAssertNotNil(t4.schema?.reference)
+        XCTAssertNil(t4.schema?.schemaValue)
 
         let t5 = OpenAPI.Content(
             schema: .string,
             examples: nil
         )
-        XCTAssertNotNil(t5.schema.schemaValue)
-        XCTAssertNil(t5.schema.reference)
+        XCTAssertNotNil(t5.schema?.schemaValue)
+        XCTAssertNil(t5.schema?.reference)
 
         let _ = OpenAPI.Content(
             schema: .init(.string),
@@ -215,6 +215,31 @@ extension ContentTests {
         let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
         XCTAssertEqual(content, OpenAPI.Content(schema: .init(.string)))
+    }
+
+    func test_schemalessContent_encode() {
+        let content = OpenAPI.Content(schema: nil, example: "hello world")
+        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+        assertJSONEquivalent(encodedContent,
+"""
+{
+  "example" : "hello world"
+}
+"""
+        )
+    }
+
+    func test_schemalessContent_decode() {
+        let contentData =
+"""
+{
+  "example" : "hello world"
+}
+""".data(using: .utf8)!
+        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+        XCTAssertEqual(content, OpenAPI.Content(schema: nil, example: "hello world"))
     }
 
     func test_exampleAndSchemaContent_encode() {

--- a/Tests/OpenAPIKitTests/Header/DereferencedHeaderTests.swift
+++ b/Tests/OpenAPIKitTests/Header/DereferencedHeaderTests.swift
@@ -26,7 +26,7 @@ final class DereferencedHeaderTests: XCTestCase {
             ]
         ).dereferenced(in: .noComponents)
 
-        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema?.jsonSchema, .string)
     }
 
     func test_referencedSchemaHeader() throws {
@@ -52,6 +52,6 @@ final class DereferencedHeaderTests: XCTestCase {
             content: [.json: .init(schemaReference: .component(named: "test"))]
         ).dereferenced(in: components)
 
-        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema?.jsonSchema, .string)
     }
 }

--- a/Tests/OpenAPIKitTests/Parameter/DereferencedParameterTests.swift
+++ b/Tests/OpenAPIKitTests/Parameter/DereferencedParameterTests.swift
@@ -30,7 +30,7 @@ final class DereferencedParameterTests: XCTestCase {
             ]
         ).dereferenced(in: .noComponents)
 
-        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema?.jsonSchema, .string)
     }
 
     func test_referencedSchemaParameter() throws {
@@ -60,7 +60,7 @@ final class DereferencedParameterTests: XCTestCase {
             content: [.json: .init(schemaReference: .component(named: "test"))]
         ).dereferenced(in: components)
 
-        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.schemaOrContent.contentValue?[.json]?.schema?.jsonSchema, .string)
     }
 }
 

--- a/Tests/OpenAPIKitTests/Request/DereferencedRequestTests.swift
+++ b/Tests/OpenAPIKitTests/Request/DereferencedRequestTests.swift
@@ -24,7 +24,7 @@ final class DereferencedRequestTests: XCTestCase {
             description: "test",
             content: [.json: .init(schema: .string)]
         ).dereferenced(in: .noComponents)
-        XCTAssertEqual(t1.content[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.content[.json]?.schema?.jsonSchema, .string)
         // test dynamic member lookup
         XCTAssertEqual(t1.description, "test")
     }
@@ -41,7 +41,7 @@ final class DereferencedRequestTests: XCTestCase {
                 .json: .init(schemaReference: .component(named: "test"))
             ]
         ).dereferenced(in: components)
-        XCTAssertEqual(t1.content[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.content[.json]?.schema?.jsonSchema, .string)
     }
 
     func test_referencedContentMissing() {

--- a/Tests/OpenAPIKitTests/Response/DereferencedResponseTests.swift
+++ b/Tests/OpenAPIKitTests/Response/DereferencedResponseTests.swift
@@ -69,7 +69,7 @@ final class DereferencedResponseTests: XCTestCase {
                 .json: .init(schemaReference: .component(named: "test"))
             ]
         ).dereferenced(in: components)
-        XCTAssertEqual(t1.content[.json]?.schema.jsonSchema, .string)
+        XCTAssertEqual(t1.content[.json]?.schema?.jsonSchema, .string)
     }
 
     func test_referencedContentMissing() {

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1155,20 +1155,20 @@ final class ValidatorTests: XCTestCase {
 
         let requestBodyContainsName = Validation(
             check: unwrap(
-                \.content[.json]?.schema.schemaValue,
+                \.content[.json]?.schema?.schemaValue,
                 into: resourceContainsName
             ),
 
-            when: \OpenAPI.Request.content[.json]?.schema.schemaValue != nil
+            when: \OpenAPI.Request.content[.json]?.schema?.schemaValue != nil
         )
 
         let responseBodyContainsNameAndId = Validation(
             check: unwrap(
-                \.content[.json]?.schema.schemaValue,
+                \.content[.json]?.schema?.schemaValue,
                 into: resourceContainsName, responseResourceContainsId
             ),
 
-            when: \OpenAPI.Response.content[.json]?.schema.schemaValue != nil
+            when: \OpenAPI.Response.content[.json]?.schema?.schemaValue != nil
         )
 
         let successResponseBodyContainsNameAndId = Validation(
@@ -1283,20 +1283,20 @@ final class ValidatorTests: XCTestCase {
 
         let requestBodyContainsName = Validation(
             check: unwrap(
-                \.content[.json]?.schema.schemaValue,
+                \.content[.json]?.schema?.schemaValue,
                 into: resourceContainsName
             ),
 
-            when: \OpenAPI.Request.content[.json]?.schema.schemaValue != nil
+            when: \OpenAPI.Request.content[.json]?.schema?.schemaValue != nil
         )
 
         let responseBodyContainsNameAndId = Validation(
             check: unwrap(
-                \.content[.json]?.schema.schemaValue,
+                \.content[.json]?.schema?.schemaValue,
                 into: resourceContainsName, responseResourceContainsId
             ),
 
-            when: \OpenAPI.Response.content[.json]?.schema.schemaValue != nil
+            when: \OpenAPI.Response.content[.json]?.schema?.schemaValue != nil
         )
 
         let successResponseBodyContainsNameAndId = Validation(

--- a/documentation/validation.md
+++ b/documentation/validation.md
@@ -472,17 +472,17 @@ let responseResourceContainsId = Validation<JSONSchema>(
 // clause to skip over any requests that do not have such schemas
 // without error.
 let requestBodyContainsName = Validation(
-   check: unwrap(\.content[.json]?.schema.schemaValue, into: resourceContainsName),
+   check: unwrap(\.content[.json]?.schema?.schemaValue, into: resourceContainsName),
 
-   when: \OpenAPI.Request.content[.json]?.schema.schemaValue != nil
+   when: \OpenAPI.Request.content[.json]?.schema?.schemaValue != nil
 )
 
 // Similarly, we check JSON response schemas. This time we check
 // for both a 'name' and an 'id'.
 let responseBodyContainsNameAndId = Validation(
-   check: unwrap(\.content[.json]?.schema.schemaValue, into: resourceContainsName, responseResourceContainsId),
+   check: unwrap(\.content[.json]?.schema?.schemaValue, into: resourceContainsName, responseResourceContainsId),
 
-   when: \OpenAPI.Response.content[.json]?.schema.schemaValue != nil
+   when: \OpenAPI.Response.content[.json]?.schema?.schemaValue != nil
 )
 
 // We are specifically looking only at 201 ("created") status code


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/OpenAPIKit/issues/115.