### PR TITLE
Fix simplified allOf schema optionality

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -365,7 +365,7 @@ extension JSONSchema {
         case .fragment(let context):
             return .fragment(context.optionalContext())
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.optionalContext())
+            return .all(of: fragments.map { $0.optionalSchemaObject() }, core: core.optionalContext())
         case .one(of: let schemas, core: let core):
             return .one(of: schemas, core: core.optionalContext())
         case .any(of: let schemas, core: let core):
@@ -395,7 +395,7 @@ extension JSONSchema {
         case .fragment(let context):
             return .fragment(context.requiredContext())
         case .all(of: let fragments, core: let core):
-            return .all(of: fragments, core: core.requiredContext())
+            return .all(of: fragments.map { $0.requiredSchemaObject() }, core: core.requiredContext())
         case .one(of: let schemas, core: let core):
             return .one(of: schemas, core: core.requiredContext())
         case .any(of: let schemas, core: let core):

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -911,6 +911,16 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertFalse(not.required)
         XCTAssertFalse(fragment.required)
 
+        // all fragments within required get flipped too:
+        switch(allOf) {
+        case .all(of: let schemas, core: _):
+            for schema in schemas {
+                XCTAssertFalse(schema.required)
+            }
+        default:
+            break
+        }
+
         XCTAssertTrue(reference.required)
     }
 
@@ -951,6 +961,16 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertTrue(not.required)
         XCTAssertTrue(reference.required)
         XCTAssertTrue(fragment.required)
+
+        // all fragments within required get flipped too:
+        switch(allOf) {
+        case .all(of: let schemas, core: _):
+            for schema in schemas {
+                XCTAssertTrue(schema.required)
+            }
+        default:
+            break
+        }
     }
 
     func test_notNullableToNullable() {
@@ -4805,10 +4825,10 @@ extension SchemaObjectTests {
             JSONSchema.object(
                 properties: [
                     "prop1": JSONSchema.all(
-                            of: .fragment(description: "hello"),
-                                .reference(.component(named: "test")),
-                            required: false
-                        )
+                        of: .fragment(required: false, description: "hello"),
+                            .reference(.component(named: "test")),
+                        required: false
+                    )
                 ]
             )
         )


### PR DESCRIPTION
Simplified `allOf` schemas were not taking on the correct optionality (they were always required) because the root `allOf` context was being marked optional but all of its fragments were being left required and combination of fragments starts with an optional assumption and flips to required the first time a required fragment is encountered.