### PR TITLE
Add an option to disable vendor extensions

### DIFF
--- a/Sources/OpenAPIKit/CodableVendorExtendable.swift
+++ b/Sources/OpenAPIKit/CodableVendorExtendable.swift
@@ -21,6 +21,10 @@ public protocol VendorExtendable {
     var vendorExtensions: VendorExtensions { get }
 }
 
+public enum VendorExtensionsConfiguration {
+    public static var isEnabled = true
+}
+
 internal protocol ExtendableCodingKey: CodingKey, Equatable {
     /// An array of all keys that are not vendor extensions.
     static var allBuiltinKeys: [Self] { get }
@@ -71,6 +75,9 @@ internal enum VendorExtensionDecodingError: Swift.Error, CustomStringConvertible
 extension CodableVendorExtendable {
 
     internal static func extensions(from decoder: Decoder) throws -> VendorExtensions {
+        guard VendorExtensionsConfiguration.isEnabled else {
+            return [:]
+        }
 
         let decoded = try AnyCodable(from: decoder).value
 
@@ -102,6 +109,9 @@ extension CodableVendorExtendable {
     }
 
     internal func encodeExtensions<T: KeyedEncodingContainerProtocol>(to container: inout T) throws where T.Key == Self.CodingKeys {
+        guard VendorExtensionsConfiguration.isEnabled else {
+            return
+        }
         for (key, value) in vendorExtensions {
             let xKey = key.starts(with: "x-") ? key : "x-\(key)"
             try container.encode(value, forKey: .extendedKey(for: xKey))

--- a/Sources/OpenAPIKit30/CodableVendorExtendable.swift
+++ b/Sources/OpenAPIKit30/CodableVendorExtendable.swift
@@ -21,6 +21,10 @@ public protocol VendorExtendable {
     var vendorExtensions: VendorExtensions { get }
 }
 
+public enum VendorExtensionsConfiguration {
+    public static var isEnabled = true
+}
+
 internal protocol ExtendableCodingKey: CodingKey, Equatable {
     /// An array of all keys that are not vendor extensions.
     static var allBuiltinKeys: [Self] { get }
@@ -71,6 +75,9 @@ internal enum VendorExtensionDecodingError: Swift.Error, CustomStringConvertible
 extension CodableVendorExtendable {
 
     internal static func extensions(from decoder: Decoder) throws -> VendorExtensions {
+        guard VendorExtensionsConfiguration.isEnabled else {
+            return [:]
+        }
 
         let decoded = try AnyCodable(from: decoder).value
 
@@ -102,6 +109,9 @@ extension CodableVendorExtendable {
     }
 
     internal func encodeExtensions<T: KeyedEncodingContainerProtocol>(to container: inout T) throws where T.Key == Self.CodingKeys {
+        guard VendorExtensionsConfiguration.isEnabled else {
+            return
+        }
         for (key, value) in vendorExtensions {
             let xKey = key.starts(with: "x-") ? key : "x-\(key)"
             try container.encode(value, forKey: .extendedKey(for: xKey))


### PR DESCRIPTION
I know it's not pretty, but it gets the job done.

My measurements (Release Mode, Yams, GitHub spec with 75K lines):

**Before:** Parse spec completed (2.507 s)
**After:** Parse spec completed (0.793 s)

That's more than three times faster!

It's not ideal to have to disable it manually every time. I'm thinking, is there a way to detect upfront whether extensions are needed? I wish spec had some metadata.