### PR TITLE
Add a hint when decoding allowedValues

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -749,7 +749,11 @@ extension JSONSchema.CoreContext: Decodable {
         description = try container.decodeIfPresent(String.self, forKey: .description)
         discriminator = try container.decodeIfPresent(OpenAPI.Discriminator.self, forKey: .discriminator)
         externalDocs = try container.decodeIfPresent(OpenAPI.ExternalDocumentation.self, forKey: .externalDocs)
-        allowedValues = try container.decodeIfPresent([AnyCodable].self, forKey: .allowedValues)
+        if Format.self == JSONTypeFormat.StringFormat.self {
+            allowedValues = try container.decodeIfPresent([String].self, forKey: .allowedValues)?.map(AnyCodable.init)
+        } else {
+            allowedValues = try container.decodeIfPresent([AnyCodable].self, forKey: .allowedValues)
+        }
         defaultValue = try container.decodeIfPresent(AnyCodable.self, forKey: .defaultValue)
 
         let readOnly = try container.decodeIfPresent(Bool.self, forKey: .readOnly)

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
@@ -718,7 +718,11 @@ extension JSONSchema.CoreContext: Decodable {
         description = try container.decodeIfPresent(String.self, forKey: .description)
         discriminator = try container.decodeIfPresent(OpenAPI.Discriminator.self, forKey: .discriminator)
         externalDocs = try container.decodeIfPresent(OpenAPI.ExternalDocumentation.self, forKey: .externalDocs)
-        allowedValues = try container.decodeIfPresent([AnyCodable].self, forKey: .allowedValues)
+        if Format.self == JSONTypeFormat.StringFormat.self {
+            allowedValues = try container.decodeIfPresent([String].self, forKey: .allowedValues)?.map(AnyCodable.init)
+        } else {
+            allowedValues = try container.decodeIfPresent([AnyCodable].self, forKey: .allowedValues)
+        }
         defaultValue = try container.decodeIfPresent(AnyCodable.self, forKey: .defaultValue)
         _nullable = try container.decodeIfPresent(Bool.self, forKey: .nullable)
 


### PR DESCRIPTION
I've tested OpenAPIKit with over 400k lines of OpenAPI specs. The most common issue I've encountered so far has to do with string enums and allowed values and the interplay of `OpenAPIKit.AnyCodable`, `Yams`, and `Double`. Here are a couple of examples:

## Issues

### Jira

```yaml
searcherKey:
  type: string
  enum:
    - com.atlassian.jira.plugin.system.customfieldtypes:cascadingselectsearcher
    ...
```

I get `AnyCodable` with value `0` of type `Int` in the allowed values.

It happens because of the sexagesimal [support in Yams](https://github.com/jpsim/Yams/issues/337). When [it sees](https://github.com/jpsim/Yams/blob/9ff1cc9327586db4e0c8f46f064b6a82ec1566fa/Sources/Yams/Constructor.swift#L302) ":" in a value, it assumes it's a number. I think it's supposed to bail out when it sees it has letters, but it doesn't and returns `0`.

Sexagesimal is just one of the crazy pre-2009 YAML features and I'm not sure why it's supported by Yams. I'm currently using a fork in my project.

### Square

```yaml
up_to:
  type: string 
  enum:
    - inf
```

I get `AnyCodable` with value `Double.infinity` in the allowed values.

This is a similar problem, but this time it's `AnyCodable` that causes an issue. YAML doesn't enforce strings to have quotes. So when `AnyCodable` calls `if let double = try? container.decode(Double.self) {`, Yams attempts to initialize a `Double` with the given string. And `Double("inf")` returns `Double.infinity`.

## Suggested Fix

I suggest to add a hint when decoding `allowedValues`. When we know that `Format.self` is `JSONTypeFormat.StringFormat.self`, we can decode `[String].self` instead of `[AnyCodable].self`. It's more reliable and is better from the performance perspective as well.
