### PR TITLE
support trailing slashes in paths (which are sometimes required by APIs)

### DIFF
--- a/Sources/OpenAPIKitCore/Shared/Path.swift
+++ b/Sources/OpenAPIKitCore/Shared/Path.swift
@@ -12,20 +12,28 @@ extension Shared {
         /// and [OpenAPI Patterned Fields](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#patterned-fields).
     public struct Path: RawRepresentable, Equatable, Hashable {
         public let components: [String]
+        public let trailingSlash: Bool
 
-        public init(_ components: [String]) {
+        public init(_ components: [String], trailingSlash: Bool = false) {
             self.components = components
+            self.trailingSlash = trailingSlash
         }
 
         public init(rawValue: String) {
             let pathComponents = rawValue.split(separator: "/").map(String.init)
             components = pathComponents.count > 0 && pathComponents[0].isEmpty
-            ? Array(pathComponents.dropFirst())
-            : pathComponents
+                ? Array(pathComponents.dropFirst())
+                : pathComponents
+            trailingSlash = rawValue.hasSuffix("/")
         }
 
         public var rawValue: String {
-            return "/\(components.joined(separator: "/"))"
+            let path =
+                "/\(components.joined(separator: "/"))"
+
+            let suffix = trailingSlash ? "/" : ""
+
+            return path + suffix
         }
     }
 }

--- a/Tests/OpenAPIKit30Tests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKit30Tests/Path Item/PathItemTests.swift
@@ -15,17 +15,22 @@ final class PathItemTests: XCTestCase {
         let t3 = OpenAPI.Path(rawValue: "hello/world")
         let t4: OpenAPI.Path = "/hello/world"
         let t5: OpenAPI.Path = "hello/world"
+        let t6: OpenAPI.Path = "hello/world/"
+        let t7 = OpenAPI.Path(["hello", "world"], trailingSlash: true)
 
         XCTAssertEqual(t1, t2)
         XCTAssertEqual(t2, t3)
         XCTAssertEqual(t3, t4)
         XCTAssertEqual(t4, t5)
+        XCTAssertNotEqual(t5,t6)
+        XCTAssertEqual(t6, t7)
 
         XCTAssertEqual(t1.rawValue, "/hello/world")
         XCTAssertEqual(t2.rawValue, "/hello/world")
         XCTAssertEqual(t3.rawValue, "/hello/world")
         XCTAssertEqual(t4.rawValue, "/hello/world")
         XCTAssertEqual(t5.rawValue, "/hello/world")
+        XCTAssertEqual(t6.rawValue, "/hello/world/")
     }
 
     func test_initializePathItem() {

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -15,17 +15,22 @@ final class PathItemTests: XCTestCase {
         let t3 = OpenAPI.Path(rawValue: "hello/world")
         let t4: OpenAPI.Path = "/hello/world"
         let t5: OpenAPI.Path = "hello/world"
+        let t6: OpenAPI.Path = "hello/world/"
+        let t7 = OpenAPI.Path(["hello", "world"], trailingSlash: true)
 
         XCTAssertEqual(t1, t2)
         XCTAssertEqual(t2, t3)
         XCTAssertEqual(t3, t4)
         XCTAssertEqual(t4, t5)
+        XCTAssertNotEqual(t5,t6)
+        XCTAssertEqual(t6, t7)
 
         XCTAssertEqual(t1.rawValue, "/hello/world")
         XCTAssertEqual(t2.rawValue, "/hello/world")
         XCTAssertEqual(t3.rawValue, "/hello/world")
         XCTAssertEqual(t4.rawValue, "/hello/world")
         XCTAssertEqual(t5.rawValue, "/hello/world")
+        XCTAssertEqual(t6.rawValue, "/hello/world/")
     }
 
     func test_initializePathItem() {


### PR DESCRIPTION
Addresses an issue found in downstream project for OpenAPIKit 3.x: https://github.com/apple/swift-openapi-generator/issues/51