### PR TITLE
Keep properties order in objects

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -235,22 +235,18 @@ extension DereferencedJSONSchema {
     public struct ObjectContext: Equatable {
         public let maxProperties: Int?
         let _minProperties: Int?
-        public let properties: [String: DereferencedJSONSchema]
+        public let properties: OrderedDictionary<String, DereferencedJSONSchema>
         public let additionalProperties: Either<Bool, DereferencedJSONSchema>?
 
         // NOTE that an object's required properties
         // array is determined by looking at its properties'
         // required Bool.
         public var requiredProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                schemaObject.required
-            }.keys)
+            properties.filter { _, schema in schema.required }.map { $0.key }
         }
 
         public var optionalProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                !schemaObject.required
-            }.keys)
+            properties.filter { _, schema in !schema.required }.map { $0.key }
         }
 
         /// The minimum number of properties allowed.
@@ -264,7 +260,7 @@ extension DereferencedJSONSchema {
 
         public init?(_ objectContext: JSONSchema.ObjectContext) {
 
-            var otherProperties = [String: DereferencedJSONSchema]()
+            var otherProperties = OrderedDictionary<String, DereferencedJSONSchema>()
             for (name, property) in objectContext.properties {
                 guard let dereferencedProperty = property.dereferenced() else {
                     return nil
@@ -307,7 +303,7 @@ extension DereferencedJSONSchema {
         }
 
         internal init(
-            properties: [String: DereferencedJSONSchema],
+            properties: OrderedDictionary<String, DereferencedJSONSchema>,
             additionalProperties: Either<Bool, DereferencedJSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -559,12 +559,16 @@ extension JSONSchema.ObjectContext {
     }
 }
 
-internal func combine(properties left: [String: JSONSchema], with right: [String: JSONSchema], resolvingIn components: OpenAPI.Components) throws -> [String: JSONSchema] {
-    var combined = left
-    try combined.merge(right) { (left, right) throws -> JSONSchema in
-        var resolver = FragmentCombiner(components: components)
-        try resolver.combine([left, right])
-        return try resolver.dereferencedSchema().jsonSchema
+internal func combine(properties left: OrderedDictionary<String, JSONSchema>, with right: OrderedDictionary<String, JSONSchema>, resolvingIn components: OpenAPI.Components) throws -> OrderedDictionary<String, JSONSchema> {
+    var combined = right
+    for (key, lhs) in left {
+        if let rhs = combined[key] {
+            var resolver = FragmentCombiner(components: components)
+            try resolver.combine([lhs, rhs])
+            combined[key] = try resolver.dereferencedSchema().jsonSchema
+        } else {
+            combined[key] = lhs
+        }
     }
     return combined
 }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -1067,7 +1067,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         minProperties: Int? = nil,
         maxProperties: Int? = nil,
-        properties: [String: JSONSchema] = [:],
+        properties: OrderedDictionary<String, JSONSchema> = [:],
         additionalProperties: Either<Bool, JSONSchema>? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -571,7 +571,7 @@ extension JSONSchema {
         /// is allowed to have.
         public let maxProperties: Int?
         let _minProperties: Int?
-        public let properties: [String: JSONSchema]
+        public let properties: OrderedDictionary<String, JSONSchema>
 
         /// Either a boolean or a schema defining or allowing
         /// additional properties on this object.
@@ -598,9 +598,7 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var requiredProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                schemaObject.required
-            }.keys).sorted()
+            properties.filter { _, schema in schema.required }.map { $0.key }
         }
 
         /// The properties of this object that are optional.
@@ -609,9 +607,7 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var optionalProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                !schemaObject.required
-            }.keys).sorted()
+            properties.filter { _, schema in !schema.required }.map { $0.key }
         }
 
         /// The minimum number of properties allowed.
@@ -624,7 +620,7 @@ extension JSONSchema {
         }
 
         public init(
-            properties: [String: JSONSchema],
+            properties: OrderedDictionary<String, JSONSchema>,
             additionalProperties: Either<Bool, JSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil
@@ -1018,7 +1014,7 @@ extension JSONSchema.ObjectContext: Decodable {
 
         let requiredArray = try container.decodeIfPresent([String].self, forKey: .required) ?? []
 
-        let decodedProperties = try container.decodeIfPresent([String: JSONSchema].self, forKey: .properties) ?? [:]
+        let decodedProperties = try container.decodeIfPresent(OrderedDictionary<String, JSONSchema>.self, forKey: .properties) ?? [:]
         properties = Self.properties(decodedProperties, takingRequirementsFrom: requiredArray)
     }
 
@@ -1036,9 +1032,9 @@ extension JSONSchema.ObjectContext: Decodable {
     ///     - properties: The properties before resolving optionality.
     ///     - required: The array of names of properties that should be required.
     internal static func properties(
-        _ properties: [String: JSONSchema],
+        _ properties: OrderedDictionary<String, JSONSchema>,
         takingRequirementsFrom required: [String]
-    ) -> [String: JSONSchema] {
+    ) -> OrderedDictionary<String, JSONSchema> {
         var properties = properties
 
         // mark any optional properties as optional.

--- a/Sources/OpenAPIKit30/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit30/Schema Object/DereferencedJSONSchema.swift
@@ -230,22 +230,18 @@ extension DereferencedJSONSchema {
     public struct ObjectContext: Equatable {
         public let maxProperties: Int?
         let _minProperties: Int?
-        public let properties: [String: DereferencedJSONSchema]
+        public let properties: OrderedDictionary<String, DereferencedJSONSchema>
         public let additionalProperties: Either<Bool, DereferencedJSONSchema>?
 
         // NOTE that an object's required properties
         // array is determined by looking at its properties'
         // required Bool.
         public var requiredProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                schemaObject.required
-            }.keys)
+            properties.filter { _, schema in schema.required }.map { $0.key }
         }
 
         public var optionalProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                !schemaObject.required
-            }.keys)
+            properties.filter { _, schema in !schema.required }.map { $0.key }
         }
 
         /// The minimum number of properties allowed.
@@ -259,7 +255,7 @@ extension DereferencedJSONSchema {
 
         public init?(_ objectContext: JSONSchema.ObjectContext) {
 
-            var otherProperties = [String: DereferencedJSONSchema]()
+            var otherProperties = OrderedDictionary<String, DereferencedJSONSchema>()
             for (name, property) in objectContext.properties {
                 guard let dereferencedProperty = property.dereferenced() else {
                     return nil
@@ -302,7 +298,7 @@ extension DereferencedJSONSchema {
         }
 
         internal init(
-            properties: [String: DereferencedJSONSchema],
+            properties: OrderedDictionary<String, DereferencedJSONSchema>,
             additionalProperties: Either<Bool, DereferencedJSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchema+Combining.swift
@@ -536,12 +536,16 @@ extension JSONSchema.ObjectContext {
     }
 }
 
-internal func combine(properties left: [String: JSONSchema], with right: [String: JSONSchema], resolvingIn components: OpenAPI.Components) throws -> [String: JSONSchema] {
-    var combined = left
-    try combined.merge(right) { (left, right) throws -> JSONSchema in
-        var resolver = FragmentCombiner(components: components)
-        try resolver.combine([left, right])
-        return try resolver.dereferencedSchema().jsonSchema
+internal func combine(properties left: OrderedDictionary<String, JSONSchema>, with right: OrderedDictionary<String, JSONSchema>, resolvingIn components: OpenAPI.Components) throws -> OrderedDictionary<String, JSONSchema> {
+    var combined = right
+    for (key, lhs) in left {
+        if let rhs = combined[key] {
+            var resolver = FragmentCombiner(components: components)
+            try resolver.combine([lhs, rhs])
+            combined[key] = try resolver.dereferencedSchema().jsonSchema
+        } else {
+            combined[key] = lhs
+        }
     }
     return combined
 }

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchema.swift
@@ -1018,7 +1018,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         minProperties: Int? = nil,
         maxProperties: Int? = nil,
-        properties: [String: JSONSchema] = [:],
+        properties: OrderedDictionary<String, JSONSchema> = [:],
         additionalProperties: Either<Bool, JSONSchema>? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
@@ -582,10 +582,7 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var requiredProperties: [String] {
-            properties
-                .filter { _, schema in schema.required }
-                .map { $0.key }
-                .sorted()
+            properties.filter { _, schema in schema.required }.map { $0.key }
         }
 
         /// The properties of this object that are optional.
@@ -594,10 +591,7 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var optionalProperties: [String] {
-            properties
-                .filter { _, schema in !schema.required }
-                .map { $0.key }
-                .sorted()
+            properties.filter { _, schema in !schema.required }.map { $0.key }
         }
 
         /// The minimum number of properties allowed.

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
@@ -555,7 +555,7 @@ extension JSONSchema {
         /// is allowed to have.
         public let maxProperties: Int?
         let _minProperties: Int?
-        public let properties: [String: JSONSchema]
+        public let properties: OrderedDictionary<String, JSONSchema>
 
         /// Either a boolean or a schema defining or allowing
         /// additional properties on this object.
@@ -582,9 +582,10 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var requiredProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                schemaObject.required
-            }.keys).sorted()
+            properties
+                .filter { _, schema in schema.required }
+                .map { $0.key }
+                .sorted()
         }
 
         /// The properties of this object that are optional.
@@ -593,9 +594,10 @@ extension JSONSchema {
         ///     is determined by looking at its properties'
         ///     required Bool.
         public var optionalProperties: [String] {
-            return Array(properties.filter { (_, schemaObject) in
-                !schemaObject.required
-            }.keys).sorted()
+            properties
+                .filter { _, schema in !schema.required }
+                .map { $0.key }
+                .sorted()
         }
 
         /// The minimum number of properties allowed.
@@ -608,7 +610,7 @@ extension JSONSchema {
         }
 
         public init(
-            properties: [String: JSONSchema],
+            properties: OrderedDictionary<String, JSONSchema>,
             additionalProperties: Either<Bool, JSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil
@@ -970,7 +972,7 @@ extension JSONSchema.ObjectContext: Decodable {
 
         let requiredArray = try container.decodeIfPresent([String].self, forKey: .required) ?? []
 
-        let decodedProperties = try container.decodeIfPresent([String: JSONSchema].self, forKey: .properties) ?? [:]
+        let decodedProperties = try container.decodeIfPresent(OrderedDictionary<String, JSONSchema>.self, forKey: .properties) ?? [:]
         properties = Self.properties(decodedProperties, takingRequirementsFrom: requiredArray)
     }
 
@@ -988,9 +990,9 @@ extension JSONSchema.ObjectContext: Decodable {
     ///     - properties: The properties before resolving optionality.
     ///     - required: The array of names of properties that should be required.
     internal static func properties(
-        _ properties: [String: JSONSchema],
+        _ properties: OrderedDictionary<String, JSONSchema>,
         takingRequirementsFrom required: [String]
-    ) -> [String: JSONSchema] {
+    ) -> OrderedDictionary<String, JSONSchema> {
         var properties = properties
 
         // mark any optional properties as optional.

--- a/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentCombiningTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentCombiningTests.swift
@@ -180,19 +180,16 @@ final class SchemaFragmentCombiningTests: XCTestCase {
 
     // MARK: - Fragment Combinations
     func assertOrderIndependentCombinedEqual(_ fragments: [JSONSchema], _ schema: DereferencedJSONSchema, file: StaticString = #file, line: UInt = #line) throws {
-        let resolved1 = try fragments.combined(resolvingAgainst: .noComponents)
+        try assertCombinedEqual(fragments, schema, file: file, line: line)
+        try assertCombinedEqual(fragments.reversed(), schema, file: file, line: line)
+    }
+    
+    func assertCombinedEqual(_ fragments: [JSONSchema], _ schema: DereferencedJSONSchema, file: StaticString = #file, line: UInt = #line) throws {
+        let resolved = try fragments.combined(resolvingAgainst: .noComponents)
         let schemaString = try orderUnstableTestStringFromEncoding(of: schema.jsonSchema)
-        let resolvedSchemaString = try orderUnstableTestStringFromEncoding(of: resolved1.jsonSchema)
+        let resolvedSchemaString = try orderUnstableTestStringFromEncoding(of: resolved.jsonSchema)
         XCTAssertEqual(
-            resolved1,
-            schema,
-            "\n\n\(resolvedSchemaString ?? "nil") \n!=\n \(schemaString ?? "nil")",
-            file: (file),
-            line: line
-        )
-        let resolved2 = try fragments.reversed().combined(resolvingAgainst: .noComponents)
-        XCTAssertEqual(
-            resolved2,
+            resolved,
             schema,
             "\n\n\(resolvedSchemaString ?? "nil") \n!=\n \(schemaString ?? "nil")",
             file: (file),
@@ -273,47 +270,62 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     }
 
     func test_deeperObjectFragments() throws {
-        try assertOrderIndependentCombinedEqual(
-            [
-                .object(.init(), .init(properties: [:], additionalProperties: .init(true))),
-                .object(.init(description: "nested"), .init(properties: [:])),
-                .object(
-                    .init(),
-                    .init(
-                        properties: [
-                            "required": .string
-                        ],
-                        minProperties: 2
-                    )
-                ),
-                .object(
-                    .init(),
-                    .init(
-                        properties: [
-                            "optional": .boolean(required: false),
-                            "someObject": .object(required: false),
-                            "anything": .fragment(.init(description: nil))
-                        ],
-                        minProperties: 2
-                    )
-                )
-            ],
+        let fragments: [JSONSchema] = [
+            .object(.init(), .init(properties: [:], additionalProperties: .init(true))),
+            .object(.init(description: "nested"), .init(properties: [:])),
             .object(
-                .init(description: "nested"),
-                DereferencedJSONSchema.ObjectContext(
-                    .init(
-                        properties: [
-                            "required": .string,
-                            "optional": .boolean(required: false),
-                            "someObject": .object(required: false),
-                            "anything": .fragment(.init(description: nil))
-                        ],
-                        additionalProperties: .init(true),
-                        minProperties: 2
-                    )
-                )!
+                .init(),
+                .init(
+                    properties: [
+                        "required": .string
+                    ],
+                    minProperties: 2
+                )
+            ),
+            .object(
+                .init(),
+                .init(
+                    properties: [
+                        "optional": .boolean(required: false),
+                        "someObject": .object(required: false),
+                        "anything": .fragment(.init(description: nil))
+                    ],
+                    minProperties: 2
+                )
             )
-        )
+        ]
+        
+        try assertCombinedEqual(fragments, .object(
+            .init(description: "nested"),
+            DereferencedJSONSchema.ObjectContext(
+                .init(
+                    properties: [
+                        "required": .string,
+                        "optional": .boolean(required: false),
+                        "someObject": .object(required: false),
+                        "anything": .fragment(.init(description: nil))
+                    ],
+                    additionalProperties: .init(true),
+                    minProperties: 2
+                )
+            )!
+        ))
+        
+        try assertCombinedEqual(fragments.reversed(), .object(
+            .init(description: "nested"),
+            DereferencedJSONSchema.ObjectContext(
+                .init(
+                    properties: [
+                        "optional": .boolean(required: false),
+                        "someObject": .object(required: false),
+                        "anything": .fragment(.init(description: nil)),
+                        "required": .string
+                    ],
+                    additionalProperties: .init(true),
+                    minProperties: 2
+                )
+            )!
+        ))
     }
 
     func test_evenDeeperObjectFragments() throws {
@@ -357,8 +369,8 @@ final class SchemaFragmentCombiningTests: XCTestCase {
                 )
             )
         ]
-
-        let expectedResult = DereferencedJSONSchema.object(
+        
+        try assertCombinedEqual(fragments, DereferencedJSONSchema.object(
             .init(),
             DereferencedJSONSchema.ObjectContext(
                 .init(
@@ -379,12 +391,30 @@ final class SchemaFragmentCombiningTests: XCTestCase {
                     ]
                 )
             )!
-        )
+        ))
 
-        try assertOrderIndependentCombinedEqual(
-            fragments,
-            expectedResult
-        )
+        try assertCombinedEqual(fragments.reversed(), DereferencedJSONSchema.object(
+            .init(),
+            DereferencedJSONSchema.ObjectContext(
+                .init(
+                    properties: [
+                        "more_fragments": .object(
+                            title: "nested test",
+                            description: "nested",
+                            properties: [
+                                "someObject": .object,
+                                "boolean": .boolean(format: .other("integer"), required: false, description: "boolean"),
+                                "string": .string(required: true, description: "string", maxLength: 50),
+                                "integer": .integer(required: false, description: "integer", maximum: (10, exclusive: false)),
+                                "number": .number(required: false, description: "number", maximum: (33.2, exclusive: false)),
+                                "array": .array(required: true, description: "array", maxItems: 22)
+                            ]
+                        ),
+                        "more_object": .object(required: false, properties: ["boolean": .boolean])
+                    ]
+                )
+            )!
+        ))
     }
 
     func test_minLessThanMaxObject() throws {


### PR DESCRIPTION
Specs are often designed with a particular order of properties in mind.

I haven't updated the tests yet – there are a few that are now failing.