### PR TITLE
Ordered dict contains

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   codecov:
     container: 
-      image: swift:5.3
+      image: swift:5.5
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,3 +14,4 @@ jobs:
       uses: mattpolzin/swift-codecov-action@0.6.0
       with:
         MINIMUM_COVERAGE: 98
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,15 @@ jobs:
           - swift:5.3-focal
           - swift:5.3-centos8
           - swift:5.3-amazonlinux2
+          # see below for 5.4, 5.5, etc.
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run tests
       run: swift test --enable-test-discovery
+  # 5.4 is separate because there was a bug in the compiler that caused
+  # us to need to run swift tets with the -sil-verify-none flag.
   linux-5_4:
     runs-on: ubuntu-latest
     strategy:
@@ -54,11 +57,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swiftlang/swift:nightly-5.5-xenial
-          - swiftlang/swift:nightly-5.5-bionic
-          - swiftlang/swift:nightly-5.5-focal
-          - swiftlang/swift:nightly-5.5-centos8
-          - swiftlang/swift:nightly-5.5-amazonlinux2
+          - swift:5.5-xenial
+          - swift:5.5-bionic
+          - swift:5.5-focal
+          - swift:5.5-centos8
+          - swift:5.5-amazonlinux2
           - swiftlang/swift:nightly-xenial
           - swiftlang/swift:nightly-bionic
           - swiftlang/swift:nightly-focal

--- a/Sources/OpenAPIKitCore/OrderedDictionary/OrderedDictionary.swift
+++ b/Sources/OpenAPIKitCore/OrderedDictionary/OrderedDictionary.swift
@@ -96,12 +96,14 @@ public struct OrderedDictionary<Key, Value> where Key: Hashable {
 
     /// Returns whether this dictionary contains a key fulfilling the given predicate.
     public func contains(where predicate: (Key) throws -> Bool) rethrows -> Bool {
-        return try keys.contains(where: predicate)
+        return try unorderedHash.contains(where: { (key: Key, _) in
+            return try predicate(key)
+        })
     }
 
     /// Returns whether the dictionary contains the given key.
     public func contains(key: Key) -> Bool {
-        return keys.contains(key)
+        return unorderedHash[key] != nil
     }
 
     /// Returns a new dictionary containing the keys of this dictionary with the


### PR DESCRIPTION
- Updates CI to use released 5.5 Docker images.
- Adopts performance improvement to `contains` in `OrderedDictionary` suggested in https://github.com/mattpolzin/OpenAPIKit/issues/232.