### PR TITLE
Feature/188/overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If retaining order is important for your use-case, I recommend the [**Yams**](ht
 The types used by this library largely mirror the object definitions found in the [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) version 3.0.3. The [Project Status](#project-status) lists each object defined by the spec and the name of the respective type in this library.
 
 #### Document Root
-At the root there is an `OpenAPI.Document`. In addition to some information that applies to the entire API, the document contains `OpenAPI.Components` (essentially a dictionary of reusable components that can be referenced with `JSONReferences`) and an `OpenAPI.PathItem.Map` (a dictionary of routes your API defines).
+At the root there is an `OpenAPI.Document`. In addition to some information that applies to the entire API, the document contains `OpenAPI.Components` (essentially a dictionary of reusable components that can be referenced with `JSONReferences` and `OpenAPI.References`) and an `OpenAPI.PathItem.Map` (a dictionary of routes your API defines).
 
 #### Routes
 Each route is an entry in the document's `OpenAPI.PathItem.Map`. The keys of this dictionary are the paths for each route (i.e. `/widgets`). The values of this dictionary are `OpenAPI.PathItems` which define any combination of endpoints (i.e. `GET`, `POST`, `PATCH`, etc.) that the given route supports. In addition to accessing endpoints on a path item under the name of the method (`.get`, `.post`, etc.), you can get an array of pairs matching endpoint methods to operations with the `.endpoints` method on `PathItem`.
@@ -150,6 +150,11 @@ JSONSchema.object(
 ```
 
 Take a look at the [OpenAPIKit Schema Object](./documentation/schema_object.md) documentation for more information.
+
+#### OpenAPI References
+The `OpenAPI.Reference` type represents the OpenAPI specification's reference support that is essentially just JSON Reference specification compliant but with the ability to override summaries and descriptions at the reference site where appropriate.
+
+For details on the underlying reference support, see the next section on the `JSONReference` type.
 
 #### JSON References
 The `JSONReference` type allows you to work with OpenAPIDocuments that store some of their information in the shared Components Object dictionary or even external files. Only documents where all references point to the Components Object can be dereferenced currently, but you can encode and decode all references.
@@ -203,7 +208,7 @@ You can even dereference the whole document with the `OpenAPI.Document` `locally
 
 Unlike what happens when you lookup an individual component using the `lookup()` method on `Components`, dereferencing a whole `OpenAPI.Document` will result in type-level changes that guarantee all references are removed. `OpenAPI.Document`'s `locallyDereferenced()` method returns a `DereferencedDocument` which exposes `DereferencedPathItem`s which have `DereferencedParameter`s and `DereferencedOperation`s and so on.
 
-Anywhere that a type would have had either a reference or a component, the dereferenced variety will simply have the component. For example, `PathItem` has an array of parameters, each of which is `Either<JSONReference<Parameter>, Parameter>` whereas a `DereferencedPathItem` has an array of `DereferencedParameter`s. The dereferenced variant of each type exposes all the same properties and you can get at the underlying `OpenAPI` type via an `underlying{TypeName}` property. This can make for a much more convenient way to traverse a document because you don't need to check for or look up references anywhere the OpenAPI Specification allows them.
+Anywhere that a type would have had either a reference or a component, the dereferenced variety will simply have the component. For example, `PathItem` has an array of parameters, each of which is `Either<OpenAPI.Reference<Parameter>, Parameter>` whereas a `DereferencedPathItem` has an array of `DereferencedParameter`s. The dereferenced variant of each type exposes all the same properties and you can get at the underlying `OpenAPI` type via an `underlying{TypeName}` property. This can make for a much more convenient way to traverse a document because you don't need to check for or look up references anywhere the OpenAPI Specification allows them.
 
 You can take things a step further and resolve the document. Calling `resolved()` on a `DereferencedDocument` will produce a canonical form of an `OpenAPI.Document`. The `ResolvedRoute`s and `ResolvedEndpoint`s that the `ResolvedDocument` exposes collect all relevant information from the whole document into themselves. For example, a `ResolvedEndpoint` knows what servers it can be used on, what path it is located at, and which parameters it supports (even if some of those parameters were defined in an `OpenAPI.Operation` and others were defined in the containing `OpenAPI.PathItem`).
 

--- a/Sources/OpenAPIKit/Callbacks.swift
+++ b/Sources/OpenAPIKit/Callbacks.swift
@@ -55,10 +55,10 @@ extension OpenAPI {
     ///
     /// See [OpenAPI Callback Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#callback-object).
     ///
-    public typealias Callbacks = OrderedDictionary<CallbackURL, Either<JSONReference<PathItem>, PathItem>>
+    public typealias Callbacks = OrderedDictionary<CallbackURL, Either<OpenAPI.Reference<PathItem>, PathItem>>
 
     /// A map of named collections of Callback Objects (`OpenAPI.Callbacks`).
-    public typealias CallbacksMap = OrderedDictionary<String, Either<JSONReference<Callbacks>, Callbacks>>
+    public typealias CallbacksMap = OrderedDictionary<String, Either<OpenAPI.Reference<Callbacks>, Callbacks>>
 }
 
 extension OpenAPI.CallbackURL: Encodable {

--- a/Sources/OpenAPIKit/Callbacks.swift
+++ b/Sources/OpenAPIKit/Callbacks.swift
@@ -1,5 +1,5 @@
 //
-//  Callback.swift
+//  Callbacks.swift
 //  
 //
 //  Created by Mathew Polzin on 11/1/20.

--- a/Sources/OpenAPIKit/Components Object/Components+JSONReference.swift
+++ b/Sources/OpenAPIKit/Components Object/Components+JSONReference.swift
@@ -100,6 +100,10 @@ extension OpenAPI.Components {
     /// of just looking it up see the various `dereference` functions
     /// on this type for more information.
     ///
+    /// If the `OpenAPI.Reference` has a `summary` or `description` then the referenced
+    /// object will have its `summary` and/or `description` overridden by that of the reference.
+    /// This only applies if the referenced object would normally have a summary/description.
+    ///
     /// - Important: Looking up an external reference (i.e. one that points to another file)
     ///     is not currently supported by OpenAPIKit and will therefore always throw an error.
     ///

--- a/Sources/OpenAPIKit/Components Object/Components+JSONReference.swift
+++ b/Sources/OpenAPIKit/Components Object/Components+JSONReference.swift
@@ -114,6 +114,8 @@ extension OpenAPI.Components {
     public func lookup<ReferenceType: ComponentDictionaryLocatable>(_ reference: OpenAPI.Reference<ReferenceType>) throws -> ReferenceType {
 
         return try lookup(reference.jsonReference)
+            .overriddenNonNil(summary: reference.summary)
+            .overriddenNonNil(description: reference.description)
     }
 
     /// Pass a reference to a component.

--- a/Sources/OpenAPIKit/Components Object/Components+Locatable.swift
+++ b/Sources/OpenAPIKit/Components Object/Components+Locatable.swift
@@ -64,7 +64,7 @@ extension OpenAPI.PathItem: ComponentDictionaryLocatable {
 }
 
 /// A dereferenceable type can be recursively looked up in
-/// the `OpenAPI.Components` until there are no `JSONReferences`
+/// the `OpenAPI.Components` until there are no `OpenAPI.References`
 /// left in it or any of its properties.
 public protocol LocallyDereferenceable {
     associatedtype DereferencedSelf

--- a/Sources/OpenAPIKit/Components Object/Components+Locatable.swift
+++ b/Sources/OpenAPIKit/Components Object/Components+Locatable.swift
@@ -9,7 +9,7 @@ import OpenAPIKitCore
 
 /// Anything conforming to ComponentDictionaryLocatable knows
 /// where to find resources of its type in the Components Dictionary.
-public protocol ComponentDictionaryLocatable {
+public protocol ComponentDictionaryLocatable: SummaryOverridable {
     /// The JSON Reference path of this type.
     ///
     /// This can be used to create a JSON path
@@ -28,7 +28,7 @@ extension OpenAPI.Response: ComponentDictionaryLocatable {
     public static var openAPIComponentsKeyPath: KeyPath<OpenAPI.Components, OpenAPI.ComponentDictionary<Self>> { \.responses }
 }
 
-extension OpenAPI.Callbacks: ComponentDictionaryLocatable {
+extension OpenAPI.Callbacks: ComponentDictionaryLocatable & SummaryOverridable {
     public static var openAPIComponentsKey: String { "callbacks" }
     public static var openAPIComponentsKeyPath: KeyPath<OpenAPI.Components, OpenAPI.ComponentDictionary<Self>> { \.callbacks }
 }

--- a/Sources/OpenAPIKit/Content/Content.swift
+++ b/Sources/OpenAPIKit/Content/Content.swift
@@ -12,7 +12,7 @@ extension OpenAPI {
     /// 
     /// See [OpenAPI Media Type Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#media-type-object).
     public struct Content: Equatable, CodableVendorExtendable {
-        public var schema: Either<JSONReference<JSONSchema>, JSONSchema>?
+        public var schema: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>?
         public var example: AnyCodable?
         public var examples: Example.Map?
         public var encoding: OrderedDictionary<String, Encoding>?
@@ -27,7 +27,7 @@ extension OpenAPI {
         /// Create `Content` with a schema, a reference to a schema, or no
         /// schema at all and optionally provide a single example.
         public init(
-            schema: Either<JSONReference<JSONSchema>, JSONSchema>?,
+            schema: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>?,
             example: AnyCodable? = nil,
             encoding: OrderedDictionary<String, Encoding>? = nil,
             vendorExtensions: [String: AnyCodable] = [:]
@@ -42,7 +42,7 @@ extension OpenAPI {
         /// Create `Content` with a reference to a schema and optionally
         /// provide a single example.
         public init(
-            schemaReference: JSONReference<JSONSchema>,
+            schemaReference: OpenAPI.Reference<JSONSchema>,
             example: AnyCodable? = nil,
             encoding: OrderedDictionary<String, Encoding>? = nil,
             vendorExtensions: [String: AnyCodable] = [:]
@@ -72,7 +72,7 @@ extension OpenAPI {
         /// Create `Content` with a schema, a reference to a schema, or no
         /// schema at all and optionally provide a map of examples.
         public init(
-            schema: Either<JSONReference<JSONSchema>, JSONSchema>?,
+            schema: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>?,
             examples: Example.Map?,
             encoding: OrderedDictionary<String, Encoding>? = nil,
             vendorExtensions: [String: AnyCodable] = [:]
@@ -87,7 +87,7 @@ extension OpenAPI {
         /// Create `Content` with a reference to a schema and optionally
         /// provide a map of examples.
         public init(
-            schemaReference: JSONReference<JSONSchema>,
+            schemaReference: OpenAPI.Reference<JSONSchema>,
             examples: Example.Map?,
             encoding: OrderedDictionary<String, Encoding>? = nil,
             vendorExtensions: [String: AnyCodable] = [:]
@@ -177,7 +177,7 @@ extension OpenAPI.Content: Decodable {
             )
         }
 
-        schema = try container.decodeIfPresent(Either<JSONReference<JSONSchema>, JSONSchema>.self, forKey: .schema)
+        schema = try container.decodeIfPresent(Either<OpenAPI.Reference<JSONSchema>, JSONSchema>.self, forKey: .schema)
 
         encoding = try container.decodeIfPresent(OrderedDictionary<String, Encoding>.self, forKey: .encoding)
 

--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -82,7 +82,7 @@ extension OpenAPI {
         public var paths: PathItem.Map
 
         /// Storage for components that need to be referenced elsewhere in the
-        /// OpenAPI Document using `JSONReferences`.
+        /// OpenAPI Document using `OpenAPI.References`.
         ///
         /// Storing components here can be in the interest of being explicit about
         /// the fact that the components are always the same (such as an
@@ -101,7 +101,7 @@ extension OpenAPI {
         /// Closely related to the callbacks feature, this section describes requests initiated other than by an API call, for example by an out of band registration.
         /// The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses
         /// See [OpenAPI Webhook Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#fixed-fields)
-        public var webhooks: OrderedDictionary<String, Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>>
+        public var webhooks: OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>>
         
         /// A declaration of which security mechanisms can be used across the API.
         ///
@@ -146,7 +146,7 @@ extension OpenAPI {
             info: Info,
             servers: [Server],
             paths: PathItem.Map,
-            webhooks: OrderedDictionary<String, Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>> = [:],
+            webhooks: OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>> = [:],
             components: Components,
             security: [SecurityRequirement] = [],
             tags: [Tag]? = nil,
@@ -317,7 +317,7 @@ extension OpenAPI.Document {
     /// Document.
     ///
     /// A dereferenced document contains no
-    /// `JSONReferences`. All components have been
+    /// `OpenAPI.References`. All components have been
     /// inlined.
     ///
     /// Dereferencing the document is a necessary
@@ -326,7 +326,7 @@ extension OpenAPI.Document {
     /// endpoints.
     ///
     /// - Important: Local dereferencing will `throw` if any
-    ///     `JSONReferences` point to other files or to
+    ///     `OpenAPI.References` point to other files or to
     ///     locations within the same file other than the
     ///     Components Object. It will also fail if any components
     ///     are missing from the Components Object.
@@ -414,7 +414,7 @@ extension OpenAPI.Document: Decodable {
             let components = try container.decodeIfPresent(OpenAPI.Components.self, forKey: .components) ?? .noComponents
             self.components = components
           
-            let webhooks = try container.decodeIfPresent(OrderedDictionary<String, Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>>.self, forKey: .webhooks) ?? [:]
+            let webhooks = try container.decodeIfPresent(OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>>.self, forKey: .webhooks) ?? [:]
             self.webhooks = webhooks
 
             let paths = try container.decode(OpenAPI.PathItem.Map.self, forKey: .paths)

--- a/Sources/OpenAPIKit/Document/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/Document/DocumentInfo.swift
@@ -147,7 +147,7 @@ extension OpenAPI.Document.Info.License {
 
 // MARK: - Describable & Summarizable
 extension OpenAPI.Document.Info : OpenAPISummarizable {
-    func overriddenNonNil(summary: String?) -> OpenAPI.Document.Info {
+    public func overriddenNonNil(summary: String?) -> OpenAPI.Document.Info {
         guard let summary = summary else { return self }
         return OpenAPI.Document.Info(
             title: title,
@@ -161,7 +161,7 @@ extension OpenAPI.Document.Info : OpenAPISummarizable {
         )
     }
 
-    func overriddenNonNil(description: String?) -> OpenAPI.Document.Info {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Document.Info {
         guard let description = description else { return self }
         return OpenAPI.Document.Info(
             title: title,

--- a/Sources/OpenAPIKit/Document/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/Document/DocumentInfo.swift
@@ -145,6 +145,37 @@ extension OpenAPI.Document.Info.License {
     }
 }
 
+// MARK: - Describable & Summarizable
+extension OpenAPI.Document.Info : OpenAPISummarizable {
+    func overriddenNonNil(summary: String?) -> OpenAPI.Document.Info {
+        guard let summary = summary else { return self }
+        return OpenAPI.Document.Info(
+            title: title,
+            summary: summary,
+            description: description,
+            termsOfService: termsOfService,
+            contact: contact,
+            license: license,
+            version: version,
+            vendorExtensions: vendorExtensions
+        )
+    }
+
+    func overriddenNonNil(description: String?) -> OpenAPI.Document.Info {
+        guard let description = description else { return self }
+        return OpenAPI.Document.Info(
+            title: title,
+            summary: summary,
+            description: description,
+            termsOfService: termsOfService,
+            contact: contact,
+            license: license,
+            version: version,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Codable
 extension OpenAPI.Document.Info.License: Encodable {
     public func encode(to encoder: Encoder) throws {

--- a/Sources/OpenAPIKit/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit/Either/Either+Convenience.swift
@@ -32,7 +32,7 @@ extension Either where A == OpenAPI.Parameter.SchemaContext {
 
     /// Retrieve the schema value if this property contains a schema context.
     ///
-    /// If the schema is a `JSONReference` this property will be `nil`
+    /// If the schema is a `OpenAPI.Reference` this property will be `nil`
     /// but the `schemaReference` property will be `non-nil`.
     public var schemaValue: JSONSchema? {
         guard case .a(let schemaContext) = self else {
@@ -45,7 +45,7 @@ extension Either where A == OpenAPI.Parameter.SchemaContext {
     ///
     /// If the schema is a `JSONSchema` this property will be `nil` but the
     /// `schemaValue` property will be `non-nil`.
-    public var schemaReference: JSONReference<JSONSchema>? {
+    public var schemaReference: OpenAPI.Reference<JSONSchema>? {
         guard case .a(let schemaContext) = self else {
             return nil
         }
@@ -61,7 +61,7 @@ extension Either where A == DereferencedSchemaContext {
 
     /// Retrieve the schema value if this property contains a schema context.
     ///
-    /// If the schema is a `JSONReference` this property will be `nil`
+    /// If the schema is an `OpenAPI.Reference` this property will be `nil`
     /// but the `schemaReference` property will be `non-nil`.
     public var schemaValue: DereferencedJSONSchema? {
         guard case .a(let schemaContext) = self else {

--- a/Sources/OpenAPIKit/Either/Either+Summarizable.swift
+++ b/Sources/OpenAPIKit/Either/Either+Summarizable.swift
@@ -1,0 +1,10 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mathew Polzin on 8/28/21.
+//
+
+import OpenAPIKitCore
+
+//extension Either: OpenAPISummarizable

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -67,7 +67,7 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Example>, B == OpenAPI.Exa
 // MARK: - Describable & Summarizable
 
 extension OpenAPI.Example : OpenAPISummarizable {
-    func overriddenNonNil(summary: String?) -> OpenAPI.Example {
+    public func overriddenNonNil(summary: String?) -> OpenAPI.Example {
         guard let summary = summary else { return self }
         return OpenAPI.Example(
             summary: summary,
@@ -77,7 +77,7 @@ extension OpenAPI.Example : OpenAPISummarizable {
         )
     }
 
-    func overriddenNonNil(description: String?) -> OpenAPI.Example {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Example {
         guard let description = description else { return self }
         return OpenAPI.Example(
             summary: summary,

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -41,11 +41,11 @@ extension OpenAPI {
 }
 
 extension OpenAPI.Example {
-    public typealias Map = OrderedDictionary<String, Either<JSONReference<OpenAPI.Example>, OpenAPI.Example>>
+    public typealias Map = OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.Example>, OpenAPI.Example>>
 }
 
 // MARK: - Either Convenience
-extension Either where A == JSONReference<OpenAPI.Example>, B == OpenAPI.Example {
+extension Either where A == OpenAPI.Reference<OpenAPI.Example>, B == OpenAPI.Example {
     /// Construct an `Example`.
     public static func example(
         summary: String? = nil,

--- a/Sources/OpenAPIKit/Example.swift
+++ b/Sources/OpenAPIKit/Example.swift
@@ -64,6 +64,30 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Example>, B == OpenAPI.Exa
     }
 }
 
+// MARK: - Describable & Summarizable
+
+extension OpenAPI.Example : OpenAPISummarizable {
+    func overriddenNonNil(summary: String?) -> OpenAPI.Example {
+        guard let summary = summary else { return self }
+        return OpenAPI.Example(
+            summary: summary,
+            description: description,
+            value: value,
+            vendorExtensions: vendorExtensions
+        )
+    }
+
+    func overriddenNonNil(description: String?) -> OpenAPI.Example {
+        guard let description = description else { return self }
+        return OpenAPI.Example(
+            summary: summary,
+            description: description,
+            value: value,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Codable
 extension OpenAPI.Example: Encodable {
     public func encode(to encoder: Encoder) throws {

--- a/Sources/OpenAPIKit/ExternalDocumentation.swift
+++ b/Sources/OpenAPIKit/ExternalDocumentation.swift
@@ -38,7 +38,7 @@ extension OpenAPI {
 // MARK: - Describable
 
 extension OpenAPI.ExternalDocumentation : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.ExternalDocumentation {
+    public func overriddenNonNil(description: String?) -> OpenAPI.ExternalDocumentation {
         guard let description = description else { return self }
         return OpenAPI.ExternalDocumentation(
             description: description,

--- a/Sources/OpenAPIKit/ExternalDocumentation.swift
+++ b/Sources/OpenAPIKit/ExternalDocumentation.swift
@@ -35,6 +35,19 @@ extension OpenAPI {
     }
 }
 
+// MARK: - Describable
+
+extension OpenAPI.ExternalDocumentation : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.ExternalDocumentation {
+        guard let description = description else { return self }
+        return OpenAPI.ExternalDocumentation(
+            description: description,
+            url: url,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.ExternalDocumentation: Encodable {

--- a/Sources/OpenAPIKit/Header/Header.swift
+++ b/Sources/OpenAPIKit/Header/Header.swift
@@ -70,7 +70,7 @@ extension OpenAPI {
         }
 
         public init(
-            schemaReference: JSONReference<JSONSchema>,
+            schemaReference: OpenAPI.Reference<JSONSchema>,
             description: String? = nil,
             required: Bool = false,
             deprecated: Bool = false,
@@ -100,7 +100,7 @@ extension OpenAPI {
 }
 
 extension OpenAPI.Header {
-    public typealias Map = OrderedDictionary<String, Either<JSONReference<OpenAPI.Header>, OpenAPI.Header>>
+    public typealias Map = OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>>
 }
 
 // MARK: - Header Convenience
@@ -119,7 +119,7 @@ extension OpenAPI.Parameter.SchemaContext {
     }
 
     public static func header(
-        schemaReference: JSONReference<JSONSchema>,
+        schemaReference: OpenAPI.Reference<JSONSchema>,
         allowReserved: Bool = false,
         example: AnyCodable? = nil
     ) -> Self {
@@ -145,7 +145,7 @@ extension OpenAPI.Parameter.SchemaContext {
     }
 
     public static func header(
-        schemaReference: JSONReference<JSONSchema>,
+        schemaReference: OpenAPI.Reference<JSONSchema>,
         allowReserved: Bool = false,
         examples: OpenAPI.Example.Map?
     ) -> Self {

--- a/Sources/OpenAPIKit/Header/Header.swift
+++ b/Sources/OpenAPIKit/Header/Header.swift
@@ -105,7 +105,7 @@ extension OpenAPI.Header {
 
 // MARK: - Describable
 extension OpenAPI.Header : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Header {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Header {
         guard let description = description else { return self }
         return OpenAPI.Header(
             schemaOrContent: schemaOrContent,

--- a/Sources/OpenAPIKit/Header/Header.swift
+++ b/Sources/OpenAPIKit/Header/Header.swift
@@ -103,6 +103,20 @@ extension OpenAPI.Header {
     public typealias Map = OrderedDictionary<String, Either<OpenAPI.Reference<OpenAPI.Header>, OpenAPI.Header>>
 }
 
+// MARK: - Describable
+extension OpenAPI.Header : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Header {
+        guard let description = description else { return self }
+        return OpenAPI.Header(
+            schemaOrContent: schemaOrContent,
+            description: description,
+            required: required,
+            deprecated: deprecated,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Header Convenience
 extension OpenAPI.Parameter.SchemaContext {
     public static func header(

--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -339,8 +339,8 @@ extension OpenAPI {
         ///     OpenAPI.Reference<JSONSchema>.component(named: "greetings")
         ///     // encoded string: "#/components/schemas/greetings"
         ///     // Swift: `document.components.schemas["greetings"]`
-        public static func component(named name: String) -> Self {
-            return .init(.internal(.component(name: name)))
+        public static func component(named name: String, summary: String? = nil, description: String? = nil) -> Self {
+            return .init(.internal(.component(name: name)), summary: summary, description: description)
         }
 
         /// Reference a path internal to this file but not within the Components Object
@@ -348,8 +348,8 @@ extension OpenAPI {
         /// in the Components Object.
         ///
         /// - Important: The path does not contain a leading '#'. Start with the root '/'.
-        public static func `internal`(path: JSONReference<ReferenceType>.Path) -> Self {
-            return .init(.internal(.path(path)))
+        public static func `internal`(path: JSONReference<ReferenceType>.Path, summary: String? = nil, description: String? = nil) -> Self {
+            return .init(.internal(.path(path)), summary: summary, description: description)
         }
 
         /// Reference an external URL.
@@ -383,6 +383,14 @@ extension OpenAPI {
             return jsonReference.absoluteString
         }
     }
+}
+
+internal protocol OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> Self
+}
+
+internal protocol OpenAPISummarizable: OpenAPIDescribable {
+    func overriddenNonNil(summary: String?) -> Self
 }
 
 // MARK: - Codable

--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -318,6 +318,58 @@ extension OpenAPI {
         public subscript<T>(dynamicMember path: KeyPath<JSONReference<ReferenceType>, T>) -> T {
             return jsonReference[keyPath: path]
         }
+
+        /// Reference a component of type `ReferenceType` in the
+        /// Components Object.
+        ///
+        /// Example:
+        ///
+        ///     OpenAPI.Reference<JSONSchema>.component(named: "greetings")
+        ///     // encoded string: "#/components/schemas/greetings"
+        ///     // Swift: `document.components.schemas["greetings"]`
+        public static func component(named name: String) -> Self {
+            return .init(.internal(.component(name: name)))
+        }
+
+        /// Reference a path internal to this file but not within the Components Object
+        /// This is likely not what you are looking for. It is advisable to store reusable components
+        /// in the Components Object.
+        ///
+        /// - Important: The path does not contain a leading '#'. Start with the root '/'.
+        public static func `internal`(path: JSONReference<ReferenceType>.Path) -> Self {
+            return .init(.internal(.path(path)))
+        }
+
+        /// Reference an external URL.
+        public static func external(_ url: URL) -> Self {
+            return .init(.external(url))
+        }
+
+        /// `true` for internal references, `false` for
+        /// external references (i.e. to another file).
+        public var isInternal: Bool {
+            return jsonReference.isInternal
+        }
+
+        /// `true` for external references, `false` for
+        /// internal references.
+        public var isExternal: Bool {
+            return jsonReference.isExternal
+        }
+
+        /// Get the name of the referenced object. This method returns optional
+        /// because a reference to an external file might not have any path if the
+        /// file itself is the referenced component.
+        public var name: String? {
+            return jsonReference.name
+        }
+
+        /// The absolute value of an external reference's
+        /// URL or the path fragment string for a local
+        /// reference as defined in [RFC 3986](https://tools.ietf.org/html/rfc3986).
+        public var absoluteString: String {
+            return jsonReference.absoluteString
+        }
     }
 }
 

--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -385,11 +385,26 @@ extension OpenAPI {
     }
 }
 
-internal protocol OpenAPIDescribable {
+public protocol SummaryOverridable {
+    func overriddenNonNil(description: String?) -> Self
+    func overriddenNonNil(summary: String?) -> Self
+}
+
+public extension SummaryOverridable {
+    func overriddenNonNil(summary: String?) -> Self {
+        self
+    }
+
+    func overriddenNonNil(description: String?) -> Self {
+        self
+    }
+}
+
+public protocol OpenAPIDescribable: SummaryOverridable {
     func overriddenNonNil(description: String?) -> Self
 }
 
-internal protocol OpenAPISummarizable: OpenAPIDescribable {
+public protocol OpenAPISummarizable: OpenAPIDescribable {
     func overriddenNonNil(summary: String?) -> Self
 }
 

--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -73,11 +73,23 @@ public enum JSONReference<ReferenceType: ComponentDictionaryLocatable>: Equatabl
         return true
     }
 
+    /// Get the internal value if this reference is internal. Otherwise, nil.
+    public var internalValue: InternalReference? {
+        guard case let .internal(value) = self else { return nil }
+        return value
+    }
+
     /// `true` for external references, `false` for
     /// internal references.
     public var isExternal: Bool {
         guard case .external = self else { return false }
         return true
+    }
+
+    /// Get the external value if this reference is external. Otherwise, nil.
+    public var externalValue: URL? {
+        guard case let .external(value) = self else { return nil }
+        return value
     }
 
     /// Get the name of the referenced object. This method returns optional

--- a/Sources/OpenAPIKit/Operation/Operation.swift
+++ b/Sources/OpenAPIKit/Operation/Operation.swift
@@ -237,6 +237,24 @@ extension OpenAPI.Operation {
     }
 }
 
+// MARK: - Describable & Summarizable
+
+extension OpenAPI.Operation : OpenAPISummarizable {
+    func overriddenNonNil(summary: String?) -> OpenAPI.Operation {
+        guard let summary = summary else { return self }
+        var operation = self
+        operation.summary = summary
+        return operation
+    }
+
+    func overriddenNonNil(description: String?) -> OpenAPI.Operation {
+        guard let description = description else { return self }
+        var operation = self
+        operation.description = description
+        return operation
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Operation: Encodable {

--- a/Sources/OpenAPIKit/Operation/Operation.swift
+++ b/Sources/OpenAPIKit/Operation/Operation.swift
@@ -27,7 +27,7 @@ extension OpenAPI {
         /// `document.components` to resolve one of these entries to
         /// an `OpenAPI.Parameter`.
         public var parameters: Parameter.Array
-        public var requestBody: Either<JSONReference<OpenAPI.Request>, OpenAPI.Request>?
+        public var requestBody: Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>?
 
         /// The possible responses for this operation, keyed by status code.
         ///
@@ -42,15 +42,15 @@ extension OpenAPI {
         ///
         /// **Example:**
         ///
-        ///     let firstResponse: (OpenAPI.Response.StatusCode, Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>)
+        ///     let firstResponse: (OpenAPI.Response.StatusCode, Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>)
         ///     firstResponse = operation.responses[0]!
         ///
         ///     // literally documented as "200" status code:
-        ///     let successResponse: Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>
+        ///     let successResponse: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>
         ///     successResponse = operation.responses[status: 200]!
         ///
         ///     // documented as "2XX" status code:
-        ///     let successResponse2: Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>
+        ///     let successResponse2: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>
         ///     successResponse2 = operation.responses[.range(.success)]!
         ///
         /// If you want to access the response (assuming it is inlined) you need to grab
@@ -112,7 +112,7 @@ extension OpenAPI {
 
         // allowing Request Body reference
         /// Create an Operation with a request body specified by an
-        /// `Either<JSONReference<OpenAPI.Request>, OpenAPI.Request>`.
+        /// `Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>`.
         public init(
             tags: [String]? = nil,
             summary: String? = nil,
@@ -120,7 +120,7 @@ extension OpenAPI {
             externalDocs: OpenAPI.ExternalDocumentation? = nil,
             operationId: String? = nil,
             parameters: Parameter.Array = [],
-            requestBody: Either<JSONReference<OpenAPI.Request>, OpenAPI.Request>,
+            requestBody: Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>,
             responses: OpenAPI.Response.Map,
             callbacks: OpenAPI.CallbacksMap = [:],
             deprecated: Bool = false,
@@ -217,11 +217,11 @@ extension OpenAPI.Operation {
     /// status code and a response.
     public struct ResponseOutcome: Equatable {
         public let status: OpenAPI.Response.StatusCode
-        public let response: Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>
+        public let response: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>
 
         public init(
             status: OpenAPI.Response.StatusCode,
-            response: Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>
+            response: Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>
         ) {
             self.status = status
             self.response = response
@@ -292,7 +292,7 @@ extension OpenAPI.Operation: Decodable {
 
             parameters = try container.decodeIfPresent(OpenAPI.Parameter.Array.self, forKey: .parameters) ?? []
 
-            requestBody = try container.decodeIfPresent(Either<JSONReference<OpenAPI.Request>, OpenAPI.Request>.self, forKey: .requestBody)
+            requestBody = try container.decodeIfPresent(Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>.self, forKey: .requestBody)
 
             responses = try container.decode(OpenAPI.Response.Map.self, forKey: .responses)
 

--- a/Sources/OpenAPIKit/Operation/Operation.swift
+++ b/Sources/OpenAPIKit/Operation/Operation.swift
@@ -240,14 +240,14 @@ extension OpenAPI.Operation {
 // MARK: - Describable & Summarizable
 
 extension OpenAPI.Operation : OpenAPISummarizable {
-    func overriddenNonNil(summary: String?) -> OpenAPI.Operation {
+    public func overriddenNonNil(summary: String?) -> OpenAPI.Operation {
         guard let summary = summary else { return self }
         var operation = self
         operation.summary = summary
         return operation
     }
 
-    func overriddenNonNil(description: String?) -> OpenAPI.Operation {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Operation {
         guard let description = description else { return self }
         var operation = self
         operation.description = description

--- a/Sources/OpenAPIKit/Parameter/Parameter.swift
+++ b/Sources/OpenAPIKit/Parameter/Parameter.swift
@@ -211,6 +211,17 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Parameter>, B == OpenAPI.P
     }
 }
 
+// MARK: - Describable
+
+extension OpenAPI.Parameter : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Parameter {
+        guard let description = description else { return self }
+        var parameter = self
+        parameter.description = description
+        return parameter
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Parameter: Encodable {

--- a/Sources/OpenAPIKit/Parameter/Parameter.swift
+++ b/Sources/OpenAPIKit/Parameter/Parameter.swift
@@ -214,7 +214,7 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Parameter>, B == OpenAPI.P
 // MARK: - Describable
 
 extension OpenAPI.Parameter : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Parameter {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Parameter {
         guard let description = description else { return self }
         var parameter = self
         parameter.description = description

--- a/Sources/OpenAPIKit/Parameter/Parameter.swift
+++ b/Sources/OpenAPIKit/Parameter/Parameter.swift
@@ -110,7 +110,7 @@ extension OpenAPI {
         public init(
             name: String,
             context: Context,
-            schemaReference: JSONReference<JSONSchema>,
+            schemaReference: OpenAPI.Reference<JSONSchema>,
             description: String? = nil,
             deprecated: Bool = false,
             vendorExtensions: [String: AnyCodable] = [:]
@@ -149,7 +149,7 @@ extension OpenAPI.Parameter {
     /// methods on the `OpenAPI.Components` found at
     /// `document.components` to resolve an `Either` to
     /// an `OpenAPI.Parameter`.
-    public typealias Array = [Either<JSONReference<OpenAPI.Parameter>, OpenAPI.Parameter>]
+    public typealias Array = [Either<OpenAPI.Reference<OpenAPI.Parameter>, OpenAPI.Parameter>]
 }
 
 extension OpenAPI.Parameter {
@@ -166,7 +166,7 @@ extension OpenAPI.Parameter {
 
 // MARK: `Either` convenience methods
 // OpenAPI.PathItem.Array.Element =>
-extension Either where A == JSONReference<OpenAPI.Parameter>, B == OpenAPI.Parameter {
+extension Either where A == OpenAPI.Reference<OpenAPI.Parameter>, B == OpenAPI.Parameter {
 
     /// Construct a parameter using a `JSONSchema`.
     public static func parameter(

--- a/Sources/OpenAPIKit/Parameter/ParameterSchemaContext.swift
+++ b/Sources/OpenAPIKit/Parameter/ParameterSchemaContext.swift
@@ -16,7 +16,7 @@ extension OpenAPI.Parameter {
         public let style: Style
         public let explode: Bool
         public let allowReserved: Bool //defaults to false
-        public let schema: Either<JSONReference<JSONSchema>, JSONSchema>
+        public let schema: Either<OpenAPI.Reference<JSONSchema>, JSONSchema>
 
         public let example: AnyCodable?
         public let examples: OpenAPI.Example.Map?
@@ -47,7 +47,7 @@ extension OpenAPI.Parameter {
             self.explode = style.defaultExplode
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
+        public init(schemaReference: OpenAPI.Reference<JSONSchema>,
                     style: Style,
                     explode: Bool,
                     allowReserved: Bool = false,
@@ -60,7 +60,7 @@ extension OpenAPI.Parameter {
             self.examples = nil
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
+        public init(schemaReference: OpenAPI.Reference<JSONSchema>,
                     style: Style,
                     allowReserved: Bool = false,
                     example: AnyCodable? = nil) {
@@ -99,7 +99,7 @@ extension OpenAPI.Parameter {
             self.explode = style.defaultExplode
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
+        public init(schemaReference: OpenAPI.Reference<JSONSchema>,
                     style: Style,
                     explode: Bool,
                     allowReserved: Bool = false,
@@ -112,7 +112,7 @@ extension OpenAPI.Parameter {
             self.example = examples.flatMap(OpenAPI.Content.firstExample(from:))
         }
 
-        public init(schemaReference: JSONReference<JSONSchema>,
+        public init(schemaReference: OpenAPI.Reference<JSONSchema>,
                     style: Style,
                     allowReserved: Bool = false,
                     examples: OpenAPI.Example.Map?) {
@@ -124,7 +124,6 @@ extension OpenAPI.Parameter {
 
             self.explode = style.defaultExplode
         }
-
     }
 }
 
@@ -211,7 +210,7 @@ extension OpenAPI.Parameter.SchemaContext {
     public init(from decoder: Decoder, for location: OpenAPI.Parameter.Context) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        schema = try container.decode(Either<JSONReference<JSONSchema>, JSONSchema>.self, forKey: .schema)
+        schema = try container.decode(Either<OpenAPI.Reference<JSONSchema>, JSONSchema>.self, forKey: .schema)
 
         let style = try container.decodeIfPresent(Style.self, forKey: .style) ?? Style.default(for: location)
         self.style = style

--- a/Sources/OpenAPIKit/Path Item/PathItem.swift
+++ b/Sources/OpenAPIKit/Path Item/PathItem.swift
@@ -247,6 +247,24 @@ extension OpenAPI.PathItem {
     }
 }
 
+// MARK: - Describable & Summarizable
+
+extension OpenAPI.PathItem : OpenAPISummarizable {
+    func overriddenNonNil(summary: String?) -> OpenAPI.PathItem {
+        guard let summary = summary else { return self }
+        var pathItem = self
+        pathItem.summary = summary
+        return pathItem
+    }
+
+    func overriddenNonNil(description: String?) -> OpenAPI.PathItem {
+        guard let description = description else { return self }
+        var pathItem = self
+        pathItem.description = description
+        return pathItem
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Path: Encodable {

--- a/Sources/OpenAPIKit/Path Item/PathItem.swift
+++ b/Sources/OpenAPIKit/Path Item/PathItem.swift
@@ -250,14 +250,14 @@ extension OpenAPI.PathItem {
 // MARK: - Describable & Summarizable
 
 extension OpenAPI.PathItem : OpenAPISummarizable {
-    func overriddenNonNil(summary: String?) -> OpenAPI.PathItem {
+    public func overriddenNonNil(summary: String?) -> OpenAPI.PathItem {
         guard let summary = summary else { return self }
         var pathItem = self
         pathItem.summary = summary
         return pathItem
     }
 
-    func overriddenNonNil(description: String?) -> OpenAPI.PathItem {
+    public func overriddenNonNil(description: String?) -> OpenAPI.PathItem {
         guard let description = description else { return self }
         var pathItem = self
         pathItem.description = description

--- a/Sources/OpenAPIKit/Request/Request.swift
+++ b/Sources/OpenAPIKit/Request/Request.swift
@@ -37,6 +37,16 @@ extension OpenAPI {
     }
 }
 
+// MARK: - Describable
+extension OpenAPI.Request : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Request {
+        guard let description = description else { return self }
+        var request = self
+        request.description = description
+        return request
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Request {

--- a/Sources/OpenAPIKit/Request/Request.swift
+++ b/Sources/OpenAPIKit/Request/Request.swift
@@ -39,7 +39,7 @@ extension OpenAPI {
 
 // MARK: - Describable
 extension OpenAPI.Request : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Request {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Request {
         guard let description = description else { return self }
         var request = self
         request.description = description

--- a/Sources/OpenAPIKit/Response/Response.swift
+++ b/Sources/OpenAPIKit/Response/Response.swift
@@ -39,7 +39,7 @@ extension OpenAPI {
 }
 
 extension OpenAPI.Response {
-    public typealias Map = OrderedDictionary<StatusCode, Either<JSONReference<OpenAPI.Response>, OpenAPI.Response>>
+    public typealias Map = OrderedDictionary<StatusCode, Either<OpenAPI.Reference<OpenAPI.Response>, OpenAPI.Response>>
 }
 
 extension OrderedDictionary where Key == OpenAPI.Response.StatusCode {
@@ -151,7 +151,7 @@ extension OpenAPI.Response.StatusCode: ExpressibleByIntegerLiteral {
 }
 
 // MARK: `Either` convenience methods
-extension Either where A == JSONReference<OpenAPI.Response>, B == OpenAPI.Response {
+extension Either where A == OpenAPI.Reference<OpenAPI.Response>, B == OpenAPI.Response {
 
     public static func response(
         description: String,

--- a/Sources/OpenAPIKit/Response/Response.swift
+++ b/Sources/OpenAPIKit/Response/Response.swift
@@ -168,6 +168,16 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Response>, B == OpenAPI.Re
     }
 }
 
+// MARK: - Describable
+extension OpenAPI.Response : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Response {
+        guard let description = description else { return self }
+        var response = self
+        response.description = description
+        return response
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Response {

--- a/Sources/OpenAPIKit/Response/Response.swift
+++ b/Sources/OpenAPIKit/Response/Response.swift
@@ -170,7 +170,7 @@ extension Either where A == OpenAPI.Reference<OpenAPI.Response>, B == OpenAPI.Re
 
 // MARK: - Describable
 extension OpenAPI.Response : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Response {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Response {
         guard let description = description else { return self }
         var response = self
         response.description = description

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -1271,7 +1271,7 @@ extension JSONSchema {
 // MARK: - Describable
 
 extension JSONSchema : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> JSONSchema {
+    public func overriddenNonNil(description: String?) -> JSONSchema {
         guard let description = description else { return self }
         return self.with(description: description)
     }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -588,6 +588,36 @@ extension JSONSchema {
             return self
         }
     }
+
+    /// Returns a version of this `JSONSchema` that has the given description.
+    public func with(description: String) -> JSONSchema {
+        switch self {
+        case .boolean(let context):
+            return .boolean(context.with(description: description))
+        case .number(let contextA, let contextB):
+            return .number(contextA.with(description: description), contextB)
+        case .integer(let contextA, let contextB):
+            return .integer(contextA.with(description: description), contextB)
+        case .string(let contextA, let contextB):
+            return .string(contextA.with(description: description), contextB)
+        case .object(let contextA, let contextB):
+            return .object(contextA.with(description: description), contextB)
+        case .array(let contextA, let contextB):
+            return .array(contextA.with(description: description), contextB)
+        case .all(of: let fragments, core: let core):
+            return .all(of: fragments, core: core.with(description: description))
+        case .one(of: let fragments, core: let core):
+            return .one(of: fragments, core: core.with(description: description))
+        case .any(of: let fragments, core: let core):
+            return .any(of: fragments, core: core.with(description: description))
+        case .not(let schema, core: let core):
+            return .not(schema, core: core.with(description: description))
+        case .fragment(let fragment):
+            return .fragment(fragment.with(description: description))
+        case .reference, .null:
+            return self
+        }
+    }
 }
 
 extension JSONSchema {
@@ -1235,6 +1265,15 @@ extension JSONSchema {
         required: Bool = true
     ) -> JSONSchema {
         return .reference(reference, .init(required: required))
+    }
+}
+
+// MARK: - Describable
+
+extension JSONSchema : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> JSONSchema {
+        guard let description = description else { return self }
+        return self.with(description: description)
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -358,6 +358,24 @@ extension JSONSchema.CoreContext {
             example: example
         )
     }
+
+    /// Return this context with the given description
+    public func with(description: String) -> JSONSchema.CoreContext<Format> {
+        return .init(
+            format: format,
+            required: required,
+            nullable: nullable,
+            permissions: _permissions,
+            deprecated: _deprecated,
+            title: title,
+            description: description,
+            discriminator: discriminator,
+            externalDocs: externalDocs,
+            allowedValues: allowedValues,
+            defaultValue: defaultValue,
+            example: example
+        )
+    }
 }
 
 // MARK: - Specific Contexts

--- a/Sources/OpenAPIKit/Security/SecurityScheme.swift
+++ b/Sources/OpenAPIKit/Security/SecurityScheme.swift
@@ -97,7 +97,7 @@ extension OpenAPI.SecurityScheme.SecurityType {
 // MARK: - Describable
 
 extension OpenAPI.SecurityScheme : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.SecurityScheme {
+    public func overriddenNonNil(description: String?) -> OpenAPI.SecurityScheme {
         guard let description = description else { return self }
         var scheme = self
         scheme.description = description

--- a/Sources/OpenAPIKit/Security/SecurityScheme.swift
+++ b/Sources/OpenAPIKit/Security/SecurityScheme.swift
@@ -94,6 +94,17 @@ extension OpenAPI.SecurityScheme.SecurityType {
     }
 }
 
+// MARK: - Describable
+
+extension OpenAPI.SecurityScheme : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.SecurityScheme {
+        guard let description = description else { return self }
+        var scheme = self
+        scheme.description = description
+        return scheme
+    }
+}
+
 // MARK: - Codable
 extension OpenAPI.SecurityScheme: Encodable {
     public func encode(to encoder: Encoder) throws {

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -91,6 +91,20 @@ extension OpenAPI.Server {
     }
 }
 
+// MARK: - Describable
+
+extension OpenAPI.Server : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Server {
+        guard let description = description else { return self }
+        return OpenAPI.Server(
+            urlTemplate: urlTemplate,
+            description: description,
+            variables: variables,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Codable
 extension OpenAPI.Server: Encodable {
     public func encode(to encoder: Encoder) throws {

--- a/Sources/OpenAPIKit/Server.swift
+++ b/Sources/OpenAPIKit/Server.swift
@@ -94,7 +94,7 @@ extension OpenAPI.Server {
 // MARK: - Describable
 
 extension OpenAPI.Server : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Server {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Server {
         guard let description = description else { return self }
         return OpenAPI.Server(
             urlTemplate: urlTemplate,

--- a/Sources/OpenAPIKit/Tag.swift
+++ b/Sources/OpenAPIKit/Tag.swift
@@ -46,7 +46,7 @@ extension OpenAPI.Tag: ExpressibleByStringLiteral {
 // MARK: - Describable
 
 extension OpenAPI.Tag : OpenAPIDescribable {
-    func overriddenNonNil(description: String?) -> OpenAPI.Tag {
+    public func overriddenNonNil(description: String?) -> OpenAPI.Tag {
         guard let description = description else { return self }
         return OpenAPI.Tag(
             name: name,

--- a/Sources/OpenAPIKit/Tag.swift
+++ b/Sources/OpenAPIKit/Tag.swift
@@ -43,6 +43,20 @@ extension OpenAPI.Tag: ExpressibleByStringLiteral {
     }
 }
 
+// MARK: - Describable
+
+extension OpenAPI.Tag : OpenAPIDescribable {
+    func overriddenNonNil(description: String?) -> OpenAPI.Tag {
+        guard let description = description else { return self }
+        return OpenAPI.Tag(
+            name: name,
+            description: description,
+            externalDocs: externalDocs,
+            vendorExtensions: vendorExtensions
+        )
+    }
+}
+
 // MARK: - Codable
 
 extension OpenAPI.Tag: Encodable {

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -247,11 +247,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var schemaReferencesAreValid: Validation<JSONReference<JSONSchema>> {
+    public static var schemaReferencesAreValid: Validation<OpenAPI.Reference<JSONSchema>> {
         .init(
             description: "JSONSchema reference can be found in components/schemas",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                     // don't make assertions about external references
                     // TODO: could make a stronger assertion including
@@ -269,11 +269,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var responseReferencesAreValid: Validation<JSONReference<OpenAPI.Response>> {
+    public static var responseReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Response>> {
         .init(
             description: "Response reference can be found in components/responses",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
@@ -291,11 +291,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var parameterReferencesAreValid: Validation<JSONReference<OpenAPI.Parameter>> {
+    public static var parameterReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Parameter>> {
         .init(
             description: "Parameter reference can be found in components/parameters",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
@@ -313,11 +313,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var exampleReferencesAreValid: Validation<JSONReference<OpenAPI.Example>> {
+    public static var exampleReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Example>> {
         .init(
             description: "Example reference can be found in components/examples",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
@@ -335,11 +335,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var requestReferencesAreValid: Validation<JSONReference<OpenAPI.Request>> {
+    public static var requestReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Request>> {
         .init(
             description: "Request reference can be found in components/requestBodies",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
@@ -357,11 +357,11 @@ extension Validation {
     ///
     /// - Important: This is included in validation by default.
     ///
-    public static var headerReferencesAreValid: Validation<JSONReference<OpenAPI.Header>> {
+    public static var headerReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Header>> {
         .init(
             description: "Header reference can be found in components/headers",
             check: { context in
-                guard case let .internal(internalReference) = context.subject,
+                guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including

--- a/Sources/OpenAPIKit/Validator/Validator+Convenience.swift
+++ b/Sources/OpenAPIKit/Validator/Validator+Convenience.swift
@@ -268,7 +268,7 @@ public func unwrap<T, U>(
 ///             the KeyPath points to.
 ///
 public func lookup<T, U>(
-    _ path: KeyPath<T, Either<JSONReference<U>, U>>,
+    _ path: KeyPath<T, Either<OpenAPI.Reference<U>, U>>,
     thenApply validations: Validation<U>...
 ) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in
@@ -302,7 +302,7 @@ public func lookup<T, U>(
 ///             the KeyPath points to.
 ///
 public func unwrapAndLookup<T, U>(
-    _ path: KeyPath<T, Either<JSONReference<U>, U>?>,
+    _ path: KeyPath<T, Either<OpenAPI.Reference<U>, U>?>,
     thenApply validations: Validation<U>...
 ) -> (ValidationContext<T>) -> [ValidationError] {
     return { context in

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -64,7 +64,7 @@ extension OpenAPI.Document {
 /// - Parameters are unique within each Path Item.
 /// - Parameters are unique within each Operation.
 /// - Operation Ids are unique across the whole Document.
-/// - All JSONReferences that refer to components in this
+/// - All OpenAPI.References that refer to components in this
 ///     document can be found in the components dictionary.
 ///
 /// If you want a Validator that won't perform any
@@ -157,7 +157,7 @@ public final class Validator {
     /// - Parameters are unique within each Path Item.
     /// - Parameters are unique within each Operation.
     /// - Operation Ids are unique across the whole Document.
-    /// - All JSONReferences that refer to components in this
+    /// - All OpenAPI.References that refer to components in this
     ///     document can be found in the components dictionary.
     /// - `Enum` must not be empty in the document's
     ///     Server Variable.

--- a/Tests/OpenAPIKitErrorReportingTests/JSONReferenceErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/JSONReferenceErrorTests.swift
@@ -30,7 +30,7 @@ final class JSONReferenceErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Parameter in .parameters[0] for the **GET** endpoint under `/hello/world`. \n\nJSONReference<Parameter> could not be decoded because:\nInconsistency encountered when parsing `JSON Reference`: Failed to parse a valid URI for a JSON Reference from 'not a reference'.\n\nParameter could not be decoded because:\nExpected to find `name` key but it is missing..")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Parameter in .parameters[0] for the **GET** endpoint under `/hello/world`. \n\nReference<Parameter> could not be decoded because:\nInconsistency encountered when parsing `JSON Reference`: Failed to parse a valid URI for a JSON Reference from 'not a reference'.\n\nParameter could not be decoded because:\nExpected to find `name` key but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
                 "/hello/world",

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -77,7 +77,7 @@ final class PathsErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Parameter in .parameters[1] under the `/hello/world` path. \n\nJSONReference<Parameter> could not be decoded because:\nExpected value to be parsable as Mapping but it was not.\n\nParameter could not be decoded because:\nExpected value to be parsable as Mapping but it was not.."
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Parameter in .parameters[1] under the `/hello/world` path. \n\nReference<Parameter> could not be decoded because:\nExpected value to be parsable as Mapping but it was not.\n\nParameter could not be decoded because:\nExpected value to be parsable as Mapping but it was not.."
             )
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["paths", "/hello/world", "parameters", "Index 1"])
         }

--- a/Tests/OpenAPIKitErrorReportingTests/RequestErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/RequestErrorTests.swift
@@ -29,7 +29,7 @@ final class RequestErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Request in .requestBody for the **GET** endpoint under `/hello/world`. \n\nJSONReference<Request> could not be decoded because:\nExpected value to be parsable as Mapping but it was not.\n\nRequest could not be decoded because:\nExpected value to be parsable as Mapping but it was not..")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Request in .requestBody for the **GET** endpoint under `/hello/world`. \n\nReference<Request> could not be decoded because:\nExpected value to be parsable as Mapping but it was not.\n\nRequest could not be decoded because:\nExpected value to be parsable as Mapping but it was not..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
                 "/hello/world",

--- a/Tests/OpenAPIKitTests/ComponentsTests.swift
+++ b/Tests/OpenAPIKitTests/ComponentsTests.swift
@@ -135,7 +135,7 @@ final class ComponentsTests: XCTestCase {
             ]
         )
 
-        let schemas: [Either<JSONReference<JSONSchema>, JSONSchema>] = [
+        let schemas: [Either<OpenAPI.Reference<JSONSchema>, JSONSchema>] = [
             .schema(.string),
             .reference(.component(named: "hello")),
             .reference(.component(named: "not_there"))
@@ -159,20 +159,20 @@ final class ComponentsTests: XCTestCase {
             ]
         )
 
-        let schema1: Either<JSONReference<JSONSchema>, JSONSchema> = .reference(.component(named: "hello"))
+        let schema1: Either<OpenAPI.Reference<JSONSchema>, JSONSchema> = .reference(.component(named: "hello"))
 
         let resolvedSchema = try components.lookup(schema1)
 
         XCTAssertEqual(resolvedSchema, .boolean)
 
-        let schema2: Either<JSONReference<JSONSchema>, JSONSchema> = .reference(.component(named: "not_there"))
+        let schema2: Either<OpenAPI.Reference<JSONSchema>, JSONSchema> = .reference(.component(named: "not_there"))
 
         XCTAssertThrowsError(try components.lookup(schema2)) { error in
             XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .missingOnLookup(name: "not_there", key: "schemas"))
             XCTAssertEqual((error as? OpenAPI.Components.ReferenceError)?.description, "Failed to look up a JSON Reference. 'not_there' was not found in schemas.")
         }
 
-        let schema3: Either<JSONReference<JSONSchema>, JSONSchema> = .reference(.external(URL(string: "https://hi.com/hi.json#/hello/world")!))
+        let schema3: Either<OpenAPI.Reference<JSONSchema>, JSONSchema> = .reference(.external(URL(string: "https://hi.com/hi.json#/hello/world")!))
 
         XCTAssertThrowsError(try components.lookup(schema3)) { error in
             XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .cannotLookupRemoteReference)

--- a/Tests/OpenAPIKitTests/Content/DereferencedContentTests.swift
+++ b/Tests/OpenAPIKitTests/Content/DereferencedContentTests.swift
@@ -78,6 +78,30 @@ final class DereferencedContentTests: XCTestCase {
         XCTAssertEqual(t1.schema, .string(.init(), .init()))
     }
 
+    func test_referencedSchemaNoOverrides() throws {
+        let components = OpenAPI.Components(
+            schemas: [
+                "test": .string(description: "a test string")
+            ]
+        )
+        let t1 = try OpenAPI.Content(
+            schemaReference: .component(named: "test")
+        ).dereferenced(in: components)
+        XCTAssertEqual(t1.schema, .string(.init(description: "a test string"), .init()))
+    }
+
+    func test_referencedSchemaOverrideDescription() throws {
+        let components = OpenAPI.Components(
+            schemas: [
+                "test": .string(description: "a test string")
+            ]
+        )
+        let t1 = try OpenAPI.Content(
+            schemaReference: .component(named: "test", description: "overridden description")
+        ).dereferenced(in: components)
+        XCTAssertEqual(t1.schema, .string(.init(description: "overridden"), .init()))
+    }
+
     func test_missingSchema() {
         XCTAssertThrowsError(
             try OpenAPI.Content(

--- a/Tests/OpenAPIKitTests/Content/DereferencedContentTests.swift
+++ b/Tests/OpenAPIKitTests/Content/DereferencedContentTests.swift
@@ -99,7 +99,8 @@ final class DereferencedContentTests: XCTestCase {
         let t1 = try OpenAPI.Content(
             schemaReference: .component(named: "test", description: "overridden description")
         ).dereferenced(in: components)
-        XCTAssertEqual(t1.schema, .string(.init(description: "overridden"), .init()))
+        XCTAssertEqual(t1.schema?.description, "overridden description")
+        XCTAssertEqual(t1.schema, .string(.init(description: "overridden description"), .init()))
     }
 
     func test_missingSchema() {

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -915,7 +915,7 @@ extension DocumentTests {
     func test_webhooks_encode() throws {
         let op = OpenAPI.Operation(responses: [:])
         let pathItem: OpenAPI.PathItem = .init(get: op, put: op, post: op, delete: op, options: op, head: op, patch: op, trace: op)
-        let pathItemTest: Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem> = .pathItem(pathItem)
+        let pathItemTest: Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem> = .pathItem(pathItem)
         
         let document = OpenAPI.Document(
             info: .init(title: "API", version: "1.0"),

--- a/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
@@ -74,6 +74,66 @@ final class OpenAPIReferenceTests: XCTestCase {
         XCTAssertEqual(OpenAPI.Reference<OpenAPI.Callbacks>.component(named: "hello").absoluteString, "#/components/callbacks/hello")
         XCTAssertEqual(OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello").absoluteString, "#/components/pathItems/hello")
     }
+
+    func test_summaryAndDescriptionOverrides() throws {
+        let components = OpenAPI.Components(
+            schemas: [
+                "hello": .string(description: "description")
+            ],
+            responses: [
+                "hello": .init(description: "description")
+            ],
+            parameters: [
+                "hello": .init(name: "name", context: .path, content: [:], description: "description")
+            ],
+            examples: [
+                "hello": .init(summary: "summary", description: "description", value: .b(""))
+            ],
+            requestBodies: [
+                "hello": .init(description: "description", content: [:])
+            ],
+            headers: [
+                "hello": .init(schemaOrContent: .content([:]), description: "description")
+            ],
+            securitySchemes: [
+                "hello": .init(type: .mutualTLS, description: "description")
+            ],
+            callbacks: [
+                "hello": [.init(url: URL(string: "http://website.com")!): .pathItem(.init())]
+            ],
+            pathItems: [
+                "hello": .init(summary: "summary", description: "description")
+            ]
+        )
+
+        XCTAssertEqual(try OpenAPI.Reference<JSONSchema>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<JSONSchema>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Response>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Response>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Parameter>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Parameter>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Example>.component(named: "hello").dereferenced(in: components).summary, "summary")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Example>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Example>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).summary, "new sum")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Example>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Request>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Request>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Header>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.Header>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.SecurityScheme>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.SecurityScheme>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello").dereferenced(in: components).summary, "summary")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello").dereferenced(in: components).description, "description")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).summary, "new sum")
+        XCTAssertEqual(try OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello", summary: "new sum", description: "new desc").dereferenced(in: components).description, "new desc")
+    }
 }
 
 // MARK: Codable

--- a/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
@@ -1,0 +1,388 @@
+//
+//  JSONReferenceTests.swift
+//  
+//
+//  Created by Mathew Polzin on 7/4/19.
+//
+
+import Foundation
+import XCTest
+import OpenAPIKit
+
+// MARK: - OpenAPI.Reference
+final class OpenAPIReferenceTests: XCTestCase {
+    func test_initialization() {
+        let t1 = OpenAPI.Reference<JSONSchema>.internal(path: "/hello")
+        let t2 = OpenAPI.Reference<JSONSchema>.init(.internal(.path("/hello")))
+        XCTAssertEqual(t1, t2)
+        XCTAssertTrue(t1.isInternal)
+        XCTAssertFalse(t1.isExternal)
+
+        let t3 = OpenAPI.Reference<JSONSchema>.component(named: "hello")
+        let t4 = OpenAPI.Reference<JSONSchema>.init(.internal(.component(name: "hello")))
+        XCTAssertEqual(t3, t4)
+        XCTAssertTrue(t3.isInternal)
+        XCTAssertFalse(t3.isExternal)
+
+        let externalTest = OpenAPI.Reference<JSONSchema>.external(URL(string: "hello.json")!)
+        XCTAssertFalse(externalTest.isInternal)
+        XCTAssertTrue(externalTest.isExternal)
+
+        let withOtherProps = OpenAPI.Reference<JSONSchema>.init(.component(named: "hello"), summary: "summary", description: "description")
+        XCTAssertTrue(withOtherProps.isInternal)
+        XCTAssertEqual(withOtherProps.jsonReference, t4.jsonReference)
+        XCTAssertEqual(withOtherProps.summary, "summary")
+        XCTAssertEqual(withOtherProps.description, "description")
+    }
+
+    func test_stringValues() {
+        #warning("TODO: rewrite as OpenAPI.Reference")
+        let t1 = JSONReference<JSONSchema>.internal(.component(name: "hello"))
+        XCTAssertEqual(t1.name, "hello")
+        XCTAssertEqual(t1.absoluteString, "#/components/schemas/hello")
+
+        let t2 = JSONReference<JSONSchema>.external(URL(string: "hello.json#/hello/world")!)
+        XCTAssertEqual(t2.name, "world")
+        XCTAssertEqual(t2.absoluteString, "hello.json#/hello/world")
+
+        let t3 = JSONReference<JSONSchema>.internal(.path("/hello/there"))
+        XCTAssertEqual(t3.name, "there")
+        XCTAssertEqual(t3.absoluteString, "#/hello/there")
+
+        let t4 = JSONReference<JSONSchema>.InternalReference.component(name: "hello")
+        XCTAssertEqual(t4.name, "hello")
+        XCTAssertEqual(t4.rawValue, "#/components/schemas/hello")
+        XCTAssertEqual(t4.description, "#/components/schemas/hello")
+
+        let t5 = JSONReference<JSONSchema>.InternalReference.path("/hello/there")
+        XCTAssertEqual(t5.name, "there")
+        XCTAssertEqual(t5.rawValue, "#/hello/there")
+        XCTAssertEqual(t5.description, "#/hello/there")
+
+        let t6 = JSONReference<JSONSchema>.Path("/hello/there")
+        XCTAssertEqual(t6.components, ["hello", "there"])
+        XCTAssertEqual(t6.rawValue, "/hello/there")
+        XCTAssertEqual(t6.description, "/hello/there")
+
+        let t7 = JSONReference<JSONSchema>.PathComponent.property(named: "hi")
+        XCTAssertEqual(t7.rawValue, "hi")
+        XCTAssertEqual(t7.description, "hi")
+        XCTAssertEqual(t7.stringValue, "hi")
+        XCTAssertNil(t7.intValue)
+
+        let t8 = JSONReference<JSONSchema>.PathComponent.index(2)
+        XCTAssertEqual(t8.rawValue, "2")
+        XCTAssertEqual(t8.description, "2")
+        XCTAssertEqual(t8.stringValue, "2")
+        XCTAssertEqual(t8.intValue, 2)
+    }
+
+    func test_specialCharacterEscapes() {
+        #warning("TODO: rewrite as OpenAPI.Reference")
+        let t1 = JSONReference<JSONSchema>.PathComponent("~0hello~1world")
+        XCTAssertEqual(t1.description, "~hello/world")
+        XCTAssertEqual(t1.stringValue, "~hello/world")
+        XCTAssertEqual(t1.rawValue, "~0hello~1world")
+    }
+
+    func test_componentPaths() {
+        #warning("TODO: rewrite as OpenAPI.Reference")
+        XCTAssertEqual(JSONReference<JSONSchema>.component(named: "hello").absoluteString, "#/components/schemas/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Response>.component(named: "hello").absoluteString, "#/components/responses/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Parameter>.component(named: "hello").absoluteString, "#/components/parameters/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Example>.component(named: "hello").absoluteString, "#/components/examples/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Request>.component(named: "hello").absoluteString, "#/components/requestBodies/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Header>.component(named: "hello").absoluteString, "#/components/headers/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.SecurityScheme>.component(named: "hello").absoluteString, "#/components/securitySchemes/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.Callbacks>.component(named: "hello").absoluteString, "#/components/callbacks/hello")
+        XCTAssertEqual(JSONReference<OpenAPI.PathItem>.component(named: "hello").absoluteString, "#/components/pathItems/hello")
+    }
+}
+
+// MARK: Codable
+extension OpenAPIReferenceTests {
+    #warning("TODO: rewrite as OpenAPI.Reference")
+    func test_externalFileOnly_encode() throws {
+        let test = ReferenceWrapper(reference: .external(URL(string: "hello.json")!))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "hello.json"
+              }
+            }
+            """
+        )
+    }
+
+    func test_externalFileOnly_decode() throws {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "hello.json"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .external(URL(string: "hello.json")!))
+        )
+    }
+
+    func test_external_encode() throws {
+        let test = ReferenceWrapper(reference: .external(URL(string: "hello.json#/hello/world")!))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "hello.json#\\/hello\\/world"
+              }
+            }
+            """
+        )
+    }
+
+    func test_external_decode() throws {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "hello.json#/schemas/hello"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .external(URL(string: "hello.json#/schemas/hello")!))
+        )
+    }
+
+    func test_validComponent_encode() throws {
+        let test = ReferenceWrapper(reference: .component(named: "hello"))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "#\\/components\\/schemas\\/hello"
+              }
+            }
+            """
+        )
+    }
+
+    func test_validComponent_decode() throws {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "#/components/schemas/hello"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .component(named: "hello"))
+        )
+    }
+
+    func test_nonComponentLocal_encode() throws {
+        let test = ReferenceWrapper(reference: .internal(path: "/hello/world"))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "#\\/hello\\/world"
+              }
+            }
+            """
+        )
+    }
+
+    func test_nonComponentLocal_decode() throws {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "#/hello/world"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .internal(path: "/hello/world"))
+        )
+    }
+
+    func test_nonComponentSpecialCharacterLocal_encode() throws {
+        let test = ReferenceWrapper(reference: .internal(path: "/hello~1to/the~0~1world"))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "#\\/hello~1to\\/the~0~1world"
+              }
+            }
+            """
+        )
+    }
+
+    func test_nonComponentSpecialCharacterLocal_decode() throws {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "#/hello~1to/the~0~1world"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .internal(path: "/hello~1to/the~0~1world"))
+        )
+        XCTAssertEqual(decoded.reference.name, "the~/world")
+    }
+
+    func test_invalidComponentFailure_decode() {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": "#/components/wrongType/hello"
+            }
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try orderUnstableDecode(ReferenceWrapper.self, from: test))
+    }
+
+    func test_emptyStringFailure_decode() {
+        let test =
+        """
+        {
+            "reference" : {
+                "$ref": ""
+            }
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertThrowsError(try orderUnstableDecode(ReferenceWrapper.self, from: test))
+    }
+
+    func test_overwriteDescription_encode() throws {
+        let test = ReferenceWrapper(reference: .init(.component(named: "hello"), description: "hello world"))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "#\\/components\\/schemas\\/hello",
+                "description" : "hello world"
+              }
+            }
+            """
+        )
+    }
+
+    func test_overwiteDescription_decode() throws {
+        let test =
+            """
+        {
+            "reference" : {
+                "$ref": "#/components/schemas/hello",
+                "description": "hello world"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .init(.component(named: "hello"), description: "hello world"))
+        )
+    }
+
+    func test_overwriteSummary_encode() throws {
+        let test = ReferenceWrapper(reference: .init(.component(named: "hello"), summary: "hello world"))
+
+        let encoded = try orderUnstableTestStringFromEncoding(of: test)
+
+        assertJSONEquivalent(
+            encoded,
+            """
+            {
+              "reference" : {
+                "$ref" : "#\\/components\\/schemas\\/hello",
+                "summary" : "hello world"
+              }
+            }
+            """
+        )
+    }
+
+    func test_overwiteSummary_decode() throws {
+        let test =
+            """
+        {
+            "reference" : {
+                "$ref": "#/components/schemas/hello",
+                "summary": "hello world"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try orderUnstableDecode(ReferenceWrapper.self, from: test)
+
+        XCTAssertEqual(
+            decoded,
+            ReferenceWrapper(reference: .init(.component(named: "hello"), summary: "hello world"))
+        )
+    }
+    
+}
+
+// MARK: - Test Types
+extension OpenAPIReferenceTests {
+    struct ReferenceWrapper: Codable, Equatable {
+        let reference: OpenAPI.Reference<JSONSchema>
+    }
+}

--- a/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/OpenAPIReferenceTests.swift
@@ -36,72 +36,48 @@ final class OpenAPIReferenceTests: XCTestCase {
     }
 
     func test_stringValues() {
-        #warning("TODO: rewrite as OpenAPI.Reference")
-        let t1 = JSONReference<JSONSchema>.internal(.component(name: "hello"))
+        let t1 = OpenAPI.Reference<JSONSchema>.component(named: "hello")
         XCTAssertEqual(t1.name, "hello")
         XCTAssertEqual(t1.absoluteString, "#/components/schemas/hello")
+        XCTAssertNil(t1.summary)
+        XCTAssertNil(t1.description)
+        XCTAssertEqual(t1.jsonReference.absoluteString, "#/components/schemas/hello")
 
-        let t2 = JSONReference<JSONSchema>.external(URL(string: "hello.json#/hello/world")!)
+        let t2 = OpenAPI.Reference<JSONSchema>.external(URL(string: "hello.json#/hello/world")!)
         XCTAssertEqual(t2.name, "world")
         XCTAssertEqual(t2.absoluteString, "hello.json#/hello/world")
+        XCTAssertNil(t2.summary)
+        XCTAssertNil(t2.description)
+        XCTAssertEqual(t2.jsonReference.absoluteString, "hello.json#/hello/world")
 
-        let t3 = JSONReference<JSONSchema>.internal(.path("/hello/there"))
+        let t3 = OpenAPI.Reference<JSONSchema>.internal(path: "/hello/there")
         XCTAssertEqual(t3.name, "there")
         XCTAssertEqual(t3.absoluteString, "#/hello/there")
-
-        let t4 = JSONReference<JSONSchema>.InternalReference.component(name: "hello")
-        XCTAssertEqual(t4.name, "hello")
-        XCTAssertEqual(t4.rawValue, "#/components/schemas/hello")
-        XCTAssertEqual(t4.description, "#/components/schemas/hello")
-
-        let t5 = JSONReference<JSONSchema>.InternalReference.path("/hello/there")
-        XCTAssertEqual(t5.name, "there")
-        XCTAssertEqual(t5.rawValue, "#/hello/there")
-        XCTAssertEqual(t5.description, "#/hello/there")
-
-        let t6 = JSONReference<JSONSchema>.Path("/hello/there")
-        XCTAssertEqual(t6.components, ["hello", "there"])
-        XCTAssertEqual(t6.rawValue, "/hello/there")
-        XCTAssertEqual(t6.description, "/hello/there")
-
-        let t7 = JSONReference<JSONSchema>.PathComponent.property(named: "hi")
-        XCTAssertEqual(t7.rawValue, "hi")
-        XCTAssertEqual(t7.description, "hi")
-        XCTAssertEqual(t7.stringValue, "hi")
-        XCTAssertNil(t7.intValue)
-
-        let t8 = JSONReference<JSONSchema>.PathComponent.index(2)
-        XCTAssertEqual(t8.rawValue, "2")
-        XCTAssertEqual(t8.description, "2")
-        XCTAssertEqual(t8.stringValue, "2")
-        XCTAssertEqual(t8.intValue, 2)
+        XCTAssertNil(t3.summary)
+        XCTAssertNil(t3.description)
+        XCTAssertEqual(t3.jsonReference.absoluteString, "#/hello/there")
     }
 
     func test_specialCharacterEscapes() {
-        #warning("TODO: rewrite as OpenAPI.Reference")
-        let t1 = JSONReference<JSONSchema>.PathComponent("~0hello~1world")
-        XCTAssertEqual(t1.description, "~hello/world")
-        XCTAssertEqual(t1.stringValue, "~hello/world")
-        XCTAssertEqual(t1.rawValue, "~0hello~1world")
+        let t1 = OpenAPI.Reference<JSONSchema>.internal(path: "/~0hello~1world")
+        XCTAssertEqual(t1.absoluteString, "#/~0hello~1world")
     }
 
     func test_componentPaths() {
-        #warning("TODO: rewrite as OpenAPI.Reference")
-        XCTAssertEqual(JSONReference<JSONSchema>.component(named: "hello").absoluteString, "#/components/schemas/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Response>.component(named: "hello").absoluteString, "#/components/responses/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Parameter>.component(named: "hello").absoluteString, "#/components/parameters/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Example>.component(named: "hello").absoluteString, "#/components/examples/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Request>.component(named: "hello").absoluteString, "#/components/requestBodies/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Header>.component(named: "hello").absoluteString, "#/components/headers/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.SecurityScheme>.component(named: "hello").absoluteString, "#/components/securitySchemes/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.Callbacks>.component(named: "hello").absoluteString, "#/components/callbacks/hello")
-        XCTAssertEqual(JSONReference<OpenAPI.PathItem>.component(named: "hello").absoluteString, "#/components/pathItems/hello")
+        XCTAssertEqual(OpenAPI.Reference<JSONSchema>.component(named: "hello").absoluteString, "#/components/schemas/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Response>.component(named: "hello").absoluteString, "#/components/responses/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Parameter>.component(named: "hello").absoluteString, "#/components/parameters/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Example>.component(named: "hello").absoluteString, "#/components/examples/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Request>.component(named: "hello").absoluteString, "#/components/requestBodies/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Header>.component(named: "hello").absoluteString, "#/components/headers/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.SecurityScheme>.component(named: "hello").absoluteString, "#/components/securitySchemes/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.Callbacks>.component(named: "hello").absoluteString, "#/components/callbacks/hello")
+        XCTAssertEqual(OpenAPI.Reference<OpenAPI.PathItem>.component(named: "hello").absoluteString, "#/components/pathItems/hello")
     }
 }
 
 // MARK: Codable
 extension OpenAPIReferenceTests {
-    #warning("TODO: rewrite as OpenAPI.Reference")
     func test_externalFileOnly_encode() throws {
         let test = ReferenceWrapper(reference: .external(URL(string: "hello.json")!))
 

--- a/Tests/OpenAPIKitTests/Response/ResponseTests.swift
+++ b/Tests/OpenAPIKitTests/Response/ResponseTests.swift
@@ -17,7 +17,7 @@ final class ResponseTests: XCTestCase {
         XCTAssertNil(r1.headers)
         XCTAssertEqual(r1.content, [:])
 
-        let content = OpenAPI.Content(schema: .init(JSONReference<JSONSchema>.external(URL(string: "hello.yml")!)))
+        let content = OpenAPI.Content(schema: .init(OpenAPI.Reference<JSONSchema>.external(URL(string: "hello.yml")!)))
         let header = OpenAPI.Header(schemaOrContent: .init(.header(.string)))
         let r2 = OpenAPI.Response(description: "",
                                   headers: ["hello": .init(header)],

--- a/documentation/specification_coverage.md
+++ b/documentation/specification_coverage.md
@@ -27,7 +27,7 @@ For more information on the OpenAPIKit types, see the [full type documentation](
 - [Link Object](#link-object)
 - [Header Object (`OpenAPI.Header`)](#header-object-openapiheader)
 - [Tag Object (`OpenAPI.Tag`)](#tag-object-openapitag)
-- [Reference Object (`JSONReference`)](#reference-object-jsonreference)
+- [Reference Object (`OpenAPI.Reference`)](#reference-object-jsonreference)
 - [Schema Object (`JSONSchema`)](#schema-object-jsonschema)
 - [Discriminator Object (`OpenAPI.Discriminator`)](#discriminator-object-openapidiscriminator)
 - [XML Object (`OpenAPI.XML`)](#xml-object-openapixml)
@@ -218,6 +218,8 @@ For more information on the OpenAPIKit types, see the [full type documentation](
 - [x] specification extensions (`vendorExtensions`)
 
 ### Reference Object (`JSONReference`)
+- [ ] summary
+- [ ] description
 - [x] $ref
     - [x] local (same file) reference (`internal` case)
         - [x] encode

--- a/documentation/validation.md
+++ b/documentation/validation.md
@@ -326,7 +326,7 @@ let contentMapValidator = Validation(
 )
 ```
 
-If you want to use a keypath to get from one context to another where there is potentially a JSON Reference between, it can be handy to use the `lookup()` function. The `lookup()` function takes a keypath that ends in an `Either<JSONReference<T>, T>` and lifts a validation context with a subject of `T` into any other validations you want to run. There is also an `unwrapAndLookup()` helper for keypaths that produce optional either references (`Either<JSONReference<T>, T>?`).
+If you want to use a keypath to get from one context to another where there is potentially a JSON Reference between, it can be handy to use the `lookup()` function. The `lookup()` function takes a keypath that ends in an `Either<OpenAPI.Reference<T>, T>` and lifts a validation context with a subject of `T` into any other validations you want to run. There is also an `unwrapAndLookup()` helper for keypaths that produce optional either references (`Either<OpenAPI.Reference<T>, T>?`).
 
 Lastly, OpenAPIKit offers the `all()` function that will combine any number of `Validations` in the current context (as opposed to `lift()`, `unwrap()`, and others which take you from one context to another).
 ```swift


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/188.

Introduce `OpenAPI.Reference` which supports taking a `JSONReference` and additionally specifying a `summary` or `description` to override the referenced object's `summary` or `description`. This overriding naturally only takes place if the referenced object normally would have a `summary` or `description`.