### PR TITLE
JSONSchema warnings

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -356,7 +356,7 @@ extension JSONSchema: LocallyDereferenceable {
     ///     on whether an unresolvable reference points to another file or just points to a
     ///     component in the same file that cannot be found in the Components Object.
     public func _dereferenced(in components: OpenAPI.Components, following references: Set<AnyHashable>) throws -> DereferencedJSONSchema {
-        switch self {
+        switch value {
         case .null:
             return .null
         case .reference(let reference, let context):

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -142,10 +142,10 @@ internal struct FragmentCombiner {
             equallyOrMoreSpecializedFragment = combinedFragment
         }
 
-        switch (lessSpecializedFragment, equallyOrMoreSpecializedFragment) {
+        switch (lessSpecializedFragment.value, equallyOrMoreSpecializedFragment.value) {
         case (.all(let schemas, core: let core), let other), (let other, .all(let schemas, core: let core)):
             // tease apart one allOf if there is one and continue from there.
-            try self.combine(schemas + [.fragment(core), other])
+            try self.combine(schemas + [.fragment(core), JSONSchema(schema: other)])
 
         case (_, .reference(let reference, let context)), (.reference(let reference, let context), _):
             var component = try components.lookup(reference)
@@ -237,7 +237,7 @@ internal struct FragmentCombiner {
         }
 
         let jsonSchema: JSONSchema
-        switch combinedFragment {
+        switch combinedFragment.value {
         case .fragment, .reference, .null:
             jsonSchema = combinedFragment
         case .boolean(let coreContext):

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -133,7 +133,7 @@ internal struct FragmentCombiner {
         // make sure any less specialized fragment (i.e. general) is on the left
         let lessSpecializedFragment: JSONSchema
         let equallyOrMoreSpecializedFragment: JSONSchema
-        switch (combinedFragment, fragment) {
+        switch (combinedFragment.value, fragment.value) {
         case (.fragment, _):
             lessSpecializedFragment = combinedFragment
             equallyOrMoreSpecializedFragment = fragment

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -15,6 +15,11 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings {
     public let warnings: [OpenAPI.Warning]
     public let value: Schema
 
+    internal init(warnings: [OpenAPI.Warning], schema: Schema) {
+        self.warnings = warnings
+        self.value = schema
+    }
+
     public init(schema: Schema) {
         value = schema
         warnings = []
@@ -435,29 +440,65 @@ extension JSONSchema {
     public func optionalSchemaObject() -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.optionalContext())
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.optionalContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.optionalContext(), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.optionalContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.optionalContext(), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.optionalContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.optionalContext(), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.optionalContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.optionalContext(), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.optionalContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.optionalContext(), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.optionalContext())
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.optionalContext())
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.optionalContext())
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.optionalContext())
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.optionalContext())
+            )
         case .reference(let reference, let context):
-            return .reference(reference, context.optionalContext())
+            return .init(
+                warnings: warnings,
+                schema: .reference(reference, context.optionalContext())
+            )
         case .null:
             return self
         }
@@ -467,29 +508,65 @@ extension JSONSchema {
     public func requiredSchemaObject() -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.requiredContext())
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.requiredContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.requiredContext(), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.requiredContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.requiredContext(), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.requiredContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.requiredContext(), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.requiredContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.requiredContext(), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.requiredContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.requiredContext(), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.requiredContext())
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.requiredContext())
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.requiredContext())
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.requiredContext())
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.requiredContext())
+            )
         case .reference(let reference, let context):
-            return .reference(reference, context.requiredContext())
+            return .init(
+                warnings: warnings,
+                schema: .reference(reference, context.requiredContext())
+            )
         case .null:
             return self
         }
@@ -499,27 +576,60 @@ extension JSONSchema {
     public func nullableSchemaObject() -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.nullableContext())
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.nullableContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.nullableContext(), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.nullableContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.nullableContext(), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.nullableContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.nullableContext(), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.nullableContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.nullableContext(), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.nullableContext(), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.nullableContext(), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.nullableContext())
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.nullableContext())
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.nullableContext())
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.nullableContext())
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.nullableContext())
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.nullableContext())
+            )
         case .reference, .null:
             return self
         }
@@ -530,27 +640,60 @@ extension JSONSchema {
     public func with(allowedValues: [AnyCodable]) -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.with(allowedValues: allowedValues))
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.with(allowedValues: allowedValues), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.with(allowedValues: allowedValues), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.with(allowedValues: allowedValues), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.with(allowedValues: allowedValues), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.with(allowedValues: allowedValues), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.with(allowedValues: allowedValues), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.with(allowedValues: allowedValues), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.with(allowedValues: allowedValues), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.with(allowedValues: allowedValues), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.with(allowedValues: allowedValues), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.with(allowedValues: allowedValues))
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.with(allowedValues: allowedValues))
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.with(allowedValues: allowedValues))
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.with(allowedValues: allowedValues))
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(allowedValues: allowedValues))
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.with(allowedValues: allowedValues))
+            )
         case .reference, .null:
             return self
         }
@@ -560,27 +703,60 @@ extension JSONSchema {
     public func with(defaultValue: AnyCodable) -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.with(defaultValue: defaultValue))
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.with(defaultValue: defaultValue), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.with(defaultValue: defaultValue), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.with(defaultValue: defaultValue), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.with(defaultValue: defaultValue), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.with(defaultValue: defaultValue), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.with(defaultValue: defaultValue), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.with(defaultValue: defaultValue), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.with(defaultValue: defaultValue), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.with(defaultValue: defaultValue), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.with(defaultValue: defaultValue), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.with(defaultValue: defaultValue))
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.with(defaultValue: defaultValue))
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.with(defaultValue: defaultValue))
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.with(defaultValue: defaultValue))
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(defaultValue: defaultValue))
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.with(defaultValue: defaultValue))
+            )
         case .reference, .null:
             return self
         }
@@ -597,27 +773,60 @@ extension JSONSchema {
     public func with(examples: [AnyCodable]) throws -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.with(examples: examples))
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.with(examples: examples), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.with(examples: examples), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.with(examples: examples), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.with(examples: examples), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.with(examples: examples), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.with(examples: examples), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.with(examples: examples), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.with(examples: examples), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.with(examples: examples), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.with(examples: examples), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.with(examples: examples))
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.with(examples: examples))
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.with(examples: examples))
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.with(examples: examples))
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(examples: examples))
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.with(examples: examples))
+            )
         case .reference, .null:
             throw Self.Error.exampleNotSupported
         }
@@ -627,27 +836,60 @@ extension JSONSchema {
     public func with(discriminator: OpenAPI.Discriminator) -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.with(discriminator: discriminator))
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.with(discriminator: discriminator), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.with(discriminator: discriminator), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.with(discriminator: discriminator), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.with(discriminator: discriminator), contextB)
+            )
         case .number(let context, let contextB):
-            return .number(context.with(discriminator: discriminator), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(context.with(discriminator: discriminator), contextB)
+            )
         case .integer(let context, let contextB):
-            return .integer(context.with(discriminator: discriminator), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(context.with(discriminator: discriminator), contextB)
+            )
         case .string(let context, let contextB):
-            return .string(context.with(discriminator: discriminator), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(context.with(discriminator: discriminator), contextB)
+            )
         case .fragment(let context):
-            return .fragment(context.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .fragment(context.with(discriminator: discriminator))
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.with(discriminator: discriminator))
+            )
         case .one(of: let schemas, core: let core):
-            return .one(of: schemas, core: core.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .one(of: schemas, core: core.with(discriminator: discriminator))
+            )
         case .any(of: let schemas, core: let core):
-            return .any(of: schemas, core: core.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .any(of: schemas, core: core.with(discriminator: discriminator))
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(discriminator: discriminator))
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.with(discriminator: discriminator))
+            )
         case .reference, .null:
             return self
         }
@@ -657,27 +899,60 @@ extension JSONSchema {
     public func with(description: String) -> JSONSchema {
         switch value {
         case .boolean(let context):
-            return .boolean(context.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .boolean(context.with(description: description))
+            )
         case .number(let contextA, let contextB):
-            return .number(contextA.with(description: description), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .number(contextA.with(description: description), contextB)
+            )
         case .integer(let contextA, let contextB):
-            return .integer(contextA.with(description: description), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .integer(contextA.with(description: description), contextB)
+            )
         case .string(let contextA, let contextB):
-            return .string(contextA.with(description: description), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .string(contextA.with(description: description), contextB)
+            )
         case .object(let contextA, let contextB):
-            return .object(contextA.with(description: description), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .object(contextA.with(description: description), contextB)
+            )
         case .array(let contextA, let contextB):
-            return .array(contextA.with(description: description), contextB)
+            return .init(
+                warnings: warnings,
+                schema: .array(contextA.with(description: description), contextB)
+            )
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .all(of: fragments, core: core.with(description: description))
+            )
         case .one(of: let fragments, core: let core):
-            return .one(of: fragments, core: core.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .one(of: fragments, core: core.with(description: description))
+            )
         case .any(of: let fragments, core: let core):
-            return .any(of: fragments, core: core.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .any(of: fragments, core: core.with(description: description))
+            )
         case .not(let schema, core: let core):
-            return .not(schema, core: core.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .not(schema, core: core.with(description: description))
+            )
         case .fragment(let fragment):
-            return .fragment(fragment.with(description: description))
+            return .init(
+                warnings: warnings,
+                schema: .fragment(fragment.with(description: description))
+            )
         case .reference, .null:
             return self
         }
@@ -1482,12 +1757,12 @@ extension JSONSchema: Decodable {
             objectContainer.allKeys.isEmpty ? nil : "object"
         ].compactMap { $0 }
 
-        var warnings = [OpenAPI.Warning]()
+        var _warnings = [OpenAPI.Warning]()
 
         // TODO: probably support properties from multiple types by turning into
         //       a oneOf for each type.
         if keysFrom.count > 1 {
-            warnings.append(
+            _warnings.append(
                 .underlyingError(
                     InconsistencyError(
                         subjectName: "Schema",
@@ -1501,10 +1776,10 @@ extension JSONSchema: Decodable {
         // TODO: support multiple types instead of just grabbing the first one (see TODO immediately above as well)
         let typeHint = typeHints.first
 
-        func assertNoTypeConflict(with type: JSONType) {
-            guard let typeHint = typeHint else { return }
+        func assertNoTypeConflict(with type: JSONType) -> [OpenAPI.Warning] {
+            guard let typeHint = typeHint else { return [] }
             if typeHint != type {
-                warnings.append(
+                return [
                     .underlyingError(
                         InconsistencyError(
                             subjectName: "OpenAPI Schema",
@@ -1512,8 +1787,9 @@ extension JSONSchema: Decodable {
                             codingPath: decoder.codingPath
                         )
                     )
-                )
+                    ]
             }
+            return []
         }
 
         if typeHint == .null {
@@ -1529,19 +1805,19 @@ extension JSONSchema: Decodable {
             }
 
         } else if typeHint == .string || !stringContainer.allKeys.isEmpty {
-            assertNoTypeConflict(with: .string)
             value = .string(try CoreContext<JSONTypeFormat.StringFormat>(from: decoder),
                            try StringContext(from: decoder))
+            _warnings += assertNoTypeConflict(with: .string)
 
         } else if typeHint == .array || !arrayContainer.allKeys.isEmpty {
-            assertNoTypeConflict(with: .array)
             value = .array(try CoreContext<JSONTypeFormat.ArrayFormat>(from: decoder),
                           try ArrayContext(from: decoder))
+            _warnings += assertNoTypeConflict(with: .array)
 
         } else if typeHint == .object || !objectContainer.allKeys.isEmpty {
-            assertNoTypeConflict(with: .object)
             value = .object(try CoreContext<JSONTypeFormat.ObjectFormat>(from: decoder),
                            try ObjectContext(from: decoder))
+            _warnings += assertNoTypeConflict(with: .object)
 
         } else if typeHint == .boolean {
             value = .boolean(try CoreContext<JSONTypeFormat.BooleanFormat>(from: decoder))
@@ -1549,7 +1825,7 @@ extension JSONSchema: Decodable {
         } else {
             let fragmentContext = try CoreContext<JSONTypeFormat.AnyFormat>(from: decoder)
             if fragmentContext.isEmpty && hintContainerCount > 0 {
-                warnings.append(
+                _warnings.append(
                     .underlyingError(
                         InconsistencyError(
                             subjectName: "OpenAPI Schema",
@@ -1562,7 +1838,7 @@ extension JSONSchema: Decodable {
             value = .fragment(fragmentContext)
         }
 
-        self.warnings = warnings
+        self.warnings = _warnings
     }
 
     private static func decodeTypes(from container: KeyedDecodingContainer<JSONSchema.HintCodingKeys>) throws -> [JSONType] {

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -281,19 +281,19 @@ extension JSONSchema {
 
     /// Check if this schema is a `.fragment`.
     public var isFragment: Bool {
-        guard case .fragment = self else { return false }
+        guard case .fragment = value else { return false }
         return true
     }
 
     /// Check if schema is `.null`
     public var isNull : Bool {
-        guard case .null = self else { return false }
+        guard case .null = value else { return false }
         return true
     }
 
     /// Check if a schema is a `.boolean`.
     public var isBoolean: Bool {
-        guard case .boolean = self else { return false }
+        guard case .boolean = value else { return false }
         return true
     }
 
@@ -303,31 +303,31 @@ extension JSONSchema {
     /// `.integer` even though Integer schemas
     /// can be easily transformed into Number schemas.
     public var isNumber: Bool {
-        guard case .number = self else { return false }
+        guard case .number = value else { return false }
         return true
     }
 
     /// Check if a schema is an `.integer`.
     public var isInteger: Bool {
-        guard case .integer = self else { return false }
+        guard case .integer = value else { return false }
         return true
     }
 
     /// Check if a schema is a `.string`.
     public var isString: Bool {
-        guard case .string = self else { return false }
+        guard case .string = value else { return false }
         return true
     }
 
     /// Check if a schema is an `.object`.
     public var isObject: Bool {
-        guard case .object = self else { return false }
+        guard case .object = value else { return false }
         return true
     }
 
     /// Check if a schema is an `.array`.
     public var isArray: Bool {
-        guard case .array = self else { return false }
+        guard case .array = value else { return false }
         return true
     }
 

--- a/Sources/OpenAPIKit/Schema Object/TypesAndFormats.swift
+++ b/Sources/OpenAPIKit/Schema Object/TypesAndFormats.swift
@@ -35,6 +35,16 @@ public enum JSONType: String, Codable {
     case number = "number"
     case integer = "integer"
     case string = "string"
+
+    public var group: String {
+        switch self {
+        case .null, .boolean: return "null/boolean"
+        case .object: return "object"
+        case .array: return "array"
+        case .number, .integer: return "number/integer"
+        case .string: return "string"
+        }
+    }
 }
 
 /// The combination of a JSON Schema type and format.

--- a/Sources/OpenAPIKit30/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit30/Schema Object/DereferencedJSONSchema.swift
@@ -351,7 +351,7 @@ extension JSONSchema: LocallyDereferenceable {
     ///     on whether an unresolvable reference points to another file or just points to a
     ///     component in the same file that cannot be found in the Components Object.
     public func _dereferenced(in components: OpenAPI.Components, following references: Set<AnyHashable>) throws -> DereferencedJSONSchema {
-        switch self {
+        switch value {
         case .reference(let reference, let context):
             var dereferenced = try reference._dereferenced(in: components, following: references)
             if !context.required {

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchema+Combining.swift
@@ -127,7 +127,7 @@ internal struct FragmentCombiner {
         // make sure any less specialized fragment (i.e. general) is on the left
         let lessSpecializedFragment: JSONSchema
         let equallyOrMoreSpecializedFragment: JSONSchema
-        switch (combinedFragment, fragment) {
+        switch (combinedFragment.value, fragment.value) {
         case (.fragment, _):
             lessSpecializedFragment = combinedFragment
             equallyOrMoreSpecializedFragment = fragment
@@ -136,10 +136,10 @@ internal struct FragmentCombiner {
             equallyOrMoreSpecializedFragment = combinedFragment
         }
 
-        switch (lessSpecializedFragment, equallyOrMoreSpecializedFragment) {
+        switch (lessSpecializedFragment.value, equallyOrMoreSpecializedFragment.value) {
         case (.all(let schemas, core: let core), let other), (let other, .all(let schemas, core: let core)):
             // tease apart one allOf if there is one and continue from there.
-            try self.combine(schemas + [.fragment(core), other])
+            try self.combine(schemas + [.fragment(core), JSONSchema(schema: other)])
 
         case (_, .reference(let reference, let context)), (.reference(let reference, let context), _):
             var component = try components.lookup(reference)
@@ -211,7 +211,7 @@ internal struct FragmentCombiner {
         }
 
         let jsonSchema: JSONSchema
-        switch combinedFragment {
+        switch combinedFragment.value {
         case .fragment, .reference:
             jsonSchema = combinedFragment
         case .boolean(let coreContext):

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchema.swift
@@ -1642,10 +1642,10 @@ extension JSONSchema: Decodable {
         let objectContainer = try decoder.container(keyedBy: JSONSchema.ObjectContext.CodingKeys.self)
 
         let keysFrom = [
-            numericOrIntegerContainer.allKeys.isEmpty ? nil : "number/integer",
-            stringContainer.allKeys.isEmpty ? nil : "string",
-            arrayContainer.allKeys.isEmpty ? nil : "array",
-            objectContainer.allKeys.isEmpty ? nil : "object"
+            numericOrIntegerContainer.allKeys.isEmpty ? nil : JSONType.number.group,
+            stringContainer.allKeys.isEmpty ? nil : JSONType.string.group,
+            arrayContainer.allKeys.isEmpty ? nil : JSONType.array.group,
+            objectContainer.allKeys.isEmpty ? nil : JSONType.object.group
         ].compactMap { $0 }
 
         var _warnings = [OpenAPI.Warning]()
@@ -1662,23 +1662,22 @@ extension JSONSchema: Decodable {
             )
         }
 
-        func assertNoTypeConflict(with type: JSONType) -> [OpenAPI.Warning] {
-            guard let typeHint = typeHint else { return [] }
-            if typeHint != type {
-                return [
+        if let typeHint = typeHint {
+            let keysFromElsewhere = keysFrom.filter({ $0 != typeHint.group })
+            if !keysFromElsewhere.isEmpty {
+                _warnings.append(
                     .underlyingError(
                         InconsistencyError(
                             subjectName: "OpenAPI Schema",
-                            details: "Found schema attributes not consistent with the type specified: \(typeHint)",
+                            details: "Found schema attributes not consistent with the type specified: \(typeHint). Specifically, attributes for these other types: \(keysFromElsewhere)",
                             codingPath: decoder.codingPath
                         )
                     )
-                ]
+                )
             }
-            return []
         }
 
-        if typeHint == .integer || typeHint == .number || !numericOrIntegerContainer.allKeys.isEmpty {
+        if typeHint == .integer || typeHint == .number || (typeHint == nil && !numericOrIntegerContainer.allKeys.isEmpty) {
             if typeHint == .integer {
                 value = .integer(try CoreContext<JSONTypeFormat.IntegerFormat>(from: decoder),
                                 try IntegerContext(from: decoder))
@@ -1687,20 +1686,17 @@ extension JSONSchema: Decodable {
                                try NumericContext(from: decoder))
             }
 
-        } else if typeHint == .string || !stringContainer.allKeys.isEmpty {
+        } else if typeHint == .string || (typeHint == nil && !stringContainer.allKeys.isEmpty) {
             value = .string(try CoreContext<JSONTypeFormat.StringFormat>(from: decoder),
                            try StringContext(from: decoder))
-            _warnings += assertNoTypeConflict(with: .string)
 
-        } else if typeHint == .array || !arrayContainer.allKeys.isEmpty {
+        } else if typeHint == .array || (typeHint == nil && !arrayContainer.allKeys.isEmpty) {
             value = .array(try CoreContext<JSONTypeFormat.ArrayFormat>(from: decoder),
                           try ArrayContext(from: decoder))
-            _warnings += assertNoTypeConflict(with: .array)
 
-        } else if typeHint == .object || !objectContainer.allKeys.isEmpty {
+        } else if typeHint == .object || (typeHint == nil && !objectContainer.allKeys.isEmpty) {
             value = .object(try CoreContext<JSONTypeFormat.ObjectFormat>(from: decoder),
                            try ObjectContext(from: decoder))
-            _warnings += assertNoTypeConflict(with: .object)
 
         } else if typeHint == .boolean {
             value = .boolean(try CoreContext<JSONTypeFormat.BooleanFormat>(from: decoder))

--- a/Sources/OpenAPIKit30/Schema Object/TypesAndFormats.swift
+++ b/Sources/OpenAPIKit30/Schema Object/TypesAndFormats.swift
@@ -34,6 +34,16 @@ public enum JSONType: String, Codable {
     case number = "number"
     case integer = "integer"
     case string = "string"
+
+    public var group: String {
+        switch self {
+        case .boolean: return "boolean"
+        case .object: return "object"
+        case .array: return "array"
+        case .number, .integer: return "number/integer"
+        case .string: return "string"
+        }
+    }
 }
 
 /// The combination of a JSON Schema type and format.

--- a/Tests/OpenAPIKit30CompatibilitySuite/PetStoreAPITests.swift
+++ b/Tests/OpenAPIKit30CompatibilitySuite/PetStoreAPITests.swift
@@ -105,7 +105,7 @@ final class PetStoreAPICampatibilityTests: XCTestCase {
 
         // check for known schema
         XCTAssertNotNil(apiDoc.components.schemas["Customer"])
-        guard case .object(_, let objectContext) = apiDoc.components[JSONReference<JSONSchema>.component(named: "Customer")] else {
+        guard case .object(_, let objectContext) = apiDoc.components[JSONReference<JSONSchema>.component(named: "Customer")]?.value else {
             XCTFail("Expected customer schema to be an object")
             return
         }

--- a/Tests/OpenAPIKit30ErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/PathsErrorTests.swift
@@ -190,7 +190,7 @@ final class PathsErrorTests: XCTestCase {
         }
     }
 
-    func test_paramSchemaHasProblemDeeplyNestedInSchema() {
+    func test_paramSchemaHasProblemDeeplyNestedInSchema() throws {
         let documentYML =
         """
         openapi: "3.0.0"
@@ -212,28 +212,27 @@ final class PathsErrorTests: XCTestCase {
                                     type: string
         """
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+        let warnResult = try testDecoder.decode(OpenAPI.Document.self, from: documentYML)
 
-            let openAPIError = OpenAPI.Error(from: error)
+        let openAPIError = try warnResult.validate(using: Validator.blank).first
 
-            XCTAssertEqual(
-                openAPIError.localizedDescription,
+        XCTAssertEqual(
+            openAPIError?.localizedDescription,
                 """
-                Inconsistency encountered when parsing `OpenAPI Schema` in .parameters[0].schema.properties.hi under the `/hello/world` path: Found schema attributes not consistent with the type specified: object.
+                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.
                 """
-            )
-            XCTAssertEqual(
-                openAPIError.codingPath.map { $0.stringValue },
-                [
-                    "paths",
-                    "/hello/world",
-                    "parameters",
-                    "Index 0",
-                    "schema",
-                    "properties",
-                    "hi"
-                ]
-            )
-        }
+        )
+        XCTAssertEqual(
+            openAPIError?.codingPath?.map { $0.stringValue },
+            [
+                "paths",
+                "/hello/world",
+                "parameters",
+                "Index 0",
+                "schema",
+                "properties",
+                "hi"
+            ]
+        )
     }
 }

--- a/Tests/OpenAPIKit30ErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/PathsErrorTests.swift
@@ -219,7 +219,7 @@ final class PathsErrorTests: XCTestCase {
         XCTAssertEqual(
             openAPIError?.localizedDescription,
                 """
-                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.
+                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].
                 """
         )
         XCTAssertEqual(

--- a/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
@@ -1324,7 +1324,7 @@ extension SchemaObjectTests {
         let warnResult = try orderUnstableDecode(JSONSchema.self, from: badSchema)
 
         XCTAssertEqual(warnResult.warnings.count, 1)
-        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].")
             // we are actually at the root path in this test case so the
             // following should be an empty string!
         XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
@@ -1332,7 +1332,7 @@ extension SchemaObjectTests {
             // NOTE: I don't think it actually makes sense to rely more on the
             // properties (which can only belong to an array) than the explicit given
             // type "object" but for now I am going with this and will revisit later.
-        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
+        XCTAssertEqual(warnResult.value, .object(.init(), .init(properties: [:])))
     }
 
     func test_decodeExampleFragment() throws {

--- a/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
@@ -1273,7 +1273,7 @@ final class SchemaObjectTests: XCTestCase {
 // MARK: - Codable
 extension SchemaObjectTests {
 
-    func test_decodeingFailsForTypo() {
+    func test_decodeingWarnsForTypo() throws {
         let oneOfData = """
         {
             "oneOff": [
@@ -1283,7 +1283,19 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: oneOfData))
+        let warnResult = try orderUnstableDecode(JSONSchema.self, from: oneOfData)
+
+        XCTAssertEqual(warnResult.warnings.count, 1)
+            // NOTE: not the most informative warnings, would like to do better.
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found nothing but unsupported attributes..")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
+
+        XCTAssertEqual(
+            warnResult,
+            .fragment()
+        )
     }
 
     func test_decodingFailsForReadOnlyAndWriteOnly() {
@@ -1298,8 +1310,8 @@ extension SchemaObjectTests {
         XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: readOnlyWriteOnlyData))
     }
 
-    func test_decodingFailsForTypeAndPropertyConflict() {
-        // has type "string" but "items" property that belongs with the "array" type.
+    func test_decodingWarnsForTypeAndPropertyConflict() throws {
+        // has type "object" but "items" property that belongs with the "array" type.
         let badSchema = """
         {
             "type": "object",
@@ -1309,7 +1321,18 @@ extension SchemaObjectTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: badSchema))
+        let warnResult = try orderUnstableDecode(JSONSchema.self, from: badSchema)
+
+        XCTAssertEqual(warnResult.warnings.count, 1)
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
+
+            // NOTE: I don't think it actually makes sense to rely more on the
+            // properties (which can only belong to an array) than the explicit given
+            // type "object" but for now I am going with this and will revisit later.
+        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
     }
 
     func test_decodeExampleFragment() throws {
@@ -1677,7 +1700,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(defaultValueObject.defaultValue, ["hello": false])
         XCTAssertEqual(discriminatorObject, JSONSchema.object(discriminator: .init(propertyName: "hello")))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -1805,7 +1828,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.title, "hello")
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -1913,7 +1936,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.description, "hello")
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2029,7 +2052,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.externalDocs, .init(url: URL(string: "http://google.com")!))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2136,7 +2159,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2243,7 +2266,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2350,7 +2373,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2466,7 +2489,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2496,7 +2519,7 @@ extension SchemaObjectTests {
             ])
             .with(example: AnyCodable(["hello": true]))
 
-        if case let .object(_, objectContext) = requiredObject {
+        if case let .object(_, objectContext) = requiredObject.value {
             XCTAssertEqual(objectContext.requiredProperties, [])
             XCTAssertEqual(objectContext.optionalProperties, ["hello"])
         }
@@ -2613,7 +2636,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.example, ["hello" : true])
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2710,7 +2733,7 @@ extension SchemaObjectTests {
             ]
         )
 
-        if case let .object(_, objectContext) = requiredObject {
+        if case let .object(_, objectContext) = requiredObject.value {
             XCTAssertEqual(objectContext.requiredProperties, ["hello"])
             XCTAssertEqual(objectContext.optionalProperties, [])
         }
@@ -2822,7 +2845,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -3000,7 +3023,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(defaultValueArray.defaultValue, [false])
         XCTAssertEqual(discriminatorArray, JSONSchema.array(discriminator: .init(propertyName: "hello")))
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3084,7 +3107,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(items: .boolean(.init(format: .generic)))))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3166,7 +3189,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray.arrayContext?.uniqueItems, true)
         XCTAssertEqual(allowedValueArray.arrayContext?.uniqueItems, true)
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3224,7 +3247,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(maxItems: 3)))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3282,7 +3305,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(minItems: 2)))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }

--- a/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentTests.swift
@@ -182,7 +182,7 @@ extension SchemaFragmentTests {
         let warnResult = try orderUnstableDecode(JSONSchema.self, from: t)
 
         XCTAssertEqual(warnResult.warnings.count, 1)
-        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].")
             // we are actually at the root path in this test case so the
             // following should be an empty string!
         XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
@@ -190,7 +190,7 @@ extension SchemaFragmentTests {
             // NOTE: I don't think it actually makes sense to rely more on the
             // properties (which can only belong to an array) than the explicit given
             // type "object" but for now I am going with this and will revisit later.
-        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
+        XCTAssertEqual(warnResult.value, .object(.init(), .init(properties: [:])))
     }
 
     func test_decodeFailsWithIntegerWithFloatingPointMin() {

--- a/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/SchemaFragmentTests.swift
@@ -144,7 +144,7 @@ final class SchemaFragmentTests: XCTestCase {
 // MARK: - Codable Tests
 extension SchemaFragmentTests {
 
-    func test_decodeFailsWithConflictingProperties() {
+    func test_decodeWarnsWithConflictingProperties() throws {
         let t =
         """
         {
@@ -157,10 +157,18 @@ extension SchemaFragmentTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: t))
+        let warnResult = try orderUnstableDecode(JSONSchema.self, from: t)
+
+        XCTAssertEqual(warnResult.warnings.count, 1)
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `Schema`: A schema contains properties for multiple types of schemas, namely: [\"array\", \"object\"]..")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
+
+        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
     }
 
-    func test_decodeFailsWithTypeAndPropertyConflict() {
+    func test_decodeWarnsWithTypeAndPropertyConflict() throws {
         let t =
         """
         {
@@ -171,7 +179,18 @@ extension SchemaFragmentTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: t))
+        let warnResult = try orderUnstableDecode(JSONSchema.self, from: t)
+
+        XCTAssertEqual(warnResult.warnings.count, 1)
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
+
+            // NOTE: I don't think it actually makes sense to rely more on the
+            // properties (which can only belong to an array) than the explicit given
+            // type "object" but for now I am going with this and will revisit later.
+        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
     }
 
     func test_decodeFailsWithIntegerWithFloatingPointMin() {
@@ -186,7 +205,7 @@ extension SchemaFragmentTests {
         XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: t))
     }
 
-    func test_decodeFailsWithInvalidReference() {
+    func test_decodeWarnsWithInvalidReference() throws {
         let t1 =
         """
         {
@@ -202,9 +221,23 @@ extension SchemaFragmentTests {
         }
         """.data(using: .utf8)!
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: t1))
+        let warnResult1 = try orderUnstableDecode(JSONSchema.self, from: t1)
 
-        XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: t2))
+        XCTAssertEqual(warnResult1.warnings.count, 1)
+            // NOTE: Not a very informative warning, would like to do better.
+        XCTAssertEqual(warnResult1.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found nothing but unsupported attributes..")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult1.warnings.first?.codingPathString, "")
+
+        let warnResult2 = try orderUnstableDecode(JSONSchema.self, from: t2)
+
+        XCTAssertEqual(warnResult2.warnings.count, 1)
+            // NOTE: Not a very informative warning, would like to do better.
+        XCTAssertEqual(warnResult2.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found nothing but unsupported attributes..")
+            // we are actually at the root path in this test case so the
+            // following should be an empty string!
+        XCTAssertEqual(warnResult2.warnings.first?.codingPathString, "")
     }
 
     func test_generalEncode() throws {

--- a/Tests/OpenAPIKit30Tests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/ValidatorTests.swift
@@ -1134,7 +1134,7 @@ final class ValidatorTests: XCTestCase {
         let resourceContainsName = Validation<JSONSchema>(
             description: "All JSON resources must have a String name",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let nameProperty = context.properties["name"] else {
                         return false
                 }
@@ -1145,7 +1145,7 @@ final class ValidatorTests: XCTestCase {
         let responseResourceContainsId = Validation<JSONSchema>(
             description: "All JSON response resources must have an Id",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let idProperty = context.properties["id"] else {
                         return false
                 }
@@ -1262,7 +1262,7 @@ final class ValidatorTests: XCTestCase {
         let resourceContainsName = Validation<JSONSchema>(
             description: "All JSON resources must have a String name",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let nameProperty = context.properties["name"] else {
                         return false
                 }
@@ -1273,7 +1273,7 @@ final class ValidatorTests: XCTestCase {
         let responseResourceContainsId = Validation<JSONSchema>(
             description: "All JSON response resources must have an Id",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let idProperty = context.properties["id"] else {
                         return false
                 }

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -190,7 +190,7 @@ final class PathsErrorTests: XCTestCase {
         }
     }
 
-    func test_paramSchemaHasProblemDeeplyNestedInSchema() {
+    func test_paramSchemaHasProblemDeeplyNestedInSchema() throws {
         let documentYML =
         """
         openapi: "3.1.0"
@@ -212,28 +212,27 @@ final class PathsErrorTests: XCTestCase {
                                     type: string
         """
 
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+        let warnResult = try testDecoder.decode(OpenAPI.Document.self, from: documentYML)
 
-            let openAPIError = OpenAPI.Error(from: error)
+        let openAPIError = try warnResult.validate(using: Validator.blank).first
 
-            XCTAssertEqual(
-                openAPIError.localizedDescription,
+        XCTAssertEqual(
+            openAPIError?.localizedDescription,
                 """
-                Inconsistency encountered when parsing `OpenAPI Schema` in .parameters[0].schema.properties.hi under the `/hello/world` path: Found schema attributes not consistent with the type specified: object.
+                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.
                 """
-            )
-            XCTAssertEqual(
-                openAPIError.codingPath.map { $0.stringValue },
-                [
-                    "paths",
-                    "/hello/world",
-                    "parameters",
-                    "Index 0",
-                    "schema",
-                    "properties",
-                    "hi"
-                ]
-            )
-        }
+        )
+        XCTAssertEqual(
+            openAPIError?.codingPath?.map { $0.stringValue },
+            [
+                "paths",
+                "/hello/world",
+                "parameters",
+                "Index 0",
+                "schema",
+                "properties",
+                "hi"
+            ]
+        )
     }
 }

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -219,7 +219,7 @@ final class PathsErrorTests: XCTestCase {
         XCTAssertEqual(
             openAPIError?.localizedDescription,
                 """
-                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.
+                Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].
                 """
         )
         XCTAssertEqual(

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1843,7 +1843,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(defaultValueObject.defaultValue, ["hello": false])
         XCTAssertEqual(discriminatorObject, JSONSchema.object(discriminator: .init(propertyName: "hello")))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -1972,7 +1972,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.title, "hello")
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2081,7 +2081,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.description, "hello")
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2198,7 +2198,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.externalDocs, .init(url: URL(string: "http://google.com")!))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2306,7 +2306,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2414,7 +2414,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2522,7 +2522,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2639,7 +2639,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -2669,7 +2669,7 @@ extension SchemaObjectTests {
             ])
             .with(example: AnyCodable(["hello": true]))
 
-        if case let .object(_, objectContext) = requiredObject {
+        if case let .object(_, objectContext) = requiredObject.value {
             XCTAssertEqual(objectContext.requiredProperties, [])
             XCTAssertEqual(objectContext.optionalProperties, ["hello"])
         }
@@ -2774,7 +2774,7 @@ extension SchemaObjectTests {
             ])
             .with(examples: [AnyCodable(["hello": true]), "world"])
 
-        if case let .object(_, objectContext) = requiredObject {
+        if case let .object(_, objectContext) = requiredObject.value {
             XCTAssertEqual(objectContext.requiredProperties, [])
             XCTAssertEqual(objectContext.optionalProperties, ["hello"])
         }
@@ -2907,7 +2907,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
         XCTAssertEqual(allowedValueObject.examples, [["hello" : true]])
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -3006,7 +3006,7 @@ extension SchemaObjectTests {
             ]
         )
 
-        if case let .object(_, objectContext) = requiredObject {
+        if case let .object(_, objectContext) = requiredObject.value {
             XCTAssertEqual(objectContext.requiredProperties, ["hello"])
             XCTAssertEqual(objectContext.optionalProperties, [])
         }
@@ -3119,7 +3119,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueObject.allowedValues?[0].value as! [String: Bool], ["hello": false])
         XCTAssertEqual(allowedValueObject.jsonTypeFormat, .object(.generic))
 
-        guard case let .object(_, contextB) = allowedValueObject else {
+        guard case let .object(_, contextB) = allowedValueObject.value else {
             XCTFail("expected object to be parsed as object")
             return
         }
@@ -3297,7 +3297,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(defaultValueArray.defaultValue, [false])
         XCTAssertEqual(discriminatorArray, JSONSchema.array(discriminator: .init(propertyName: "hello")))
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3383,7 +3383,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(items: .boolean(.init(format: .generic)))))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3467,7 +3467,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray.arrayContext?.uniqueItems, true)
         XCTAssertEqual(allowedValueArray.arrayContext?.uniqueItems, true)
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3527,7 +3527,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(maxItems: 3)))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }
@@ -3587,7 +3587,7 @@ extension SchemaObjectTests {
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init(minItems: 2)))
         XCTAssertEqual(allowedValueArray.allowedValues?[0].value as! [Bool], [false])
 
-        guard case let .array(_, contextB) = allowedValueArray else {
+        guard case let .array(_, contextB) = allowedValueArray.value else {
             XCTFail("expected array")
             return
         }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1426,15 +1426,12 @@ extension SchemaObjectTests {
         let warnResult = try orderUnstableDecode(JSONSchema.self, from: badSchema)
 
         XCTAssertEqual(warnResult.warnings.count, 1)
-        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].")
             // we are actually at the root path in this test case so the
             // following should be an empty string!
         XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
 
-            // NOTE: I don't think it actually makes sense to rely more on the
-            // properties (which can only belong to an array) than the explicit given
-            // type "object" but for now I am going with this and will revisit later.
-        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
+        XCTAssertEqual(warnResult.value, .object(.init(), .init(properties: [:])))
     }
 
     func test_decodeExampleFragment() throws {

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentTests.swift
@@ -182,15 +182,12 @@ extension SchemaFragmentTests {
         let warnResult = try orderUnstableDecode(JSONSchema.self, from: t)
 
         XCTAssertEqual(warnResult.warnings.count, 1)
-        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object.")
+        XCTAssertEqual(warnResult.warnings.first?.localizedDescription, "Inconsistency encountered when parsing `OpenAPI Schema`: Found schema attributes not consistent with the type specified: object. Specifically, attributes for these other types: [\"array\"].")
         // we are actually at the root path in this test case so the
         // following should be an empty string!
         XCTAssertEqual(warnResult.warnings.first?.codingPathString, "")
 
-        // NOTE: I don't think it actually makes sense to rely more on the
-        // properties (which can only belong to an array) than the explicit given
-        // type "object" but for now I am going with this and will revisit later.
-        XCTAssertEqual(warnResult.value, .array(.init(), .init(items: .string)))
+        XCTAssertEqual(warnResult.value, .object(.init(), .init(properties: [:])))
     }
 
     func test_decodeFailsWithIntegerWithFloatingPointMin() {

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1134,7 +1134,7 @@ final class ValidatorTests: XCTestCase {
         let resourceContainsName = Validation<JSONSchema>(
             description: "All JSON resources must have a String name",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let nameProperty = context.properties["name"] else {
                         return false
                 }
@@ -1145,7 +1145,7 @@ final class ValidatorTests: XCTestCase {
         let responseResourceContainsId = Validation<JSONSchema>(
             description: "All JSON response resources must have an Id",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let idProperty = context.properties["id"] else {
                         return false
                 }
@@ -1262,7 +1262,7 @@ final class ValidatorTests: XCTestCase {
         let resourceContainsName = Validation<JSONSchema>(
             description: "All JSON resources must have a String name",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let nameProperty = context.properties["name"] else {
                         return false
                 }
@@ -1273,7 +1273,7 @@ final class ValidatorTests: XCTestCase {
         let responseResourceContainsId = Validation<JSONSchema>(
             description: "All JSON response resources must have an Id",
             check: take(\.subject) { schema in
-                guard case let .object(_, context) = schema,
+                guard case let .object(_, context) = schema.value,
                     let idProperty = context.properties["id"] else {
                         return false
                 }


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/OpenAPIKit/issues/239

⚠️ Breaking Changes ⚠️ 
`JSONSchema` changes from an enum to a struct (as usual, to facilitate storage of warnings). For most code, use will not change, but if you switch over any `JSONSchemas`, you should change to switching over the newly exposed `value` property of `JSONSchema`.