### PR TITLE
Remove FineJSON test requirement

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,18 @@ jobs:
           - swift:5.3-focal
           - swift:5.3-centos8
           - swift:5.3-amazonlinux2
+    container: ${{ matrix.image }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: swift test --enable-test-discovery
+  linux-5_4-plus:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
           - swift:5.4-xenial
           - swift:5.4-bionic
           - swift:5.4-focal
@@ -34,8 +46,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Run tests
-      run: swift test --enable-test-discovery
+    - name: Run tests (without test discovery flag)
+      run: swift test
   osx:
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   linux:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests (without test discovery flag)
-      run: swift test
+      run: swift test -Xswiftc -Xfrontend -Xswiftc -sil-verify-none
   osx:
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,11 @@ jobs:
           - swift:5.3-focal
           - swift:5.3-centos8
           - swift:5.3-amazonlinux2
-          - swiftlang/swift:nightly-5.4-focal
+          - swift:5.4-xenial
+          - swift:5.4-bionic
+          - swift:5.4-focal
+          - swift:5.4-centos8
+          - swift:5.4-amazonlinux2
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
-          "version": "4.0.4"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,30 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "FineJSON",
-        "repositoryURL": "https://github.com/omochi/FineJSON.git",
-        "state": {
-          "branch": null,
-          "revision": "05101709243cb66d80c92e645210a3b80cf4e17f",
-          "version": "1.14.0"
-        }
-      },
-      {
-        "package": "RichJSONParser",
-        "repositoryURL": "https://github.com/omochi/RichJSONParser.git",
-        "state": {
-          "branch": null,
-          "revision": "263e2ecfe88d0500fa99e4cbc8c948529d335534",
-          "version": "3.0.0"
-        }
-      },
-      {
         "package": "Yams",
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "1bce5b89a11912fb8a8c48bd404bd24979472f27",
-          "version": "4.0.3"
+          "revision": "9003d51672e516cc59297b7e96bff1dfdedcb4ea",
+          "version": "4.0.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,7 @@ let package = Package(
             targets: ["OpenAPIKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"), // just for tests
-        .package(url: "https://github.com/omochi/FineJSON.git", from: "1.14.0") // just for tests
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0") // just for tests
     ],
     targets: [
         .target(
@@ -23,7 +22,7 @@ let package = Package(
             dependencies: []),
         .testTarget(
             name: "OpenAPIKitTests",
-            dependencies: ["OpenAPIKit", "Yams", "FineJSON"]),
+            dependencies: ["OpenAPIKit", "Yams"]),
         .testTarget(
             name: "OpenAPIKitCompatibilitySuite",
             dependencies: ["OpenAPIKit", "Yams"]),
@@ -35,7 +34,7 @@ let package = Package(
             dependencies: ["OpenAPIKit"]),
         .testTarget(
             name: "OrderedDictionaryTests",
-            dependencies: ["OpenAPIKit", "Yams", "FineJSON"]),
+            dependencies: ["OpenAPIKit", "Yams"]),
         .testTarget(
             name: "AnyCodableTests",
             dependencies: ["OpenAPIKit"])

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ You can use this same validation system to dig arbitrarily deep into an OpenAPI 
 ### A note on dictionary ordering
 The **Foundation** library's `JSONEncoder` and `JSONDecoder` do not make any guarantees about the ordering of keyed containers. This means decoding a JSON OpenAPI Document and then encoding again might result in the document's various hashed structures being in a different order.
 
-If retaining order is important for your use-case, I recommend the [**Yams**](https://github.com/jpsim/Yams) and [**FineJSON**](https://github.com/omochi/FineJSON) libraries for YAML and JSON respectively.
+If retaining order is important for your use-case, I recommend the [**Yams**](https://github.com/jpsim/Yams) and [**FineJSON**](https://github.com/omochi/FineJSON) libraries for YAML and JSON respectively. Also keep in mind that JSON is entirely valid YAML and therefore you will likely get good results from Yams decoding of JSON as well (it just won't _encode_ as valid JSON). 
+
+The Foundation JSON encoding and decoding will be the most stable and battle-tested option with Yams as a pretty well established and stable option as well. FineJSON is lesser used (to my knowledge) but I have had success with it in the past.
 
 ### OpenAPI Document structure
 The types used by this library largely mirror the object definitions found in the [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) version 3.0.3. The [Project Status](#project-status) lists each object defined by the spec and the name of the respective type in this library.

--- a/Tests/OpenAPIKitTests/Operation/OperationTests.swift
+++ b/Tests/OpenAPIKitTests/Operation/OperationTests.swift
@@ -320,24 +320,17 @@ extension OperationTests {
             ]
         )
 
-        let encodedOperation = String(
-            data: try orderStableEncode(operation),
-            encoding: .utf8
-        )!
+        let encodedOperation = try orderStableYAMLEncode(operation)
 
         XCTAssertEqual(
             encodedOperation,
             """
-            {
-              "responses": {
-                "404": {
-                  "$ref": "#/components/responses/404"
-                },
-                "200": {
-                  "$ref": "#/components/responses/200"
-                }
-              }
-            }
+            responses:
+              404:
+                $ref: '#/components/responses/404'
+              200:
+                $ref: '#/components/responses/200'
+
             """
         )
 
@@ -348,24 +341,17 @@ extension OperationTests {
             ]
         )
 
-        let encodedOperation2 = String(
-            data: try orderStableEncode(operation2),
-            encoding: .utf8
-            )!
+        let encodedOperation2 = try orderStableYAMLEncode(operation2)
 
         XCTAssertEqual(
             encodedOperation2,
             """
-            {
-              "responses": {
-                "200": {
-                  "$ref": "#/components/responses/200"
-                },
-                "404": {
-                  "$ref": "#/components/responses/404"
-                }
-              }
-            }
+            responses:
+              200:
+                $ref: '#/components/responses/200'
+              404:
+                $ref: '#/components/responses/404'
+
             """
         )
     }

--- a/Tests/OpenAPIKitTests/TestHelpers.swift
+++ b/Tests/OpenAPIKitTests/TestHelpers.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import FineJSON
+import Yams
 import XCTest
 
 fileprivate let foundationTestEncoder = { () -> JSONEncoder in
@@ -32,12 +32,12 @@ func orderUnstableTestStringFromEncoding<T: Encodable>(of entity: T) throws -> S
     return String(data: try orderUnstableEncode(entity), encoding: .utf8)
 }
 
-fileprivate let fineJSONTestEncoder = { () -> FineJSONEncoder in
-    return FineJSONEncoder()
+fileprivate let yamsTestEncoder = { () -> YAMLEncoder in
+    return YAMLEncoder()
 }()
 
-func orderStableEncode<T: Encodable>(_ value: T) throws -> Data {
-    return try fineJSONTestEncoder.encode(value)
+func orderStableYAMLEncode<T: Encodable>(_ value: T) throws -> String {
+    return try yamsTestEncoder.encode(value)
 }
 
 fileprivate let foundationTestDecoder = { () -> JSONDecoder in
@@ -57,12 +57,12 @@ func orderUnstableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -
     return try foundationTestDecoder.decode(T.self, from: data)
 }
 
-fileprivate let fineJSONTestDecoder = { () -> FineJSONDecoder in
-    return FineJSONDecoder()
+fileprivate let yamsTestDecoder = { () -> YAMLDecoder in
+    return YAMLDecoder()
 }()
 
 func orderStableDecode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
-    return try fineJSONTestDecoder.decode(T.self, from: data)
+    return try yamsTestDecoder.decode(T.self, from: data)
 }
 
 func assertJSONEquivalent(_ str1: String?, _ str2: String?, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/OrderedDictionaryTests/OrderedDictionaryTests.swift
+++ b/Tests/OrderedDictionaryTests/OrderedDictionaryTests.swift
@@ -8,7 +8,6 @@
 import OpenAPIKit
 import XCTest
 import Yams
-import FineJSON
 
 final class OrderedDictionaryTests: XCTestCase {
     func test_initGrouping() {
@@ -192,18 +191,14 @@ extension OrderedDictionaryTests {
             "a": "thing"
         ]
 
-        let encodedDict = String(
-            data: try FineJSONEncoder().encode(dict),
-            encoding: .utf8
-            )!
+        let encodedDict = try YAMLEncoder().encode(dict)
 
         XCTAssertEqual(
             encodedDict,
             """
-            {
-              "hello": "world",
-              "a": "thing"
-            }
+            hello: world
+            a: thing
+
             """
         )
 
@@ -212,18 +207,14 @@ extension OrderedDictionaryTests {
             "hello": "thing"
         ]
 
-        let encodedDict2 = String(
-            data: try FineJSONEncoder().encode(dict2),
-            encoding: .utf8
-            )!
+        let encodedDict2 = try YAMLEncoder().encode(dict2)
 
         XCTAssertEqual(
             encodedDict2,
             """
-            {
-              "a": "world",
-              "hello": "thing"
-            }
+            a: world
+            hello: thing
+
             """
         )
     }
@@ -234,6 +225,7 @@ extension OrderedDictionaryTests {
         """
         hello: world
         a: thing
+
         """
 
         let dict = try YAMLDecoder().decode(OrderedDictionary<String, String>.self, from: dictString)
@@ -247,38 +239,10 @@ extension OrderedDictionaryTests {
         """
         a: world
         hello: thing
+
         """
 
         let dict2 = try YAMLDecoder().decode(OrderedDictionary<String, String>.self, from: dictString2)
-
-        XCTAssertEqual(
-            dict2,
-            ["a": "world", "hello": "thing"]
-        )
-    }
-
-    // sadly, ordering works for YAMLDecoder and FineJSONDecoder, not JSONDecoder
-    func test_stringKeyDecode2() throws {
-        let dictData =
-        """
-        {"hello": "world",
-        "a": "thing"}
-        """.data(using: .utf8)!
-
-        let dict = try FineJSONDecoder().decode(OrderedDictionary<String, String>.self, from: dictData)
-
-        XCTAssertEqual(
-            dict,
-            ["hello": "world", "a": "thing"]
-        )
-
-        let dictData2 =
-        """
-        {"a": "world",
-        "hello": "thing"}
-        """.data(using: .utf8)!
-
-        let dict2 = try FineJSONDecoder().decode(OrderedDictionary<String, String>.self, from: dictData2)
 
         XCTAssertEqual(
             dict2,
@@ -316,18 +280,14 @@ extension OrderedDictionaryTests {
             7.0: "thing"
         ]
 
-        let encodedDict2 = String(
-            data: try FineJSONEncoder().encode(dict2),
-            encoding: .utf8
-            )!
+        let encodedDict2 = try YAMLEncoder().encode(dict2)
 
         XCTAssertEqual(
             encodedDict2,
             """
-            {
-              "1.0": "world",
-              "7.0": "thing"
-            }
+            1.0: world
+            7.0: thing
+
             """
         )
 
@@ -337,18 +297,14 @@ extension OrderedDictionaryTests {
             8.5: "thing"
         ]
 
-        let encodedDict3 = String(
-            data: try FineJSONEncoder().encode(dict3),
-            encoding: .utf8
-            )!
+        let encodedDict3 = try YAMLEncoder().encode(dict3)
 
         XCTAssertEqual(
             encodedDict3,
             """
-            {
-              "100.5": "world",
-              "8.5": "thing"
-            }
+            100.5: world
+            8.5: thing
+
             """
         )
     }
@@ -382,35 +338,6 @@ extension OrderedDictionaryTests {
         )
     }
 
-    // sadly, ordering works for YAMLDecoder and FineJSONDecoder, not JSONDecoder
-    func test_doubleKeyDecode2() throws {
-        let dictData =
-        """
-        {"1.0": "world",
-        "7.0": "thing"}
-        """.data(using: .utf8)!
-
-        let dict = try FineJSONDecoder().decode(OrderedDictionary<Double, String>.self, from: dictData)
-
-        XCTAssertEqual(
-            dict,
-            [1.0: "world", 7.0: "thing"]
-        )
-
-        let dictData2 =
-        """
-        {"100.5": "world",
-        "8.5": "thing"}
-        """.data(using: .utf8)!
-
-        let dict2 = try FineJSONDecoder().decode(OrderedDictionary<Double, String>.self, from: dictData2)
-
-        XCTAssertEqual(
-            dict2,
-            [100.5: "world", 8.5: "thing"]
-        )
-    }
-
     // Sadly JSONEncoder does not retain order for Linux Foundation
     func test_intKeyEncode() throws {
         // should use lossless
@@ -419,18 +346,14 @@ extension OrderedDictionaryTests {
             2: "thing"
         ]
 
-        let encodedDict = String(
-            data: try FineJSONEncoder().encode(dict),
-            encoding: .utf8
-            )!
+        let encodedDict = try YAMLEncoder().encode(dict)
 
         XCTAssertEqual(
             encodedDict,
             """
-            {
-              "3": "world",
-              "2": "thing"
-            }
+            3: world
+            2: thing
+
             """
         )
 
@@ -439,18 +362,14 @@ extension OrderedDictionaryTests {
             3: "thing"
         ]
 
-        let encodedDict2 = String(
-            data: try FineJSONEncoder().encode(dict2),
-            encoding: .utf8
-            )!
+        let encodedDict2 = try YAMLEncoder().encode(dict2)
 
         XCTAssertEqual(
             encodedDict2,
             """
-            {
-              "2": "world",
-              "3": "thing"
-            }
+            2: world
+            3: thing
+
             """
         )
 
@@ -459,18 +378,14 @@ extension OrderedDictionaryTests {
             3: "thing"
         ]
 
-        let encodedDict3 = String(
-            data: try FineJSONEncoder().encode(dict3),
-            encoding: .utf8
-            )!
+        let encodedDict3 = try YAMLEncoder().encode(dict3)
 
         XCTAssertEqual(
             encodedDict3,
             """
-            {
-              "20": "world",
-              "3": "thing"
-            }
+            20: world
+            3: thing
+
             """
         )
     }
@@ -504,35 +419,6 @@ extension OrderedDictionaryTests {
         )
     }
 
-    // sadly, ordering works for YAMLDecoder and FineJSONDecoder, not JSONDecoder
-    func test_intKeyDecode2() throws {
-        let dictData =
-        """
-        {"1": "world",
-        "7": "thing"}
-        """.data(using: .utf8)!
-
-        let dict = try FineJSONDecoder().decode(OrderedDictionary<Int, String>.self, from: dictData)
-
-        XCTAssertEqual(
-            dict,
-            [1: "world", 7: "thing"]
-        )
-
-        let dictData2 =
-        """
-        {"100": "world",
-        "8": "thing"}
-        """.data(using: .utf8)!
-
-        let dict2 = try FineJSONDecoder().decode(OrderedDictionary<Int, String>.self, from: dictData2)
-
-        XCTAssertEqual(
-            dict2,
-            [100: "world", 8: "thing"]
-        )
-    }
-
     // Sadly JSONEncoder does not retain order for Linux Foundation
     func test_stringEnumKeyEncode() throws {
         let dict: OrderedDictionary = [
@@ -540,18 +426,14 @@ extension OrderedDictionaryTests {
             TestKey.world: "there"
         ]
 
-        let encodedDict = String(
-            data: try FineJSONEncoder().encode(dict),
-            encoding: .utf8
-            )!
+        let encodedDict = try YAMLEncoder().encode(dict)
 
         XCTAssertEqual(
             encodedDict,
             """
-            {
-              "hello": "here",
-              "world": "there"
-            }
+            hello: here
+            world: there
+
             """
         )
 
@@ -560,18 +442,14 @@ extension OrderedDictionaryTests {
             TestKey.hello: "there"
         ]
 
-        let encodedDict2 = String(
-            data: try FineJSONEncoder().encode(dict2),
-            encoding: .utf8
-            )!
+        let encodedDict2 = try YAMLEncoder().encode(dict2)
 
         XCTAssertEqual(
             encodedDict2,
             """
-            {
-              "world": "here",
-              "hello": "there"
-            }
+            world: here
+            hello: there
+
             """
         )
     }
@@ -598,35 +476,6 @@ extension OrderedDictionaryTests {
         """
 
         let dict2 = try YAMLDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictString2)
-
-        XCTAssertEqual(
-            dict2,
-            [.world: "world", .hello: "thing"]
-        )
-    }
-
-    // sadly, ordering works for YAMLDecoder and FineJSONDecoder, not JSONDecoder
-    func test_stringEnumKeyDecode2() throws {
-        let dictData =
-        """
-        {"hello": "world",
-        "world": "thing"}
-        """.data(using: .utf8)!
-
-        let dict = try FineJSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData)
-
-        XCTAssertEqual(
-            dict,
-            [.hello: "world", .world: "thing"]
-        )
-
-        let dictData2 =
-        """
-        {"world": "world",
-        "hello": "thing"}
-        """.data(using: .utf8)!
-
-        let dict2 = try FineJSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData2)
 
         XCTAssertEqual(
             dict2,
@@ -725,42 +574,6 @@ extension OrderedDictionaryTests {
         )
     }
 
-    func test_otherKeyDecodeFineJSON() throws {
-        let dictData =
-        """
-        [
-            {"x": "x"},
-            "hello",
-            {"x": "y"},
-            "there"
-        ]
-        """.data(using: .utf8)!
-
-        let dict = try FineJSONDecoder().decode(OrderedDictionary<TestKey2, String>.self, from: dictData)
-
-        XCTAssertEqual(
-            dict,
-            [TestKey2("x"): "hello", TestKey2("y"): "there"]
-        )
-
-        let dictData2 =
-        """
-        [
-            {"x": "y"},
-            "there",
-            {"x": "x"},
-            "hello"
-        ]
-        """.data(using: .utf8)!
-
-        let dict2 = try FineJSONDecoder().decode(OrderedDictionary<TestKey2, String>.self, from: dictData2)
-
-        XCTAssertEqual(
-            dict2,
-            [TestKey2("y"): "there", TestKey2("x"): "hello"]
-        )
-    }
-
     func test_failedKeyDecodeYAML() {
         let dictString =
         """
@@ -779,21 +592,6 @@ extension OrderedDictionaryTests {
 
         XCTAssertThrowsError(try JSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData))
         XCTAssertThrowsError(try JSONDecoder().decode(OrderedDictionary<TestKey3, String>.self, from: dictData))
-    }
-
-    func test_failedKeyDecodeFineJSON() {
-        let dictData =
-        """
-        [
-            {"x": "x"},
-            "hello",
-            {"x": "y"},
-            "there"
-        ]
-        """.data(using: .utf8)!
-
-        XCTAssertThrowsError(try FineJSONDecoder().decode(OrderedDictionary<TestKey, String>.self, from: dictData))
-        XCTAssertThrowsError(try FineJSONDecoder().decode(OrderedDictionary<TestKey3, String>.self, from: dictData))
     }
 }
 


### PR DESCRIPTION
- Switch to using Yams for all order-dependent test cases (which removes the second test-only dependency from the package manifest).
- Add a Swift 5.4 nightly step to CI.