### PR TITLE
Update Yams to support versions 4.x.x and 5.x.x (v3 branch)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["OpenAPIKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0") // just for tests
+        .package(url: "https://github.com/jpsim/Yams.git", "4.0.0"..<"6.0.0") // just for tests
     ],
     targets: [
         .target(


### PR DESCRIPTION
As discussed in https://github.com/mattpolzin/OpenAPIKit/issues/259, this extends the range of Yams versions supported on the v3 branch.