### PR TITLE
Fix typo 'unqiue' -> 'unique'

### DIFF
--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -201,7 +201,7 @@ extension Validation {
     ///
     public static var pathItemParametersAreUnique: Validation<OpenAPI.PathItem> {
         .init(
-            description: "Path Item parameters are unqiue (identity is defined by the 'name' and 'location')",
+            description: "Path Item parameters are unique (identity is defined by the 'name' and 'location')",
             check: { parametersAreUnique($0.subject.parameters, components: $0.document.components) },
             when: \.parameters.count > 0
         )
@@ -219,7 +219,7 @@ extension Validation {
     ///
     public static var operationParametersAreUnique: Validation<OpenAPI.Operation> {
         .init(
-            description: "Operation parameters are unqiue (identity is defined by the 'name' and 'location')",
+            description: "Operation parameters are unique (identity is defined by the 'name' and 'location')",
             check: { parametersAreUnique($0.subject.parameters, components: $0.document.components) },
             when: \.parameters.count > 0
         )

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -401,7 +401,7 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         XCTAssertThrowsError(try document.validate()) { error in
             let error = error as? ValidationErrorCollection
-            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Operation parameters are unqiue (identity is defined by the 'name' and 'location')")
+            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Operation parameters are unique (identity is defined by the 'name' and 'location')")
             XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello", "get"])
             XCTAssertEqual(error?.values.first?.codingPathString, ".paths['/hello'].get")
         }
@@ -552,7 +552,7 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         XCTAssertThrowsError(try document.validate()) { error in
             let error = error as? ValidationErrorCollection
-            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Path Item parameters are unqiue (identity is defined by the 'name' and 'location')")
+            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Path Item parameters are unique (identity is defined by the 'name' and 'location')")
             XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello"])
             XCTAssertEqual(error?.values.first?.codingPathString, ".paths['/hello']")
         }


### PR DESCRIPTION
Thanks for making such a nice abstraction around OpenAPI, @mattpolzin. I'm using it to great effect for generating a [specification for the Swift registry server interface](https://github.com/mattt/swift-package-registry-oas).

I recently noticed this typo, and thought I'd send a quick patch over.