### PR TITLE
status code warning becomes a real warning.

### DIFF
--- a/Sources/OpenAPIKit/Response/Response.swift
+++ b/Sources/OpenAPIKit/Response/Response.swift
@@ -82,12 +82,27 @@ extension OpenAPI.Response {
     /// You can use integer literals to specify an exact status code.
     ///
     /// Status code ranges are named in the `StatusCode.Range` enum. For example, the "1XX" range (100-199) can be written as either `.range(.information)` or as `.range(.init(rawValue: "1XX"))`.
-    public enum StatusCode: RawRepresentable, Equatable, Hashable {
+    public struct StatusCode: RawRepresentable, Equatable, Hashable, HasWarnings {
         public typealias RawValue = String
 
-        case `default`
-        case range(Range)
-        case status(code: Int)
+        public let warnings: [OpenAPI.Warning]
+
+        public var value: Code
+
+        internal init(value: Code) {
+            self.value = value
+            warnings = []
+        }
+
+        public static let `default`: Self = .init(value: .default)
+        public static func range(_ range: Range) -> Self { .init(value: .range(range)) }
+        public static func status(code: Int) -> Self { .init(value: .status(code: code)) }
+
+        public enum Code: Equatable, Hashable {
+            case `default`
+            case range(Range)
+            case status(code: Int)
+        }
 
         public enum Range: String {
             /// Status Code `100-199`
@@ -103,7 +118,7 @@ extension OpenAPI.Response {
         }
 
         public var rawValue: String {
-            switch self {
+            switch value {
             case .default:
                 return "default"
 
@@ -116,7 +131,7 @@ extension OpenAPI.Response {
         }
 
         public var isSuccess: Bool {
-            switch self {
+            switch value {
             case .range(.success), .status(code: 200..<300):
                 return true
             case .range, .status, .default:
@@ -126,20 +141,21 @@ extension OpenAPI.Response {
 
         public init?(rawValue: String) {
             if let val = Int(rawValue) {
-                self = .status(code: val)
-
-            } else if rawValue == OpenAPI.Response.StatusCode.default.rawValue {
-                self = .default
-
+                value = .status(code: val)
+                warnings = []
+            } else if rawValue == "default" {
+                value = .default
+                warnings = []
             } else if let range = Range(rawValue: rawValue.uppercased()) {
-                self = .range(range)
-
+                value = .range(range)
+                warnings = []
             } else if rawValue.contains("/"),
-                let first = (rawValue.split(separator: "/")).first,
-                let fallback = Self(rawValue: String(first)) {
-                self = fallback
-                print("WARNING: Found non-compliant Status Code '\(rawValue)' but was able to parse as \(first)")
-
+                      let first = (rawValue.split(separator: "/")).first,
+                      let fallback = Self(rawValue: String(first)) {
+                value = fallback.value
+                warnings = [
+                    .message("Found non-compliant Status Code '\(rawValue)' but was able to parse as \(first)")
+                ]
             } else {
                 return nil
             }
@@ -150,7 +166,8 @@ extension OpenAPI.Response {
 extension OpenAPI.Response.StatusCode: ExpressibleByIntegerLiteral {
 
     public init(integerLiteral value: Int) {
-        self = .status(code: value)
+        self.value = .status(code: value)
+        warnings = []
     }
 }
 

--- a/Tests/OpenAPIKit30Tests/Response/ResponseTests.swift
+++ b/Tests/OpenAPIKit30Tests/Response/ResponseTests.swift
@@ -60,14 +60,14 @@ final class ResponseTests: XCTestCase {
 
 // MARK: Response Status Code
 extension ResponseTests {
+    typealias StatusCode = OpenAPI.Response.StatusCode
+
     func test_defaultFromString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(StatusCode(rawValue: "default"), .default)
         XCTAssertEqual(StatusCode(rawValue: "default")?.rawValue, "default")
     }
 
     func test_codeFromString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(StatusCode(rawValue: "123"), .status(code: 123))
         XCTAssertEqual(StatusCode(rawValue: "123")?.rawValue, "123")
         XCTAssertEqual(StatusCode(rawValue: "404"), .status(code: 404))
@@ -77,12 +77,16 @@ extension ResponseTests {
     }
 
     func test_NilForNonIntegerString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertNil(StatusCode(rawValue: "hello"))
     }
 
+    func test_fallbackForTwoAlts() {
+        let test = StatusCode(rawValue: "404/500")
+        XCTAssertEqual(test?.rawValue, "404")
+        XCTAssertEqual(test?.warnings.first?.localizedDescription, "Found non-compliant Status Code \'404/500\' but was able to parse as 404")
+    }
+
     func test_codeFromIntegerLiteral() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(123, StatusCode.status(code: 123))
         XCTAssertEqual(404, StatusCode.status(code: 404))
         XCTAssertEqual(500, StatusCode.status(code: 500))

--- a/Tests/OpenAPIKitTests/Response/ResponseTests.swift
+++ b/Tests/OpenAPIKitTests/Response/ResponseTests.swift
@@ -60,14 +60,14 @@ final class ResponseTests: XCTestCase {
 
 // MARK: Response Status Code
 extension ResponseTests {
+    typealias StatusCode = OpenAPI.Response.StatusCode
+
     func test_defaultFromString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(StatusCode(rawValue: "default"), .default)
         XCTAssertEqual(StatusCode(rawValue: "default")?.rawValue, "default")
     }
 
     func test_codeFromString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(StatusCode(rawValue: "123"), .status(code: 123))
         XCTAssertEqual(StatusCode(rawValue: "123")?.rawValue, "123")
         XCTAssertEqual(StatusCode(rawValue: "404"), .status(code: 404))
@@ -77,12 +77,16 @@ extension ResponseTests {
     }
 
     func test_NilForNonIntegerString() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertNil(StatusCode(rawValue: "hello"))
     }
 
+    func test_fallbackForTwoAlts() {
+        let test = StatusCode(rawValue: "404/500")
+        XCTAssertEqual(test?.rawValue, "404")
+        XCTAssertEqual(test?.warnings.first?.localizedDescription, "Found non-compliant Status Code \'404/500\' but was able to parse as 404")
+    }
+
     func test_codeFromIntegerLiteral() {
-        typealias StatusCode = OpenAPI.Response.StatusCode
         XCTAssertEqual(123, StatusCode.status(code: 123))
         XCTAssertEqual(404, StatusCode.status(code: 404))
         XCTAssertEqual(500, StatusCode.status(code: 500))


### PR DESCRIPTION

⚠️ Breaking Change ⚠️ 
`Response.StatusCode` is changing from an enum to a struct. Code won't necessarily need to change, but switching on it will need to instead switch on its `value` property.