### PR TITLE
Update GitHub Action to Test on Swift 5.5 and Higher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Run tests
       run: swift test --enable-test-discovery
-  linux-5_4-plus:
+  linux-5_4:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,12 +48,35 @@ jobs:
       uses: actions/checkout@v2
     - name: Run tests (without test discovery flag)
       run: swift test -Xswiftc -Xfrontend -Xswiftc -sil-verify-none
+  linux-5_5-plus:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - swiftlang/swift:nightly-5.5-xenial
+          - swiftlang/swift:nightly-5.5-bionic
+          - swiftlang/swift:nightly-5.5-focal
+          - swiftlang/swift:nightly-5.5-centos8
+          - swiftlang/swift:nightly-5.5-amazonlinux2
+          - swiftlang/swift:nightly-xenial
+          - swiftlang/swift:nightly-bionic
+          - swiftlang/swift:nightly-focal
+          - swiftlang/swift:nightly-centos8
+          - swiftlang/swift:nightly-amazonlinux2
+    container: ${{ matrix.image }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run tests
+      run: swift test
   osx:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@v1.2.1
-        with: { 'xcode-version': 'latest' }
+        uses: maxim-lobanov/setup-xcode@v1.2.3
+        with:
+          xcode-version: latest
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run tests


### PR DESCRIPTION
As noted in #224, OpenAPIKit fails to build on Linux using Swift 5.4.

The workaround documented in #224 to pass the `-Xswiftc -Xfrontend -Xswiftc -sil-verify-none` is gladly no longer needed for the latest nightly builds of Swift 5.5 👍
This is verified [by the GitHub Action run](https://github.com/PSchmiedmayer/OpenAPIKit/actions/runs/1163126009) documented in my fork at: https://github.com/PSchmiedmayer/OpenAPIKit .

This PR adds the corresponding builds to the Test GitHub Action to verify that behavior in the main repo. This PR therefore somehow closes #224 as a future Swift version will solve that issue. 
It also solves the issue in our Apodini and we will remove the additional flags in a corresponding PR as well: Apodini/Apodini#344