### PR TITLE
Add a bit more information to the schemaComponentsAreDefined validation error message.

### DIFF
--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -54,6 +54,10 @@ extension Validation {
     /// are non-empty and therefore offer some value to the consumer/reader of
     /// the OpenAPI documentation beyond just "this property exists."
     ///
+    /// - Note: A sneaky way for the empty object to get into documentation is
+    ///     by putting a property name in a parent object's `required` array
+    ///     without adding that property to the `properties` map.
+    ///
     /// - Important: This is not an included validation by default.
     public static var schemaComponentsAreDefined: Validation<JSONSchema> {
         .init(

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -57,7 +57,7 @@ extension Validation {
     /// - Important: This is not an included validation by default.
     public static var schemaComponentsAreDefined: Validation<JSONSchema> {
         .init(
-            description: "JSON Schema components have defining characteristics (i.e. they are not just the empty schema component: `{}`)",
+            description: "JSON Schema components have defining characteristics (i.e. they are not just the empty schema component: `{}`) [Note that one way to end up with empty schema components is by having property names in an object's `required` array that are not defined in that object's `properties` map]",
             check: \.subject.isEmpty == false
         )
     }

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -134,7 +134,7 @@ final class BuiltinValidationTests: XCTestCase {
         XCTAssertThrowsError(try document.validate(using: validator)) { error in
             XCTAssertEqual(
                 (error as? ValidationErrorCollection)?.values.map(String.init(describing:)),
-                [#"Failed to satisfy: JSON Schema components have defining characteristics (i.e. they are not just the empty schema component: `{}`) at path: .paths['/hello/world'].get.responses.200.content['application/json'].schema.properties.nested"#]
+                [#"Failed to satisfy: JSON Schema components have defining characteristics (i.e. they are not just the empty schema component: `{}`) [Note that one way to end up with empty schema components is by having property names in an object's `required` array that are not defined in that object's `properties` map] at path: .paths['/hello/world'].get.responses.200.content['application/json'].schema.properties.nested"#]
             )
         }
     }


### PR DESCRIPTION
The message was a bit cryptic in one specific situation that the validation will fail.