### PR TITLE
Misc. additions

### DIFF
--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -157,6 +157,26 @@ extension OpenAPI {
 }
 
 extension OpenAPI.Document {
+    /// Create a new OpenAPI Document with
+    /// all paths not passign the given predicate
+    /// removed.
+    public func filteringPaths(with predicate: (OpenAPI.Path) -> Bool) -> OpenAPI.Document {
+        let filteredPaths = paths.filteringPaths(with: predicate)
+        return OpenAPI.Document(
+            openAPIVersion: openAPIVersion,
+            info: info,
+            servers: servers,
+            paths: filteredPaths,
+            components: components,
+            security: security,
+            tags: tags,
+            externalDocs: externalDocs,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
+extension OpenAPI.Document {
     /// A `Route` is the combination of a path (where the route lives)
     /// and a path item (the definition of the route).
     public struct Route: Equatable {

--- a/Sources/OpenAPIKit/Either/Either.swift
+++ b/Sources/OpenAPIKit/Either/Either.swift
@@ -18,6 +18,14 @@ public enum Either<A, B> {
 	case a(A)
 	case b(B)
 
+    /// Get the first of the possible values of the `Either` (if it is
+    /// set).
+    ///
+    /// This is sometimes known as the `Left` or error case of some
+    /// `Either` types, but `OpenAPIKit` makes regular use of
+    /// this type in situations where neither of the possible values could
+    /// be considered an error. In fact, `OpenAPIKit` sticks to using
+    /// the Swift `Result` type where such semantics are needed.
 	public var a: A? {
 		guard case let .a(ret) = self else { return nil }
 		return ret
@@ -27,6 +35,8 @@ public enum Either<A, B> {
 		self = .a(a)
 	}
 
+    /// Get the second of the possible values of the `Either` (if
+    /// it is set).
 	public var b: B? {
 		guard case let .b(ret) = self else { return nil }
 		return ret

--- a/Sources/OpenAPIKit/Header/Header.swift
+++ b/Sources/OpenAPIKit/Header/Header.swift
@@ -103,9 +103,11 @@ extension OpenAPI.Header {
 
 // MARK: - Header Convenience
 extension OpenAPI.Parameter.SchemaContext {
-    public static func header(_ schema: JSONSchema,
-                              allowReserved: Bool = false,
-                              example: AnyCodable? = nil) -> Self {
+    public static func header(
+        _ schema: JSONSchema,
+        allowReserved: Bool = false,
+        example: AnyCodable? = nil
+    ) -> Self {
         return .init(
             schema,
             style: .default(for: .header),
@@ -114,9 +116,11 @@ extension OpenAPI.Parameter.SchemaContext {
         )
     }
 
-    public static func header(schemaReference: JSONReference<JSONSchema>,
-                              allowReserved: Bool = false,
-                              example: AnyCodable? = nil) -> Self {
+    public static func header(
+        schemaReference: JSONReference<JSONSchema>,
+        allowReserved: Bool = false,
+        example: AnyCodable? = nil
+    ) -> Self {
         return .init(
             schemaReference: schemaReference,
             style: .default(for: .header),
@@ -125,9 +129,11 @@ extension OpenAPI.Parameter.SchemaContext {
         )
     }
 
-    public static func header(_ schema: JSONSchema,
-                              allowReserved: Bool = false,
-                              examples: OpenAPI.Example.Map?) -> Self {
+    public static func header(
+        _ schema: JSONSchema,
+        allowReserved: Bool = false,
+        examples: OpenAPI.Example.Map?
+    ) -> Self {
         return .init(
             schema,
             style: .default(for: .header),
@@ -136,9 +142,11 @@ extension OpenAPI.Parameter.SchemaContext {
         )
     }
 
-    public static func header(schemaReference: JSONReference<JSONSchema>,
-                              allowReserved: Bool = false,
-                              examples: OpenAPI.Example.Map?) -> Self {
+    public static func header(
+        schemaReference: JSONReference<JSONSchema>,
+        allowReserved: Bool = false,
+        examples: OpenAPI.Example.Map?
+    ) -> Self {
         return .init(
             schemaReference: schemaReference,
             style: .default(for: .header),

--- a/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OpenAPIKit/OrderedDictionary/OrderedDictionary.swift
@@ -26,7 +26,10 @@ public struct OrderedDictionary<Key, Value> where Key: Hashable {
         unorderedHash = [:]
     }
 
-    public init<S>(grouping values: S, by keyForValue: (S.Element) throws -> Key) rethrows where Value == [S.Element], S : Sequence {
+    public init<S>(
+        grouping values: S,
+        by keyForValue: (S.Element) throws -> Key
+    ) rethrows where Value == [S.Element], S : Sequence {
         var temporaryDictionary = Self()
 
         for value in values {
@@ -35,7 +38,10 @@ public struct OrderedDictionary<Key, Value> where Key: Hashable {
         self = temporaryDictionary
     }
 
-    public init<S>(_ keysAndValues: S, uniquingKeysWith combine: (Value, Value) throws -> Value) rethrows where S : Sequence, S.Element == (Key, Value) {
+    public init<S>(
+        _ keysAndValues: S,
+        uniquingKeysWith combine: (Value, Value) throws -> Value
+    ) rethrows where S : Sequence, S.Element == (Key, Value) {
         var temporaryDictionary = Self()
 
         for (key, value) in keysAndValues {

--- a/Sources/OpenAPIKit/Path Item/PathItem.swift
+++ b/Sources/OpenAPIKit/Path Item/PathItem.swift
@@ -166,6 +166,13 @@ extension OpenAPI.PathItem {
     public typealias Map = OrderedDictionary<OpenAPI.Path, OpenAPI.PathItem>
 }
 
+extension OrderedDictionary where Key == OpenAPI.Path {
+    public func filteringPaths(with predicate: (OpenAPI.Path) -> Bool) -> OrderedDictionary {
+        let filteredPaths = filter { (path, _) in predicate(path) }
+        return OrderedDictionary(filteredPaths, uniquingKeysWith: { fst, _ in fst })
+    }
+}
+
 extension OpenAPI.PathItem {
     /// Retrieve the operation for the given verb, if one is set for this path.
     public func `for`(_ verb: OpenAPI.HttpMethod) -> OpenAPI.Operation? {

--- a/Sources/OpenAPIKit/Validator/Validator+Convenience.swift
+++ b/Sources/OpenAPIKit/Validator/Validator+Convenience.swift
@@ -155,7 +155,10 @@ public func take<T, U>(_ path: KeyPath<ValidationContext<T>, U>, check: @escapin
 ///         when: \.a == "hello"
 ///     )
 ///
-public func lift<T, U>(_ path: KeyPath<ValidationContext<T>, U>, into validations: Validation<U>...) -> (ValidationContext<T>) -> [ValidationError] {
+public func lift<T, U>(
+    _ path: KeyPath<ValidationContext<T>, U>,
+    into validations: Validation<U>...
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         return validations.flatMap { $0.apply(to: context[keyPath: path], at: context.codingPath, in: context.document) }
     }
@@ -184,7 +187,10 @@ public func lift<T, U>(_ path: KeyPath<ValidationContext<T>, U>, into validation
 ///         when: \.a == "hello"
 ///     )
 ///
-public func lift<T, U>(_ path: KeyPath<T, U>, into validations: Validation<U>...) -> (ValidationContext<T>) -> [ValidationError] {
+public func lift<T, U>(
+    _ path: KeyPath<T, U>,
+    into validations: Validation<U>...
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         return validations.flatMap { $0.apply(to: context.subject[keyPath: path], at: context.codingPath, in: context.document) }
     }
@@ -205,7 +211,11 @@ public func lift<T, U>(_ path: KeyPath<T, U>, into validations: Validation<U>...
 /// on what this function does when the value pointed to
 /// is non-nil.
 ///
-public func unwrap<T, U>(_ path: KeyPath<ValidationContext<T>, U?>, into validations: Validation<U>..., description: String? = nil) -> (ValidationContext<T>) -> [ValidationError] {
+public func unwrap<T, U>(
+    _ path: KeyPath<ValidationContext<T>, U?>,
+    into validations: Validation<U>...,
+    description: String? = nil
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         guard let subject = context[keyPath: path] else {
             let error = description.map { "Tried to unwrap but found nil: \($0)" }
@@ -231,7 +241,11 @@ public func unwrap<T, U>(_ path: KeyPath<ValidationContext<T>, U?>, into validat
 /// on what this function does when the value pointed to
 /// is non-nil.
 ///
-public func unwrap<T, U>(_ path: KeyPath<T, U?>, into validations: Validation<U>..., description: String? = nil) -> (ValidationContext<T>) -> [ValidationError] {
+public func unwrap<T, U>(
+    _ path: KeyPath<T, U?>,
+    into validations: Validation<U>...,
+    description: String? = nil
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         guard let subject = context.subject[keyPath: path] else {
             let error = description.map { "Tried to unwrap but found nil: \($0)" }
@@ -251,7 +265,10 @@ public func unwrap<T, U>(_ path: KeyPath<T, U?>, into validations: Validation<U>
 ///         - validations: One or more validations to perform on the value
 ///             the KeyPath points to.
 ///
-public func lookup<T, U>(_ path: KeyPath<T, Either<JSONReference<U>, U>>, thenApply validations: Validation<U>...) -> (ValidationContext<T>) -> [ValidationError] {
+public func lookup<T, U>(
+    _ path: KeyPath<T, Either<JSONReference<U>, U>>,
+    thenApply validations: Validation<U>...
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         return validations.flatMap { validation -> [ValidationError] in
             let subject = context.subject[keyPath: path]
@@ -282,7 +299,10 @@ public func lookup<T, U>(_ path: KeyPath<T, Either<JSONReference<U>, U>>, thenAp
 ///         - validations: One or more validations to perform on the value
 ///             the KeyPath points to.
 ///
-public func unwrapAndLookup<T, U>(_ path: KeyPath<T, Either<JSONReference<U>, U>?>, thenApply validations: Validation<U>...) -> (ValidationContext<T>) -> [ValidationError] {
+public func unwrapAndLookup<T, U>(
+    _ path: KeyPath<T, Either<JSONReference<U>, U>?>,
+    thenApply validations: Validation<U>...
+) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
         return validations.flatMap { validation -> [ValidationError] in
             guard let subject = context.subject[keyPath: path] else {

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -342,6 +342,24 @@ final class DocumentTests: XCTestCase {
         XCTAssertEqual(t.allServers, [s1, s2])
     }
 
+    func test_pathFiltering() {
+        let t = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/test1": .init(),
+                "/test2": .init()
+            ],
+            components: .noComponents
+        )
+
+        let t2 = t.filteringPaths(with: { $0 == "/test1" })
+
+        XCTAssertEqual(t.paths.count, 2)
+        XCTAssertEqual(t2.paths.count, 1)
+        XCTAssertNotNil(t2.paths["/test1"])
+    }
+
     func test_existingSecuritySchemeSuccess() {
         let docData =
         """

--- a/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
@@ -276,6 +276,45 @@ final class ValidationConvenienceTests: XCTestCase {
         )
     }
 
+    func test_subject_lookup() {
+        let v = Validation<OpenAPI.Parameter>(
+            description: "parameter is named test",
+            check: \.name == "test"
+        )
+
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/test": .init(
+                    parameters: [
+                        .reference(.component(named: "test1")), // passes  validation
+                        .reference(.component(named: "test2")), // wrong name
+                        .reference(.component(named: "test3")) // not found
+                    ]
+                )
+            ],
+            components: .init(
+                parameters: [
+                    "test1": .init(name: "test", context: .header, content: [:]),
+                    "test2": .init(name: "test2", context: .query, content: [:])
+                ]
+            )
+        )
+
+        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!, codingPath: [])
+
+        XCTAssertTrue(
+            lookup(\OpenAPI.PathItem.parameters[0], thenApply: v)(context).isEmpty
+        )
+        XCTAssertFalse(
+            lookup(\OpenAPI.PathItem.parameters[1], thenApply: v)(context).isEmpty
+        )
+        XCTAssertFalse(
+            lookup(\OpenAPI.PathItem.parameters[2], thenApply: v)(context).isEmpty
+        )
+    }
+
     func test_allCombinator() {
         let v1 = Validation<String>(
             description: "String is more than 5 characters",

--- a/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
@@ -304,12 +304,15 @@ final class ValidationConvenienceTests: XCTestCase {
 
         let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!, codingPath: [])
 
+        // passses
         XCTAssertTrue(
             lookup(\OpenAPI.PathItem.parameters[0], thenApply: v)(context).isEmpty
         )
+        // wrong name
         XCTAssertFalse(
             lookup(\OpenAPI.PathItem.parameters[1], thenApply: v)(context).isEmpty
         )
+        // not found reference
         XCTAssertFalse(
             lookup(\OpenAPI.PathItem.parameters[2], thenApply: v)(context).isEmpty
         )
@@ -343,15 +346,19 @@ final class ValidationConvenienceTests: XCTestCase {
 
         let context = ValidationContext<OpenAPI.Document>(document: document, subject: document, codingPath: [])
 
+        // passes
         XCTAssertTrue(
             unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[0], thenApply: v)(context).isEmpty
         )
+        // wrong name
         XCTAssertFalse(
             unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[1], thenApply: v)(context).isEmpty
         )
+        // not found reference
         XCTAssertFalse(
             unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[2], thenApply: v)(context).isEmpty
         )
+        // nil keypath
         XCTAssertFalse(
             unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.parameters.first, thenApply: v)(context).isEmpty
         )


### PR DESCRIPTION
- add `lookup()` and `unwrapAndLookup()` validation helpers.
- add `filteringPaths()` to `OpenAPI.PathItem.Map` to make it a bit easier to filter paths out and still have a path item map after you're done (instead of an array of key/value pairs).