### PR TITLE
update OpenAPI spec versions

### DIFF
--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -142,7 +142,7 @@ extension OpenAPI {
         public var vendorExtensions: [String: AnyCodable]
 
         public init(
-            openAPIVersion: Version = .v3_0_0,
+            openAPIVersion: Version = .v3_1_0,
             info: Info,
             servers: [Server],
             paths: PathItem.Map,
@@ -361,10 +361,7 @@ extension OpenAPI.Document {
     /// this enum. Other versions may or may not be decodable by
     /// OpenAPIKit to a certain extent.
     public enum Version: String, Codable {
-        case v3_0_0 = "3.0.0"
-        case v3_0_1 = "3.0.1"
-        case v3_0_2 = "3.0.2"
-        case v3_0_3 = "3.0.3"
+        case v3_1_0 = "3.1.0"
     }
 }
 

--- a/Tests/OpenAPIKitErrorReportingTests/ComponentErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/ComponentErrorTests.swift
@@ -15,7 +15,7 @@ final class ComponentErrorTests: XCTestCase {
     func test_badComponentKeyNames() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -38,7 +38,7 @@ final class ComponentErrorTests: XCTestCase {
     func test_badResponseBecauseOfHeaderInsideComponents() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/DocumentErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/DocumentErrorTests.swift
@@ -92,7 +92,7 @@ final class DocumentErrorTests: XCTestCase {
     func test_missingInfo() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         paths: {}
         """
 
@@ -108,7 +108,7 @@ final class DocumentErrorTests: XCTestCase {
     func test_wrongTypesInfo() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info: null
         paths: {}
         """
@@ -125,7 +125,7 @@ final class DocumentErrorTests: XCTestCase {
 
         let documentYML2 =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info: []
         paths: {}
         """
@@ -144,7 +144,7 @@ final class DocumentErrorTests: XCTestCase {
     func test_missingTitleInsideInfo() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info: {}
         paths: {}
         """
@@ -163,7 +163,7 @@ final class DocumentErrorTests: XCTestCase {
     func test_missingNameInsideSecondTag() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/JSONReferenceErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/JSONReferenceErrorTests.swift
@@ -14,7 +14,7 @@ final class JSONReferenceErrorTests: XCTestCase {
     func test_referenceFailedToParse() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -14,7 +14,7 @@ final class OperationErrorTests: XCTestCase {
     func test_missingResponses() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -39,7 +39,7 @@ final class OperationErrorTests: XCTestCase {
     func test_wrongTypeTags() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -67,7 +67,7 @@ final class OperationErrorTests: XCTestCase {
     func test_missingUrlInServer() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -101,7 +101,7 @@ extension OperationErrorTests {
     func test_missingResponseFromSSWGPitchConversation() {
         let documentYML =
         """
-        openapi: 3.0.0
+        openapi: 3.1.0
         info:
           title: API
           version: 1.0.0

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -14,7 +14,7 @@ final class PathsErrorTests: XCTestCase {
     func test_missingPaths() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -32,7 +32,7 @@ final class PathsErrorTests: XCTestCase {
     func test_wrongTypeParameter() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -58,7 +58,7 @@ final class PathsErrorTests: XCTestCase {
 
         let documentYML2 =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -86,7 +86,7 @@ final class PathsErrorTests: XCTestCase {
     func test_optionalPositionalPathParam() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -121,7 +121,7 @@ final class PathsErrorTests: XCTestCase {
     func test_noContentOrSchemaParam() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -154,7 +154,7 @@ final class PathsErrorTests: XCTestCase {
     func test_bothContentAndSchemaParam() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -193,7 +193,7 @@ final class PathsErrorTests: XCTestCase {
     func test_paramSchemaHasProblemDeeplyNestedInSchema() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestContentMapErrorTests.swift
@@ -22,7 +22,7 @@ final class RequestContentMapErrorTests: XCTestCase {
 //    func test_wrongTypeContentMapKey() {
 //        let documentYML =
 //"""
-//openapi: "3.0.0"
+//openapi: "3.1.0"
 //info:
 //    title: test
 //    version: 1.0
@@ -54,7 +54,7 @@ final class RequestContentMapErrorTests: XCTestCase {
     func test_wrongTypeContentValue() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -86,7 +86,7 @@ final class RequestContentMapErrorTests: XCTestCase {
     func test_incorrectVendorExtension() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/RequestContentSchemaErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestContentSchemaErrorTests.swift
@@ -14,7 +14,7 @@ final class RequestContentSchemaErrorTests: XCTestCase {
     func test_wrongTypeContentSchemaTypeProperty() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/RequestErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestErrorTests.swift
@@ -14,7 +14,7 @@ final class RequestErrorTests: XCTestCase {
     func test_wrongTypeRequest() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -42,7 +42,7 @@ final class RequestErrorTests: XCTestCase {
     func test_missingContentMap() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -71,7 +71,7 @@ final class RequestErrorTests: XCTestCase {
     func test_wrongTypeContentMap() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/ResponseErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/ResponseErrorTests.swift
@@ -14,7 +14,7 @@ final class ResponseErrorTests: XCTestCase {
     func test_headerWithContentAndSchema() {
         let documentYML =
         """
-        openapi: "3.0.0"
+        openapi: "3.1.0"
         info:
             title: test
             version: 1.0
@@ -62,7 +62,7 @@ final class ResponseErrorTests: XCTestCase {
 //    func test_badStatusCode() {
 //        let documentYML =
 //"""
-//openapi: "3.0.0"
+//openapi: "3.1.0"
 //info:
 //    title: test
 //    version: 1.0

--- a/Tests/OpenAPIKitErrorReportingTests/SecuritySchemeErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/SecuritySchemeErrorTests.swift
@@ -15,7 +15,7 @@ final class SecuritySchemeErrorTests: XCTestCase {
         // missing as-in not found in the Components Object
         let documentYML =
         """
-        openapi: 3.0.0
+        openapi: 3.1.0
         info:
             title: test
             version: 1.0
@@ -40,7 +40,7 @@ final class SecuritySchemeErrorTests: XCTestCase {
         // missing as-in not found in the Components Object
         let documentYML =
         """
-        openapi: 3.0.0
+        openapi: 3.1.0
         info:
             title: test
             version: 1.0

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -19,7 +19,7 @@ final class DocumentTests: XCTestCase {
         )
 
         let _ = OpenAPI.Document(
-            openAPIVersion: .v3_0_2,
+            openAPIVersion: .v3_1_0,
             info: .init(title: "hi", version: "1.0"),
             servers: [
                 .init(url: URL(string: "https://google.com")!)
@@ -447,7 +447,7 @@ extension DocumentTests {
 
     func test_specifyOpenAPIVersion_encode() throws {
         let document = OpenAPI.Document(
-            openAPIVersion: .v3_0_2,
+            openAPIVersion: .v3_1_0,
             info: .init(title: "API", version: "1.0"),
             servers: [],
             paths: [:],
@@ -491,7 +491,7 @@ extension DocumentTests {
         XCTAssertEqual(
             document,
             OpenAPI.Document(
-                openAPIVersion: .v3_0_2,
+                openAPIVersion: .v3_1_0,
                 info: .init(title: "API", version: "1.0"),
                 servers: [],
                 paths: [:],

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -364,7 +364,7 @@ final class DocumentTests: XCTestCase {
         let docData =
         """
         {
-            "openapi": "3.0.0",
+            "openapi": "3.1.0",
             "info": {
                 "title": "test",
                 "version": "1.0"
@@ -409,7 +409,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               }
@@ -426,7 +426,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           }
@@ -463,7 +463,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.2",
+              "openapi" : "3.1.0",
               "paths" : {
 
               }
@@ -539,7 +539,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           },
@@ -580,7 +580,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
                 "\\/test" : {
                   "summary" : "hi"
@@ -599,7 +599,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
             "\\/test" : {
               "summary" : "hi"
@@ -649,7 +649,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               },
@@ -682,7 +682,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           },
@@ -729,7 +729,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               },
@@ -751,7 +751,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           },
@@ -797,7 +797,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               }
@@ -817,7 +817,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           }
@@ -859,7 +859,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               },
@@ -883,7 +883,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           },
@@ -939,7 +939,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.0",
+          "openapi" : "3.1.0",
           "paths" : {
 
           },
@@ -1026,7 +1026,7 @@ extension DocumentTests {
           "title": "API",
           "version": "1.0"
         },
-        "openapi": "3.0.0",
+        "openapi": "3.1.0",
         "paths": {
         },
         "webhooks": {

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -480,7 +480,7 @@ extension DocumentTests {
             "title" : "API",
             "version" : "1.0"
           },
-          "openapi" : "3.0.2",
+          "openapi" : "3.1.0",
           "paths" : {
 
           }
@@ -517,7 +517,7 @@ extension DocumentTests {
                 "title" : "API",
                 "version" : "1.0"
               },
-              "openapi" : "3.0.0",
+              "openapi" : "3.1.0",
               "paths" : {
 
               },

--- a/Tests/OpenAPIKitTests/EaseOfUseTests.swift
+++ b/Tests/OpenAPIKitTests/EaseOfUseTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class DeclarativeEaseOfUseTests: XCTestCase {
     func test_wholeBoi() {
         let _ = OpenAPI.Document(
-            openAPIVersion: .v3_0_0,
+            openAPIVersion: .v3_1_0,
             info: .init(
                 title: "Test Documentation",
                 description: "Description of Test Documentation",
@@ -263,7 +263,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
         )
 
         let _ = OpenAPI.Document(
-            openAPIVersion: .v3_0_0,
+            openAPIVersion: .v3_1_0,
             info: apiInfo,
             servers: [server],
             paths: [
@@ -505,7 +505,7 @@ fileprivate let testInfo = OpenAPI.Document.Info(title: "Test API", version: "1.
 fileprivate let testServer = OpenAPI.Server(url: URL(string: "http://website.com")!)
 
 fileprivate let testDocument =  OpenAPI.Document(
-    openAPIVersion: .v3_0_3,
+    openAPIVersion: .v3_1_0,
     info: testInfo,
     servers: [testServer],
     paths: [

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -16,11 +16,11 @@ final class ValidatorTests: XCTestCase {
 
         _ = validator.validating(
             "",
-            check: \OpenAPI.Document.openAPIVersion == .v3_0_0
+            check: \OpenAPI.Document.openAPIVersion == .v3_1_0
         )
         _ = validator.validating(
             "",
-            check: { (context: ValidationContext<OpenAPI.Document>) in context.subject.openAPIVersion == .v3_0_0 }
+            check: { (context: ValidationContext<OpenAPI.Document>) in context.subject.openAPIVersion == .v3_1_0 }
         )
 
         _ = validator.validating(


### PR DESCRIPTION
The `Version` enum needed to be changed to disallow 3.0.x and add 3.1.0