### PR TITLE
Json schema `examples` support

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -132,7 +132,7 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
     public var defaultValue: AnyCodable? { jsonSchema.defaultValue }
 
     // See `JSONSchemaContext`
-    public var example: AnyCodable? { jsonSchema.example }
+    public var examples: [AnyCodable] { jsonSchema.examples }
 
     // See `JSONSchemaContext`
     public var readOnly: Bool { jsonSchema.readOnly }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -294,7 +294,7 @@ extension JSONSchema.CoreContext where Format == JSONTypeFormat.AnyFormat {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         return try transformedContext.combined(with: other)
     }
@@ -363,10 +363,7 @@ extension JSONSchema.CoreContext {
         let newAllowedValues = allowedValues ?? other.allowedValues
         let newDefaultValue = defaultValue ?? other.defaultValue
 
-        if let conflict = conflicting(example, other.example) {
-            throw JSONSchemaResolutionError(.attributeConflict(jsonType: nil, name: "example", original: String(describing: conflict.0), new: String(describing: conflict.1)))
-        }
-        let newExample = example ?? other.example
+        let newExamples = examples + other.examples
 
         let newRequired = required || other.required
         return .init(
@@ -381,7 +378,7 @@ extension JSONSchema.CoreContext {
             externalDocs: newExternalDocs,
             allowedValues: newAllowedValues,
             defaultValue: newDefaultValue,
-            example: newExample
+            examples: newExamples
         )
     }
 }
@@ -590,7 +587,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -531,29 +531,35 @@ extension JSONSchema {
     /// Returns a version of this `JSONSchema` that has the given example
     /// attached.
     public func with(example: AnyCodable) throws -> JSONSchema {
+        return try with(examples: [example])
+    }
+
+    /// Returns a version of this `JSONSchema` that has the given examples
+    /// attached.
+    public func with(examples: [AnyCodable]) throws -> JSONSchema {
         switch self {
         case .boolean(let context):
-            return .boolean(context.with(example: example))
+            return .boolean(context.with(examples: examples))
         case .object(let contextA, let contextB):
-            return .object(contextA.with(example: example), contextB)
+            return .object(contextA.with(examples: examples), contextB)
         case .array(let contextA, let contextB):
-            return .array(contextA.with(example: example), contextB)
+            return .array(contextA.with(examples: examples), contextB)
         case .number(let context, let contextB):
-            return .number(context.with(example: example), contextB)
+            return .number(context.with(examples: examples), contextB)
         case .integer(let context, let contextB):
-            return .integer(context.with(example: example), contextB)
+            return .integer(context.with(examples: examples), contextB)
         case .string(let context, let contextB):
-            return .string(context.with(example: example), contextB)
+            return .string(context.with(examples: examples), contextB)
         case .fragment(let context):
-            return .fragment(context.with(example: example))
+            return .fragment(context.with(examples: examples))
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(example: example))
+            return .all(of: fragments, core: core.with(examples: examples))
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.with(example: example))
+            return .one(of: schemas, core: core.with(examples: examples))
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.with(example: example))
+            return .any(of: schemas, core: core.with(examples: examples))
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(example: example))
+            return .not(schema, core: core.with(examples: examples))
         case .reference, .null:
             throw Self.Error.exampleNotSupported
         }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -196,8 +196,8 @@ public enum JSONSchema: Equatable, JSONSchemaContext {
     }
 
     // See `JSONSchemaContext`
-    public var example: AnyCodable? {
-        return coreContext?.example
+    public var examples: [AnyCodable] {
+        return coreContext?.examples ?? []
     }
 }
 
@@ -672,7 +672,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let context = JSONSchema.CoreContext<JSONTypeFormat.BooleanFormat>(
             format: format,
@@ -686,7 +686,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         return .boolean(context)
     }
@@ -705,7 +705,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         return .boolean(
             format: format,
@@ -719,7 +719,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -742,7 +742,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let context = JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>(
             format: format,
@@ -756,7 +756,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         return .fragment(context)
     }
@@ -775,7 +775,7 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         return .fragment(
             format: format,
@@ -789,7 +789,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -818,7 +818,7 @@ extension JSONSchema {
         pattern: String? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.StringFormat>(
             format: format,
@@ -832,7 +832,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         let stringContext = JSONSchema.StringContext(
             maxLength: maxLength,
@@ -859,7 +859,7 @@ extension JSONSchema {
         pattern: String? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         return .string(
             format: format,
@@ -876,7 +876,7 @@ extension JSONSchema {
             pattern: pattern,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -902,7 +902,7 @@ extension JSONSchema {
         minimum: (Double, exclusive: Bool)? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.NumberFormat>(
             format: format,
@@ -916,7 +916,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         let numbericContext = JSONSchema.NumericContext(
             multipleOf: multipleOf,
@@ -943,7 +943,7 @@ extension JSONSchema {
         minimum: (Double, exclusive: Bool)? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         return .number(
             format: format,
@@ -960,7 +960,7 @@ extension JSONSchema {
             minimum: minimum,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -986,7 +986,7 @@ extension JSONSchema {
         minimum: (Int, exclusive: Bool)? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.IntegerFormat>(
             format: format,
@@ -1000,7 +1000,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         let integerContext = JSONSchema.IntegerContext(
             multipleOf: multipleOf,
@@ -1027,7 +1027,7 @@ extension JSONSchema {
         minimum: (Int, exclusive: Bool)? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         return .integer(
             format: format,
@@ -1044,7 +1044,7 @@ extension JSONSchema {
             minimum: minimum,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -1071,7 +1071,7 @@ extension JSONSchema {
         additionalProperties: Either<Bool, JSONSchema>? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let coreContext = JSONSchema.CoreContext<JSONTypeFormat.ObjectFormat>(
             format: format,
@@ -1085,7 +1085,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
         let objectContext = JSONSchema.ObjectContext(
             properties: properties,
@@ -1119,7 +1119,7 @@ extension JSONSchema {
         items: JSONSchema? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        example: AnyCodable? = nil
+        examples: [AnyCodable] = []
     ) -> JSONSchema {
         let coreContext = JSONSchema.CoreContext<JSONTypeFormat.ArrayFormat>(
             format: format,
@@ -1133,7 +1133,7 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
 
         let arrayContext = JSONSchema.ArrayContext(

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -346,6 +346,24 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
+            examples: [example]
+        )
+    }
+
+    /// Return this context with the given examples
+    public func with(examples: [AnyCodable]) -> JSONSchema.CoreContext<Format> {
+        return .init(
+            format: format,
+            required: required,
+            nullable: nullable,
+            permissions: _permissions,
+            deprecated: _deprecated,
+            title: title,
+            description: description,
+            discriminator: discriminator,
+            externalDocs: externalDocs,
+            allowedValues: allowedValues,
+            defaultValue: defaultValue,
             examples: examples
         )
     }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -92,8 +92,8 @@ public protocol JSONSchemaContext {
     /// `Format.SwiftType` into a default.
     var defaultValue: AnyCodable? { get }
 
-    /// Get an example, if specified. If unspecified, returns `nil`.
-    var example: AnyCodable? { get }
+    /// Get examples of values fitting the schema.
+    var examples: [AnyCodable] { get }
 
     /// `true` if this schema can only be read from and is therefore
     /// unsupported for request data.
@@ -123,14 +123,23 @@ extension JSONSchema {
 
         public let discriminator: OpenAPI.Discriminator?
 
-        // NOTE: "const" is supported by the newest JSON Schema spec but not
-        // yet by OpenAPI. Instead, will use "enum" with one possible value for now.
+        // TODO: "const" is supported by the newest JSON Schema spec but not
+        //        yet by OpenAPIKit. It is mutually exclusive with "enum"
+        //        (i.e. `allowedValues`).
 //        public let constantValue: Format.SwiftType?
 
         public let allowedValues: [AnyCodable]?
         public let defaultValue: AnyCodable?
 
-        public let example: AnyCodable?
+        /// One or more examples of values fitting the schema. Note that OpenAPI 3.1 supports
+        /// both `examples` (via the JSON Schema specification) and also `example` which
+        /// comes from OpenAPI 3.0 and is now deprecated. Because the latter is deprecated,
+        /// `example` in an OpenAPI document will be parsed as a single-element `examples`
+        /// property of a schema. It will be encoded as `examples` (so there is no way to output
+        /// the deprecated `example` property from OpenAPIKit).
+        ///
+        /// An empty examples array is omitted from encoding.
+        public let examples: [AnyCodable]
 
         public var permissions: Permissions { _permissions ?? .readWrite}
         public var deprecated: Bool { _deprecated ?? false }
@@ -149,7 +158,7 @@ extension JSONSchema {
                 && externalDocs == nil
                 && allowedValues == nil
                 && defaultValue == nil
-                && example == nil
+                && examples.isEmpty
                 && _permissions == nil
         }
 
@@ -165,7 +174,7 @@ extension JSONSchema {
             externalDocs: OpenAPI.ExternalDocumentation? = nil,
             allowedValues: [AnyCodable]? = nil,
             defaultValue: AnyCodable? = nil,
-            example: AnyCodable? = nil
+            examples: [AnyCodable] = []
         ) {
             self.format = format
             self.required = required
@@ -178,7 +187,7 @@ extension JSONSchema {
             self.externalDocs = externalDocs
             self.allowedValues = allowedValues
             self.defaultValue = defaultValue
-            self.example = example
+            self.examples = examples
         }
 
         public init(
@@ -193,7 +202,7 @@ extension JSONSchema {
             externalDocs: OpenAPI.ExternalDocumentation? = nil,
             allowedValues: [AnyCodable]? = nil,
             defaultValue: AnyCodable? = nil,
-            example: String
+            examples: [String]
         ) {
             self.format = format
             self.required = required
@@ -206,7 +215,7 @@ extension JSONSchema {
             self.externalDocs = externalDocs
             self.allowedValues = allowedValues
             self.defaultValue = defaultValue
-            self.example = AnyCodable(example)
+            self.examples = examples.map(AnyCodable.init)
         }
 
         public enum Permissions: String, Codable {
@@ -247,7 +256,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -265,7 +274,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -283,7 +292,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -301,7 +310,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -319,7 +328,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -337,7 +346,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -355,7 +364,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 
@@ -373,7 +382,7 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            examples: examples
         )
     }
 }
@@ -667,7 +676,8 @@ extension JSONSchema {
         case externalDocs
         case allowedValues = "enum"
         case defaultValue = "default"
-        case example
+        case example // deprecated in favor of examples
+        case examples
         case readOnly
         case writeOnly
         case deprecated
@@ -692,7 +702,9 @@ extension JSONSchema.CoreContext: Encodable {
         try container.encodeIfPresent(description, forKey: .description)
         try container.encodeIfPresent(discriminator, forKey: .discriminator)
         try container.encodeIfPresent(externalDocs, forKey: .externalDocs)
-        try container.encodeIfPresent(example, forKey: .example)
+        if !examples.isEmpty {
+            try container.encode(examples, forKey: .examples)
+        }
 
         // deprecated is false if omitted
         if deprecated {
@@ -778,7 +790,11 @@ extension JSONSchema.CoreContext: Decodable {
         }
 
         _deprecated = try container.decodeIfPresent(Bool.self, forKey: .deprecated)
-        example = try container.decodeIfPresent(AnyCodable.self, forKey: .example)
+        if container.contains(.example) {
+            examples = [try container.decode(AnyCodable.self, forKey: .example)]
+        } else {
+            examples = try container.decodeIfPresent([AnyCodable].self, forKey: .examples) ?? []
+        }
     }
 
     /// Decode whether or not this is a nullable JSONSchema.

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1469,7 +1469,7 @@ extension SchemaObjectTests {
             encoded,
             """
             {
-              "example" : [
+              "examples" : [
                 "hello",
                 true
               ]
@@ -2676,15 +2676,19 @@ extension SchemaObjectTests {
 
         testEncodingPropertyLines(entity: string,
                                   propertyLines: [
-                                    "\"example\" : \"hello\",",
+                                    "\"examples\" : [",
+                                    "  \"hello\"",
+                                    "],",
                                     "\"type\" : \"string\""
         ])
 
         testEncodingPropertyLines(entity: requiredObject,
                                   propertyLines: [
-                                    "\"example\" : {",
-                                    "  \"hello\" : true",
-                                    "},",
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  }",
+                                    "],",
                                     "\"properties\" : {",
                                     "  \"hello\" : {",
                                     "    \"type\" : \"boolean\"",
@@ -2695,9 +2699,11 @@ extension SchemaObjectTests {
 
         testEncodingPropertyLines(entity: optionalObject,
                                   propertyLines: [
-                                    "\"example\" : {",
-                                    "  \"hello\" : true",
-                                    "},",
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  }",
+                                    "],",
                                     "\"properties\" : {",
                                     "  \"hello\" : {",
                                     "    \"type\" : \"boolean\"",
@@ -2708,9 +2714,11 @@ extension SchemaObjectTests {
 
         testEncodingPropertyLines(entity: nullableObject,
                                   propertyLines: [
-                                    "\"example\" : {",
-                                    "  \"hello\" : true",
-                                    "},",
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  }",
+                                    "],",
                                     "\"properties\" : {",
                                     "  \"hello\" : {",
                                     "    \"type\" : \"boolean\"",
@@ -2729,9 +2737,11 @@ extension SchemaObjectTests {
                                     "    \"hello\" : false",
                                     "  }",
                                     "],",
-                                    "\"example\" : {",
-                                    "  \"hello\" : true",
-                                    "},",
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  }",
+                                    "],",
                                     "\"properties\" : {",
                                     "  \"hello\" : {",
                                     "    \"type\" : \"boolean\"",
@@ -2739,6 +2749,116 @@ extension SchemaObjectTests {
                                     "},",
                                     "\"type\" : \"object\""
         ])
+    }
+
+    func test_encodeObjectWithMultipleExamples() {
+        let string = try! JSONSchema.string(.init(format: .unspecified, required: true), .init())
+            .with(examples: ["hello", "world"])
+        let requiredObject = try! JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [
+            "hello": .boolean(.init(format: .unspecified, required: false))
+        ]))
+            .with(examples: [AnyCodable(["hello": true]), "world"])
+        let optionalObject = try! JSONSchema.object(.init(format: .unspecified, required: false), .init(properties: [
+            "hello": .boolean(.init(format: .unspecified, required: false))
+        ]))
+            .with(examples: [AnyCodable(["hello": true]), "world"])
+        let nullableObject = try! JSONSchema.object(.init(format: .unspecified, required: true, nullable: true), .init(properties: [
+            "hello": .boolean(.init(format: .unspecified, required: false))
+        ]))
+            .with(examples: [AnyCodable(["hello": true]), "world"])
+        let allowedValueObject = try! JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [
+            "hello": .boolean(.init(format: .unspecified, required: false))
+        ]))
+            .with(allowedValues: [
+                AnyCodable(["hello": false])
+            ])
+            .with(examples: [AnyCodable(["hello": true]), "world"])
+
+        if case let .object(_, objectContext) = requiredObject {
+            XCTAssertEqual(objectContext.requiredProperties, [])
+            XCTAssertEqual(objectContext.optionalProperties, ["hello"])
+        }
+
+        testEncodingPropertyLines(entity: string,
+                                  propertyLines: [
+                                    "\"examples\" : [",
+                                    "  \"hello\",",
+                                    "  \"world\"",
+                                    "],",
+                                    "\"type\" : \"string\""
+                                  ])
+
+        testEncodingPropertyLines(entity: requiredObject,
+                                  propertyLines: [
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  },",
+                                    "  \"world\"",
+                                    "],",
+                                    "\"properties\" : {",
+                                    "  \"hello\" : {",
+                                    "    \"type\" : \"boolean\"",
+                                    "  }",
+                                    "},",
+                                    "\"type\" : \"object\""
+                                  ])
+
+        testEncodingPropertyLines(entity: optionalObject,
+                                  propertyLines: [
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  },",
+                                    "  \"world\"",
+                                    "],",
+                                    "\"properties\" : {",
+                                    "  \"hello\" : {",
+                                    "    \"type\" : \"boolean\"",
+                                    "  }",
+                                    "},",
+                                    "\"type\" : \"object\""
+                                  ])
+
+        testEncodingPropertyLines(entity: nullableObject,
+                                  propertyLines: [
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  },",
+                                    "  \"world\"",
+                                    "],",
+                                    "\"properties\" : {",
+                                    "  \"hello\" : {",
+                                    "    \"type\" : \"boolean\"",
+                                    "  }",
+                                    "},",
+                                    "\"type\" : [",
+                                    "  \"object\",",
+                                    "  \"null\"",
+                                    "]"
+                                  ])
+
+        testEncodingPropertyLines(entity: allowedValueObject,
+                                  propertyLines: [
+                                    "\"enum\" : [",
+                                    "  {",
+                                    "    \"hello\" : false",
+                                    "  }",
+                                    "],",
+                                    "\"examples\" : [",
+                                    "  {",
+                                    "    \"hello\" : true",
+                                    "  },",
+                                    "  \"world\"",
+                                    "],",
+                                    "\"properties\" : {",
+                                    "  \"hello\" : {",
+                                    "    \"type\" : \"boolean\"",
+                                    "  }",
+                                    "},",
+                                    "\"type\" : \"object\""
+                                  ])
     }
 
     func test_decodeObjectWithExample() throws {

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
@@ -253,13 +253,14 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     }
 
     func test_examples() throws {
-        try assertOrderIndependentCombinedEqual(
-            [
-                .string(examples: ["hello"]),
-                .string(examples: ["world"])
-            ],
-            .string(.init(examples: ["hello", "world"]), .init())
-        )
+        let fragments: [JSONSchema] = [
+            .string(examples: ["hello"]),
+            .string(examples: ["world"])
+        ]
+        let combined = try fragments.combined(resolvingAgainst: .noComponents)
+        XCTAssertTrue(combined.examples.contains("hello"))
+        XCTAssertTrue(combined.examples.contains("world"))
+        XCTAssertEqual(combined.examples.count, 2)
     }
 
     func test_nullAndBoolean() throws {

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
@@ -252,6 +252,16 @@ final class SchemaFragmentCombiningTests: XCTestCase {
         )
     }
 
+    func test_examples() throws {
+        try assertOrderIndependentCombinedEqual(
+            [
+                .string(examples: ["hello"]),
+                .string(examples: ["world"])
+            ],
+            .string(.init(examples: ["hello", "world"]), .init())
+        )
+    }
+
     func test_nullAndBoolean() throws {
         try assertOrderIndependentCombinedEqual(
             [
@@ -800,19 +810,13 @@ final class SchemaFragmentCombiningTests: XCTestCase {
             AnyContext(allowedValues: ["string2"])
         ]
 
-        let differentExample = [
-            AnyContext(example: "string1"),
-            AnyContext(example: "string2")
-        ]
-
         let differences = [
             differentDescription,
             differentDiscriminator,
             differentTitle,
             differentDeprecated,
             differentExternalDocs,
-            differentAllowedValues,
-            differentExample
+            differentAllowedValues
         ]
 
         // break up for type checking
@@ -1285,7 +1289,7 @@ extension JSONSchema.CoreContext {
             discriminator: discriminator,
             externalDocs: externalDocs,
             allowedValues: allowedValues,
-            example: example
+            examples: examples
         )
     }
 }

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -16,7 +16,7 @@ final class SchemaFragmentTests: XCTestCase {
             XCTAssertEqual(fragment.deprecated, false, file: (file), line: line)
             XCTAssertNil(fragment.description, file: (file), line: line)
             XCTAssertNil(fragment.discriminator, file: (file), line: line)
-            XCTAssertNil(fragment.example, file: (file), line: line)
+            XCTAssertTrue(fragment.examples.isEmpty, file: (file), line: line)
             XCTAssertNil(fragment.externalDocs, file: (file), line: line)
             XCTAssertEqual(fragment.formatString ?? "", "", file: (file), line: line)
             XCTAssertEqual(fragment.nullable, false, file: (file), line: line)
@@ -38,7 +38,7 @@ final class SchemaFragmentTests: XCTestCase {
             XCTAssertEqual(fragment.deprecated, properties.deprecated, file: (file), line: line)
             XCTAssertEqual(fragment.description, properties.description, file: (file), line: line)
             XCTAssertEqual(fragment.discriminator, properties.discriminator, file: (file), line: line)
-            XCTAssertEqual(fragment.example, properties.example, file: (file), line: line)
+            XCTAssertEqual(fragment.examples, properties.examples, file: (file), line: line)
             XCTAssertEqual(fragment.externalDocs, properties.externalDocs, file: (file), line: line)
             XCTAssertEqual(fragment.formatString, properties.formatString, file: (file), line: line)
             XCTAssertEqual(fragment.nullable, properties.nullable, file: (file), line: line)
@@ -48,7 +48,7 @@ final class SchemaFragmentTests: XCTestCase {
         }
 
         // maximal
-        let generalProperties = JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>(format: .other("date"), nullable: false, permissions: .readWrite, deprecated: false, title: "Date", description: "a date", discriminator: .init(propertyName: "test"), externalDocs: .init(url: URL(string: "http://url.com")!), allowedValues: [], example: "2020-01-01")
+        let generalProperties = JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>(format: .other("date"), nullable: false, permissions: .readWrite, deprecated: false, title: "Date", description: "a date", discriminator: .init(propertyName: "test"), externalDocs: .init(url: URL(string: "http://url.com")!), allowedValues: [], examples: ["2020-01-01"])
         let t1 = JSONSchema.fragment(generalProperties)
         assertSameGeneralProperties(t1, as: generalProperties)
         let t2 = JSONSchema.integer(generalProperties.transformed(), .init(multipleOf: 10, maximum: (20, exclusive: false), minimum: (0, exclusive: true)))


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/201.

⚠️ Breaking Change ⚠️ 
The OpenAPIKit module (but not the OpenAPIKit30 module) now exposes only an `examples` property on `JSONSchema`s and their contexts. This is backwards compatible with `example` when decoding, but code that references `example` will need to be updated to use the new `examples` array instead.