### PR TITLE
Bugfix/280/path item references

### DIFF
--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -595,7 +595,7 @@ internal func decodeSecurityRequirements<CodingKeys: CodingKey>(from container: 
 
 internal func validateSecurityRequirements(in paths: OpenAPI.PathItem.Map, against components: OpenAPI.Components) throws {
     for (path, pathItem) in paths {
-        guard let pathItemValue = pathItem.pathItemValue else { continue }
+        guard let pathItemValue = components[pathItem] else { continue }
 
         for endpoint in pathItemValue.endpoints {
             if let securityRequirements = endpoint.operation.security {

--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -456,6 +456,9 @@ extension OpenAPI.Document: Decodable {
         } catch let error as DecodingError {
 
             throw OpenAPI.Error.Decoding.Document(error)
+        } catch let error as EitherDecodeNoTypesMatchedError {
+
+            throw OpenAPI.Error.Decoding.Document(error)
         }
     }
 }

--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -8,7 +8,7 @@
 import OpenAPIKitCore
 
 extension OpenAPI {
-    /// The root of an OpenAPI 3.0 document.
+    /// The root of an OpenAPI 3.1 document.
     /// 
     /// See [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md).
     ///

--- a/Sources/OpenAPIKit/Document/ResolvedDocument.swift
+++ b/Sources/OpenAPIKit/Document/ResolvedDocument.swift
@@ -125,13 +125,4 @@ public struct ResolvedDocument: Equatable {
     ///
     /// An empty security requirement in the array means that security is optional.
     public var security: [DereferencedSecurityRequirement] { underlyingDocument.security }
-
-    /// All Tags used anywhere in the document.
-    ///
-    /// The tags stored in the `OpenAPI.Document.tags`
-    /// property need not contain all tags used anywhere in
-    /// the document. This property is comprehensive.
-    public var allTags: Set<String> {
-        return underlyingDocument.allTags
-    }
 }

--- a/Sources/OpenAPIKit/Document/ResolvedDocument.swift
+++ b/Sources/OpenAPIKit/Document/ResolvedDocument.swift
@@ -125,4 +125,13 @@ public struct ResolvedDocument: Equatable {
     ///
     /// An empty security requirement in the array means that security is optional.
     public var security: [DereferencedSecurityRequirement] { underlyingDocument.security }
+
+    /// All Tags used anywhere in the document.
+    ///
+    /// The tags stored in the `OpenAPI.Document.tags`
+    /// property need not contain all tags used anywhere in
+    /// the document. This property is comprehensive.
+    public var allTags: Set<String> {
+        return underlyingDocument.allTags
+    }
 }

--- a/Sources/OpenAPIKit/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit/Either/Either+Convenience.swift
@@ -73,7 +73,7 @@ extension Either where A == DereferencedSchemaContext {
 
 extension Either where B == OpenAPI.PathItem {
     /// Retrieve the path item if that is what this property contains.
-    public var pathItem: B? { b }
+    public var pathItemValue: B? { b }
 }
 
 extension Either where B == OpenAPI.Parameter {
@@ -129,11 +129,6 @@ extension Either where B == AnyCodable {
 extension Either where B == OpenAPI.Header {
     /// Retrieve the header if that is what this property contains.
     public var headerValue: B? { b }
-}
-
-extension Either where B == OpenAPI.PathItem {
-    /// Retrieve the path item if that is what this property contains.
-    public var pathItemValue: B? { b }
 }
 
 // MARK: - Convenience constructors

--- a/Sources/OpenAPIKit/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit/Either/Either+Convenience.swift
@@ -71,6 +71,11 @@ extension Either where A == DereferencedSchemaContext {
     }
 }
 
+extension Either where B == OpenAPI.PathItem {
+    /// Retrieve the path item if that is what this property contains.
+    public var pathItem: B? { b }
+}
+
 extension Either where B == OpenAPI.Parameter {
     /// Retrieve the parameter if that is what this property contains.
     public var parameterValue: B? { b }
@@ -152,6 +157,45 @@ extension Either where B == JSONSchema {
     public static func schema(_ schema: JSONSchema) -> Self { .b(schema) }
 }
 
+extension Either where B == OpenAPI.PathItem {
+    /// Construct a path item value.
+    public static func pathItem(_ pathItem: OpenAPI.PathItem) -> Self { .b(pathItem) }
+
+    public init(
+        summary: String? = nil,
+        description: String? = nil,
+        servers: [OpenAPI.Server]? = nil,
+        parameters: OpenAPI.Parameter.Array = [],
+        get: OpenAPI.Operation? = nil,
+        put: OpenAPI.Operation? = nil,
+        post: OpenAPI.Operation? = nil,
+        delete: OpenAPI.Operation? = nil,
+        options: OpenAPI.Operation? = nil,
+        head: OpenAPI.Operation? = nil,
+        patch: OpenAPI.Operation? = nil,
+        trace: OpenAPI.Operation? = nil,
+        vendorExtensions: [String: AnyCodable] = [:]
+    ) {
+        self = .b(
+            .init(
+                summary: summary,
+                description: description,
+                servers: servers,
+                parameters: parameters,
+                get: get,
+                put: put,
+                post: post,
+                delete: delete,
+                options: options,
+                head: head,
+                patch: patch,
+                trace: trace,
+                vendorExtensions: vendorExtensions
+            )
+        )
+    }
+}
+
 extension Either where B == OpenAPI.Parameter {
     /// Construct a parameter value.
     public static func parameter(_ parameter: OpenAPI.Parameter) -> Self { .b(parameter) }
@@ -180,9 +224,4 @@ extension Either where B == OpenAPI.Response {
 extension Either where B == OpenAPI.Header {
     /// Construct a header value.
     public static func header(_ header: OpenAPI.Header) -> Self { .b(header) }
-}
-
-extension Either where B == OpenAPI.PathItem {
-    /// Construct a path item value.
-    public static func pathItem(_ pathItem: OpenAPI.PathItem) -> Self { .b(pathItem) }
 }

--- a/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
+++ b/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
@@ -73,7 +73,7 @@ extension OpenAPI.Error.Decoding.Document {
         case .path(let pathError):
             return pathError.relativeCodingPathString
         case .neither(let eitherError):
-            return eitherError.relativeCodingPathString
+            return eitherError.codingPath.stringValue
         }
     }
 

--- a/Sources/OpenAPIKit/Path Item/PathItem.swift
+++ b/Sources/OpenAPIKit/Path Item/PathItem.swift
@@ -134,7 +134,7 @@ extension OpenAPI {
 }
 
 extension OpenAPI.PathItem {
-    public typealias Map = OrderedDictionary<OpenAPI.Path, OpenAPI.PathItem>
+    public typealias Map = OrderedDictionary<OpenAPI.Path, Either<OpenAPI.Reference<OpenAPI.PathItem>, OpenAPI.PathItem>>
 }
 
 extension OrderedDictionary where Key == OpenAPI.Path {

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -252,7 +252,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all JSONSchema references are found in the document's
+    /// Validate that all non-external JSONSchema references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -274,7 +274,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Response references are found in the document's
+    /// Validate that all non-external Response references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -296,7 +296,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Parameter references are found in the document's
+    /// Validate that all non-external Parameter references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -318,7 +318,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Example references are found in the document's
+    /// Validate that all non-external Example references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -340,7 +340,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Request references are found in the document's
+    /// Validate that all non-external Request references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -362,7 +362,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Header references are found in the document's
+    /// Validate that all non-external Header references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -373,6 +373,50 @@ extension Validation {
             check: { context in
                 guard case let .internal(internalReference) = context.subject.jsonReference,
                     case .component = internalReference else {
+                        // don't make assertions about external references
+                        // TODO: could make a stronger assertion including
+                        // internal references outside of components given
+                        // some way to resolve those references.
+                        return true
+                }
+                return context.document.components.contains(internalReference)
+            }
+        )
+    }
+
+    /// Validate that all non-external Link references are found in the document's
+    /// components dictionary.
+    ///
+    /// - Important: This is included in validation by default.
+    ///
+    public static var linkReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.Link>> {
+        .init(
+            description: "Link reference can be found in components/links",
+            check: { context in
+                guard case let .internal(internalReference) = context.subject.jsonReference,
+                      case .component = internalReference else {
+                        // don't make assertions about external references
+                        // TODO: could make a stronger assertion including
+                        // internal references outside of components given
+                        // some way to resolve those references.
+                        return true
+                }
+                return context.document.components.contains(internalReference)
+            }
+        )
+    }
+
+    /// Validate that all non-external PathItem references are found in the document's
+    /// components dictionary.
+    ///
+    /// - Important: This is included in validation by default.
+    ///
+    public static var pathItemReferencesAreValid: Validation<OpenAPI.Reference<OpenAPI.PathItem>> {
+        .init(
+            description: "PathItem reference can be found in components/pathItems",
+            check: { context in
+                guard case let .internal(internalReference) = context.subject.jsonReference,
+                      case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
                         // internal references outside of components given

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -195,6 +195,8 @@ public final class Validator {
             .init(.exampleReferencesAreValid),
             .init(.requestReferencesAreValid),
             .init(.headerReferencesAreValid),
+            .init(.linkReferencesAreValid),
+            .init(.pathItemReferencesAreValid),
             .init(.serverVarialbeEnumIsValid),
             .init(.serverVarialbeDefaultExistsInEnum)
         ])

--- a/Sources/OpenAPIKit30/Components Object/Components+Locatable.swift
+++ b/Sources/OpenAPIKit30/Components Object/Components+Locatable.swift
@@ -63,6 +63,13 @@ extension OpenAPI.Link: ComponentDictionaryLocatable {
     public static var openAPIComponentsKeyPath: KeyPath<OpenAPI.Components, OpenAPI.ComponentDictionary<Self>> { \.links }
 }
 
+// Until OpenAPI 3.1, path items cannot actually be stored in the Components Object. This is here to facilitate path item
+// references, albeit in a less than ideal way.
+extension OpenAPI.PathItem: ComponentDictionaryLocatable {
+    public static var openAPIComponentsKey: String { "pathItems" }
+    public static var openAPIComponentsKeyPath: KeyPath<OpenAPI.Components, OpenAPI.ComponentDictionary<Self>> { \.pathItems }
+}
+
 /// A dereferenceable type can be recursively looked up in
 /// the `OpenAPI.Components` until there are no `JSONReferences`
 /// left in it or any of its properties.

--- a/Sources/OpenAPIKit30/Components Object/Components.swift
+++ b/Sources/OpenAPIKit30/Components Object/Components.swift
@@ -26,6 +26,7 @@ extension OpenAPI {
         public var securitySchemes: ComponentDictionary<SecurityScheme>
         public var links: ComponentDictionary<Link>
         public var callbacks: ComponentDictionary<Callbacks>
+        internal var pathItems: ComponentDictionary<PathItem>
 
         /// Dictionary of vendor extensions.
         ///
@@ -56,6 +57,9 @@ extension OpenAPI {
             self.links = links
             self.callbacks = callbacks
             self.vendorExtensions = vendorExtensions
+            // Until OpenAPI 3.1, path items cannot actually be stored in the Components Object. This is here to facilitate path item
+            // references, albeit in a less than ideal way.
+            self.pathItems = [:]
         }
 
         /// An empty OpenAPI Components Object.
@@ -145,6 +149,10 @@ extension OpenAPI.Components: Decodable {
             links = try container.decodeIfPresent(OpenAPI.ComponentDictionary<OpenAPI.Link>.self, forKey: .links) ?? [:]
 
             callbacks = try container.decodeIfPresent(OpenAPI.ComponentDictionary<OpenAPI.Callbacks>.self, forKey: .callbacks) ?? [:]
+
+            // Until OpenAPI 3.1, path items cannot actually be stored in the Components Object. This is here to facilitate path item
+            // references, albeit in a less than ideal way.
+            pathItems = [:]
 
             vendorExtensions = try Self.extensions(from: decoder)
         } catch let error as DecodingError {

--- a/Sources/OpenAPIKit30/Document/DereferencedDocument.swift
+++ b/Sources/OpenAPIKit30/Document/DereferencedDocument.swift
@@ -49,11 +49,7 @@ public struct DereferencedDocument: Equatable {
     ///     component in the same file that cannot be found in the Components Object.
     internal init(_ document: OpenAPI.Document) throws {
         self.paths = try document.paths.mapValues {
-            try DereferencedPathItem(
-                $0,
-                resolvingIn: document.components,
-                following: []
-            )
+            try $0._dereferenced(in: document.components, following: [])
         }
         self.security = try document.security.map {
             try DereferencedSecurityRequirement(
@@ -67,6 +63,7 @@ public struct DereferencedDocument: Equatable {
     }
 }
 
+// MARK: - Dereferenced Helpers
 extension DereferencedDocument {
     /// The pairing of a path and the path item that describes the
     /// route at that path.
@@ -88,6 +85,105 @@ extension DereferencedDocument {
     /// route at that path.
     public var routes: [Route] {
         return paths.map { (path, pathItem) in .init(path: path, pathItem: pathItem) }
+    }
+
+    /// Retrieve an array of all Operation Ids defined by
+    /// this API. These Ids are guaranteed to be unique by
+    /// the OpenAPI Specification.
+    ///
+    /// The ordering is not necessarily significant, but it will
+    /// be the order in which each operation is occurred within
+    /// each path, traversed in the order the paths appear in
+    /// the document.
+    ///
+    /// See [Operation Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operation-object) in the specifcation.
+    ///
+    public var allOperationIds: [String] {
+        return paths.values
+            .flatMap { $0.endpoints }
+            .compactMap { $0.operation.operationId }
+    }
+
+    /// All servers referenced anywhere in the whole document.
+    ///
+    /// This property contains all servers defined at any level the document
+    /// and therefore may or may not contain servers not found in the
+    /// root servers array.
+    ///
+    /// The `servers` property on `OpenAPI.Document`, by contrast, contains
+    /// servers that are applicable to all paths and operations that
+    /// do not define their own `serves` array to override the root array.
+    ///
+    /// - Important: For the purposes of returning one of each `Server`,
+    ///     two servers are considered identical if they have the same `url`
+    ///     and `variables`. Differing `description` properties for
+    ///     otherwise identical servers are considered to be two ways to
+    ///     describe the same server. `vendorExtensions` are also
+    ///     ignored when determining server uniqueness.
+    ///
+    ///     The first `Server` encountered will be used, so if the only
+    ///     difference between a server at the root document level and
+    ///     one in an `Operation`'s override of the servers array is the
+    ///     description, the description of the `Server` returned by this
+    ///     property will be that of the root document definition.
+    ///
+    public var allServers: [OpenAPI.Server] {
+        // We hash `Variable` without its
+        // `description` or `vendorExtensions`.
+        func hash(variable: OpenAPI.Server.Variable, into hasher: inout Hasher) {
+            hasher.combine(variable.enum)
+            hasher.combine(variable.default)
+        }
+
+        // We hash `Server` without its `description` or
+        // `vendorExtensions`.
+        func hash(server: OpenAPI.Server, into hasher: inout Hasher) {
+            hasher.combine(server.urlTemplate)
+            for (key, value) in server.variables {
+                hasher.combine(key)
+                hash(variable: value, into: &hasher)
+            }
+        }
+
+        func hash(for server: OpenAPI.Server) -> Int {
+            var hasher = Hasher()
+            hash(server: server, into: &hasher)
+            return hasher.finalize()
+        }
+
+        var collectedServers = underlyingDocument.servers
+        var seenHashes = Set(underlyingDocument.servers.map(hash(for:)))
+
+        func insertUniquely(server: OpenAPI.Server) {
+            let serverHash = hash(for: server)
+            if !seenHashes.contains(serverHash) {
+                seenHashes.insert(serverHash)
+                collectedServers.append(server)
+            }
+        }
+
+        for pathItem in paths.values {
+            let pathItemServers = pathItem.servers ?? []
+            pathItemServers.forEach(insertUniquely)
+
+            let endpointServers = pathItem.endpoints.flatMap { $0.operation.servers ?? [] }
+            endpointServers.forEach(insertUniquely)
+        }
+
+        return collectedServers
+    }
+
+    /// All Tags used anywhere in the document.
+    ///
+    /// The tags stored in the `OpenAPI.Document.tags`
+    /// property need not contain all tags used anywhere in
+    /// the document. This property is comprehensive.
+    public var allTags: Set<String> {
+        return Set(
+            (underlyingDocument.tags ?? []).map { $0.name }
+            + paths.values.flatMap { $0.endpoints }
+                .flatMap { $0.operation.tags ?? [] }
+        )
     }
 }
 

--- a/Sources/OpenAPIKit30/Document/Document.swift
+++ b/Sources/OpenAPIKit30/Document/Document.swift
@@ -427,6 +427,9 @@ extension OpenAPI.Document: Decodable {
         } catch let error as DecodingError {
 
             throw OpenAPI.Error.Decoding.Document(error)
+        } catch let error as EitherDecodeNoTypesMatchedError {
+
+            throw OpenAPI.Error.Decoding.Document(error)
         }
     }
 }

--- a/Sources/OpenAPIKit30/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit30/Either/Either+Convenience.swift
@@ -71,6 +71,11 @@ extension Either where A == DereferencedSchemaContext {
     }
 }
 
+extension Either where B == OpenAPI.PathItem {
+    /// Retrieve the path item if that is what this property contains.
+    public var pathItem: B? { b }
+}
+
 extension Either where B == OpenAPI.Parameter {
     /// Retrieve the parameter if that is what this property contains.
     public var parameterValue: B? { b }
@@ -145,6 +150,45 @@ extension Either where A == OpenAPI.Parameter.SchemaContext {
 extension Either where B == JSONSchema {
     /// Construct a schema value.
     public static func schema(_ schema: JSONSchema) -> Self { .b(schema) }
+}
+
+extension Either where B == OpenAPI.PathItem {
+    /// Construct a path item value.
+    public static func pathItem(_ pathItem: OpenAPI.PathItem) -> Self { .b(pathItem) }
+
+    public static func pathItem(
+        summary: String? = nil,
+        description: String? = nil,
+        servers: [OpenAPI.Server]? = nil,
+        parameters: OpenAPI.Parameter.Array = [],
+        get: OpenAPI.Operation? = nil,
+        put: OpenAPI.Operation? = nil,
+        post: OpenAPI.Operation? = nil,
+        delete: OpenAPI.Operation? = nil,
+        options: OpenAPI.Operation? = nil,
+        head: OpenAPI.Operation? = nil,
+        patch: OpenAPI.Operation? = nil,
+        trace: OpenAPI.Operation? = nil,
+        vendorExtensions: [String: AnyCodable] = [:]
+    ) -> Self {
+        .b(
+            .init(
+                summary: summary,
+                description: description,
+                servers: servers,
+                parameters: parameters,
+                get: get,
+                put: put,
+                post: post,
+                delete: delete,
+                options: options,
+                head: head,
+                patch: patch,
+                trace: trace,
+                vendorExtensions: vendorExtensions
+            )
+        )
+    }
 }
 
 extension Either where B == OpenAPI.Parameter {

--- a/Sources/OpenAPIKit30/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit30/Either/Either+Convenience.swift
@@ -156,7 +156,7 @@ extension Either where B == OpenAPI.PathItem {
     /// Construct a path item value.
     public static func pathItem(_ pathItem: OpenAPI.PathItem) -> Self { .b(pathItem) }
 
-    public static func pathItem(
+    public init(
         summary: String? = nil,
         description: String? = nil,
         servers: [OpenAPI.Server]? = nil,
@@ -170,8 +170,8 @@ extension Either where B == OpenAPI.PathItem {
         patch: OpenAPI.Operation? = nil,
         trace: OpenAPI.Operation? = nil,
         vendorExtensions: [String: AnyCodable] = [:]
-    ) -> Self {
-        .b(
+    ) {
+        self = .b(
             .init(
                 summary: summary,
                 description: description,

--- a/Sources/OpenAPIKit30/Either/Either+Convenience.swift
+++ b/Sources/OpenAPIKit30/Either/Either+Convenience.swift
@@ -73,7 +73,7 @@ extension Either where A == DereferencedSchemaContext {
 
 extension Either where B == OpenAPI.PathItem {
     /// Retrieve the path item if that is what this property contains.
-    public var pathItem: B? { b }
+    public var pathItemValue: B? { b }
 }
 
 extension Either where B == OpenAPI.Parameter {

--- a/Sources/OpenAPIKit30/Encoding and Decoding Errors/DocumentDecodingError.swift
+++ b/Sources/OpenAPIKit30/Encoding and Decoding Errors/DocumentDecodingError.swift
@@ -16,6 +16,7 @@ extension OpenAPI.Error.Decoding {
             case path(Path)
             case inconsistency(InconsistencyError)
             case other(Swift.DecodingError)
+            case neither(EitherDecodeNoTypesMatchedError)
         }
     }
 }
@@ -31,6 +32,9 @@ extension OpenAPI.Error.Decoding.Document {
 
         case .inconsistency(let error):
             return error.subjectName
+
+        case .neither(let eitherError):
+            return eitherError.subjectName
         }
     }
 
@@ -38,7 +42,7 @@ extension OpenAPI.Error.Decoding.Document {
         switch context {
         case .path(let pathError):
             return pathError.contextString
-        case .other, .inconsistency:
+        case .other, .inconsistency, .neither:
             return relativeCodingPathString.isEmpty
                 ? "in the root Document object"
                 : "in Document\(relativeCodingPathString)"
@@ -53,6 +57,8 @@ extension OpenAPI.Error.Decoding.Document {
             return error.errorCategory
         case .inconsistency(let error):
             return .inconsistency(details: error.details)
+        case .neither(let eitherError):
+            return eitherError.errorCategory
         }
     }
 
@@ -66,6 +72,8 @@ extension OpenAPI.Error.Decoding.Document {
                 : error.codingPath.dropLast().stringValue
         case .path(let pathError):
             return pathError.relativeCodingPathString
+        case .neither(let eitherError):
+            return eitherError.codingPath.stringValue
         }
     }
 
@@ -82,5 +90,31 @@ extension OpenAPI.Error.Decoding.Document {
     internal init(_ error: OpenAPI.Error.Decoding.Path) {
         context = .path(error)
         codingPath = error.codingPath
+    }
+
+    internal init(_ eitherError: EitherDecodeNoTypesMatchedError) {
+        if let eitherBranchToDigInto = Self.eitherBranchToDigInto(eitherError) {
+            self = Self(unwrapping: eitherBranchToDigInto)
+            return
+        }
+
+        context = .neither(eitherError)
+        codingPath = eitherError.codingPath
+    }
+}
+
+extension OpenAPI.Error.Decoding.Document: DiggingError {
+    public init(unwrapping error: Swift.DecodingError) {
+        if let decodingError = error.underlyingError as? Swift.DecodingError {
+            self = Self(unwrapping: decodingError)
+        } else if let inconsistencyError = error.underlyingError as? InconsistencyError {
+            self = Self(inconsistencyError)
+        } else if let pathError = error.underlyingError as? OpenAPI.Error.Decoding.Path {
+            self = Self(pathError)
+        } else if let eitherError = error.underlyingError as? EitherDecodeNoTypesMatchedError {
+            self = Self(eitherError)
+        } else {
+            self = Self(error)
+        }
     }
 }

--- a/Sources/OpenAPIKit30/Path Item/PathItem.swift
+++ b/Sources/OpenAPIKit30/Path Item/PathItem.swift
@@ -134,7 +134,7 @@ extension OpenAPI {
 }
 
 extension OpenAPI.PathItem {
-    public typealias Map = OrderedDictionary<OpenAPI.Path, OpenAPI.PathItem>
+    public typealias Map = OrderedDictionary<OpenAPI.Path, Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>>
 }
 
 extension OrderedDictionary where Key == OpenAPI.Path {

--- a/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
@@ -84,19 +84,20 @@ extension Validation {
                 var errors = [ValidationError]()
 
                 for (path, item) in context.subject {
+                    guard let pathItem = context.document.components[item] else { continue }
                     let variablesInPath = path.components
                         .lazy
                         .filter { $0.first == "{" && $0.last == "}" }
                         .map { String($0.dropFirst().dropLast()) }
 
                     let paramsInPathItem = Array(
-                        item.parameters
+                        pathItem.parameters
                         .lazy
                         .compactMap { context.document.components[$0] }
                         .map { $0.name }
                     )
 
-                    for endpoint in item.endpoints {
+                    for endpoint in pathItem.endpoints {
                         let paramsInOperation = Array(
                             endpoint.operation.parameters
                             .lazy

--- a/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
@@ -243,7 +243,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all JSONSchema references are found in the document's
+    /// Validate that all non-external JSONSchema references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -265,7 +265,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Response references are found in the document's
+    /// Validate that all non-external Response references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -287,7 +287,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Parameter references are found in the document's
+    /// Validate that all non-external Parameter references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -309,7 +309,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Example references are found in the document's
+    /// Validate that all non-external Example references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -331,7 +331,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Request references are found in the document's
+    /// Validate that all non-external Request references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -353,7 +353,7 @@ extension Validation {
         )
     }
 
-    /// Validate that all Header references are found in the document's
+    /// Validate that all non-external Header references are found in the document's
     /// components dictionary.
     ///
     /// - Important: This is included in validation by default.
@@ -364,6 +364,28 @@ extension Validation {
             check: { context in
                 guard case let .internal(internalReference) = context.subject,
                     case .component = internalReference else {
+                        // don't make assertions about external references
+                        // TODO: could make a stronger assertion including
+                        // internal references outside of components given
+                        // some way to resolve those references.
+                        return true
+                }
+                return context.document.components.contains(internalReference)
+            }
+        )
+    }
+
+    /// Validate that all non-external Link references are found in the document's
+    /// components dictionary.
+    ///
+    /// - Important: This is included in validation by default.
+    ///
+    public static var linkReferencesAreValid: Validation<JSONReference<OpenAPI.Link>> {
+        .init(
+            description: "Link reference can be found in components/links",
+            check: { context in
+                guard case let .internal(internalReference) = context.subject,
+                      case .component = internalReference else {
                         // don't make assertions about external references
                         // TODO: could make a stronger assertion including
                         // internal references outside of components given

--- a/Sources/OpenAPIKit30/Validator/Validator.swift
+++ b/Sources/OpenAPIKit30/Validator/Validator.swift
@@ -189,7 +189,8 @@ public final class Validator {
             .init(.parameterReferencesAreValid),
             .init(.exampleReferencesAreValid),
             .init(.requestReferencesAreValid),
-            .init(.headerReferencesAreValid)
+            .init(.headerReferencesAreValid),
+            .init(.linkReferencesAreValid)
         ])
     }
 

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -30,7 +30,7 @@ extension OpenAPIKit30.OpenAPI.Document: To31 {
             openAPIVersion: .v3_1_0,
             info: info.to31(),
             servers: servers.map { $0.to31() },
-            paths: paths.mapValues { $0.to31() },
+            paths: paths.mapValues { .pathItem($0.to31()) },
             components: components.to31(),
             security: security.map { $0.to31() },
             tags: tags?.map { $0.to31() },

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -30,7 +30,7 @@ extension OpenAPIKit30.OpenAPI.Document: To31 {
             openAPIVersion: .v3_1_0,
             info: info.to31(),
             servers: servers.map { $0.to31() },
-            paths: paths.mapValues { .pathItem($0.to31()) },
+            paths: paths.mapValues { .pathItem($0.to31()) }, // TODO: once OpenAPIKit30 has path item references, go back to just `$0.to31()`
             components: components.to31(),
             security: security.map { $0.to31() },
             tags: tags?.map { $0.to31() },

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -30,7 +30,7 @@ extension OpenAPIKit30.OpenAPI.Document: To31 {
             openAPIVersion: .v3_1_0,
             info: info.to31(),
             servers: servers.map { $0.to31() },
-            paths: paths.mapValues { .pathItem($0.to31()) }, // TODO: once OpenAPIKit30 has path item references, go back to just `$0.to31()`
+            paths: paths.mapValues { eitherRefTo31($0) },
             components: components.to31(),
             security: security.map { $0.to31() },
             tags: tags?.map { $0.to31() },

--- a/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DecodingErrorExtensions.swift
+++ b/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DecodingErrorExtensions.swift
@@ -53,8 +53,8 @@ public extension Swift.DecodingError {
             return .missing(.value)
         case .keyNotFound:
             return .missing(.key)
-        case .dataCorrupted:
-            return .dataCorrupted(underlying: underlyingError)
+        case .dataCorrupted(let context):
+            return .inconsistency(details: context.debugDescription)
         @unknown default:
             return .dataCorrupted(underlying: underlyingError)
         }

--- a/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DiggingError.swift
+++ b/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DiggingError.swift
@@ -32,7 +32,7 @@ extension DiggingError {
     /// trivially (i.e. the user does not need to know that both branches failed because one
     /// of those branches is very unlikely to have been the intended one). If that happens, it is
     /// more useful to dig into the less trivial branch and display a more granular error to the user
-    /// from deeper in that brach. When this occurs, this function retruns the udnerlying error on
+    /// from deeper in that brach. When this occurs, this function retruns the underlying error on
     /// that branch.
     public static func eitherBranchToDigInto(_ eitherError: EitherDecodeNoTypesMatchedError) -> DecodingError? {
         // Just a guard against this being an error with more than 2 branches.

--- a/Tests/OpenAPIKit30ErrorReportingTests/DocumentErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/DocumentErrorTests.swift
@@ -44,7 +44,7 @@ final class DocumentErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Could not parse `openapi` in the root Document object.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Inconsistency encountered when parsing `openapi` in the root Document object: Cannot initialize Version from invalid String value null.")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "openapi"
             ])

--- a/Tests/OpenAPIKit30ErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/OperationErrorTests.swift
@@ -27,11 +27,10 @@ final class OperationErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/hello/world']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
-                "/hello/world",
-                "get"
+                "/hello/world"
             ])
         }
     }
@@ -121,11 +120,10 @@ extension OperationErrorTests {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/one-item']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
-                "/one-item",
-                "get"
+                "/one-item"
             ])
         }
     }

--- a/Tests/OpenAPIKit30ErrorReportingTests/ResponseErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/ResponseErrorTests.swift
@@ -52,40 +52,95 @@ final class ResponseErrorTests: XCTestCase {
         }
     }
 
-    /*
+    func test_missingDescriptionResponseObject() {
+        let documentYML =
+        """
+        openapi: "3.0.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                get:
+                    responses:
+                        '200':
+                            not-a-thing: hi
+        """
 
-     The following will start failing once OrderedDictionary starts throwing an
-     error when it fails to decode a key like it should be.
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
 
-     */
+            let openAPIError = OpenAPI.Error(from: error)
 
-//    func test_badStatusCode() {
-//        let documentYML =
-//"""
-//openapi: "3.0.0"
-//info:
-//    title: test
-//    version: 1.0
-//paths:
-//    /hello/world:
-//        get:
-//            responses:
-//                'twohundred':
-//                    description: hello
-//                    content: {}
-//"""
-//
-//        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
-//
-//            let openAPIError = OpenAPI.Error(from: error)
-//
-//            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find either a $ref or a Header in .responses.200.headers.hi for the **GET** endpoint under `/hello/world` but found neither. \n\nHeader could not be decoded because:\nInconsistency encountered when parsing `Header`: A single path parameter must specify one but not both `content` and `schema`..")
-//            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
-//                "paths",
-//                "/hello/world",
-//                "get",
-//                "responses"
-//            ])
-//        }
-//    }
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Response in .responses.200 for the **GET** endpoint under `/hello/world`. \n\nResponse could not be decoded because:\nExpected to find `description` key but it is missing..")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
+                "paths",
+                "/hello/world",
+                "get",
+                "responses",
+                "200"
+            ])
+        }
+    }
+
+    func test_badResponseExtension() {
+        let documentYML =
+        """
+        openapi: "3.0.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                get:
+                    responses:
+                        '200':
+                            description: described
+                            not-a-thing: hi
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a Response in .responses.200 for the **GET** endpoint under `/hello/world`. \n\nResponse could not be decoded because:\nInconsistency encountered when parsing `Vendor Extension`: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ not-a-thing ]..")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
+                "paths",
+                "/hello/world",
+                "get",
+                "responses",
+                "200"
+            ])
+        }
+    }
+
+    func test_badStatusCode() {
+        let documentYML =
+        """
+        openapi: "3.0.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                get:
+                    responses:
+                        'twohundred':
+                            description: hello
+                            content: {}
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Expected `twohundred` value in .responses for the **GET** endpoint under `/hello/world` to be parsable as ResponseStatusCode but it was not.")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
+                "paths",
+                "/hello/world",
+                "get",
+                "responses",
+                "twohundred"
+            ])
+        }
+    }
 }

--- a/Tests/OpenAPIKit30RealSpecSuite/GitHubAPITests.swift
+++ b/Tests/OpenAPIKit30RealSpecSuite/GitHubAPITests.swift
@@ -92,13 +92,13 @@ final class GitHubAPICampatibilityTests: XCTestCase {
         XCTAssert(apiDoc.paths.contains(key: "/app/installations/{installation_id}/access_tokens"))
 
         // check for a known POST response
-        XCTAssertNotNil(apiDoc.paths["/app/installations/{installation_id}/access_tokens"]?.post?.responses[status: 201])
+        XCTAssertNotNil(apiDoc.paths["/app/installations/{installation_id}/access_tokens"]?.pathItemValue?.post?.responses[status: 201])
 
         // and a known GET response
-        XCTAssertNotNil(apiDoc.paths["/app/installations/{installation_id}"]?.get?.responses[status: 200])
+        XCTAssertNotNil(apiDoc.paths["/app/installations/{installation_id}"]?.pathItemValue?.get?.responses[status: 200])
 
         // check for parameters
-        XCTAssertFalse(apiDoc.paths["/app/installations/{installation_id}"]?.get?.parameters.isEmpty ?? true)
+        XCTAssertFalse(apiDoc.paths["/app/installations/{installation_id}"]?.pathItemValue?.get?.parameters.isEmpty ?? true)
     }
 
     func test_successfullyParsedComponents() throws {
@@ -120,7 +120,7 @@ final class GitHubAPICampatibilityTests: XCTestCase {
 
         let installationsPath = apiDoc.paths["/app/installations/{installation_id}"]
 
-        let installationsParameters = try installationsPath?.get?.parameters.compactMap(apiDoc.components.lookup)
+        let installationsParameters = try installationsPath?.pathItemValue?.get?.parameters.compactMap(apiDoc.components.lookup)
 
         XCTAssertNotNil(installationsParameters)
         XCTAssertEqual(installationsParameters?.count, 1)

--- a/Tests/OpenAPIKit30RealSpecSuite/GoogleBooksAPITests.swift
+++ b/Tests/OpenAPIKit30RealSpecSuite/GoogleBooksAPITests.swift
@@ -86,13 +86,13 @@ final class GoogleBooksAPICampatibilityTests: XCTestCase {
         XCTAssert(apiDoc.paths.contains(key: "/books/v1/familysharing/share"))
 
         // check for a known POST response
-        XCTAssertNotNil(apiDoc.paths["/books/v1/cloudloading/addBook"]?.post?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/books/v1/cloudloading/addBook"]?.pathItemValue?.post?.responses[200 as OpenAPI.Response.StatusCode])
 
         // and a known GET response
-        XCTAssertNotNil(apiDoc.paths["/books/v1/dictionary/listOfflineMetadata"]?.get?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/books/v1/dictionary/listOfflineMetadata"]?.pathItemValue?.get?.responses[200 as OpenAPI.Response.StatusCode])
 
         // check for parameters
-        XCTAssertFalse(apiDoc.paths["/books/v1/dictionary/listOfflineMetadata"]?.parameters.isEmpty ?? true)
+        XCTAssertFalse(apiDoc.paths["/books/v1/dictionary/listOfflineMetadata"]?.pathItemValue?.parameters.isEmpty ?? true)
     }
 
     func test_successfullyParsedComponents() throws {
@@ -112,7 +112,7 @@ final class GoogleBooksAPICampatibilityTests: XCTestCase {
     func test_someReferences() throws {
         guard let apiDoc = apiDoc else { return }
 
-        let addBooksPath = apiDoc.paths["/books/v1/cloudloading/addBook"]
+        let addBooksPath = apiDoc.paths["/books/v1/cloudloading/addBook"]?.pathItemValue
 
         let addBooksParameters = addBooksPath?.parameters.compactMap { apiDoc.components[$0] }
 

--- a/Tests/OpenAPIKit30RealSpecSuite/PetStoreAPITests.swift
+++ b/Tests/OpenAPIKit30RealSpecSuite/PetStoreAPITests.swift
@@ -88,16 +88,16 @@ final class PetStoreAPICampatibilityTests: XCTestCase {
         XCTAssert(apiDoc.paths.contains(key: "/store/inventory"))
 
         // check for a known POST response
-        XCTAssertNotNil(apiDoc.paths["/pet/{petId}/uploadImage"]?.post?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/pet/{petId}/uploadImage"]?.pathItemValue?.post?.responses[200 as OpenAPI.Response.StatusCode])
 
         // and a known GET response
-        XCTAssertNotNil(apiDoc.paths["/pet/{petId}"]?.get?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/pet/{petId}"]?.pathItemValue?.get?.responses[200 as OpenAPI.Response.StatusCode])
 
         // check for parameters
-        XCTAssertFalse(apiDoc.paths["/pet/{petId}"]?.get?.parameters.isEmpty ?? true)
-        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.name, "petId")
-        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.context, .path)
-        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.get?.parameters.first?.parameterValue?.schemaOrContent.schemaValue, .integer(format: .int64))
+        XCTAssertFalse(apiDoc.paths["/pet/{petId}"]?.pathItemValue?.get?.parameters.isEmpty ?? true)
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.pathItemValue?.get?.parameters.first?.parameterValue?.name, "petId")
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.pathItemValue?.get?.parameters.first?.parameterValue?.context, .path)
+        XCTAssertEqual(apiDoc.paths["/pet/{petId}"]?.pathItemValue?.get?.parameters.first?.parameterValue?.schemaOrContent.schemaValue, .integer(format: .int64))
     }
 
     func test_successfullyParsedComponents() throws {

--- a/Tests/OpenAPIKit30RealSpecSuite/SwaggerDocSamplesTests.swift
+++ b/Tests/OpenAPIKit30RealSpecSuite/SwaggerDocSamplesTests.swift
@@ -68,7 +68,7 @@ final class SwaggerDocSamplesTests: XCTestCase {
             try doc.validate()
 
             XCTAssertEqual(
-                doc.paths["/pets"]?.patch?.requestBody?.requestValue?
+                doc.paths["/pets"]?.pathItemValue?.patch?.requestBody?.requestValue?
                     .content[.json]?.schema?.schemaValue,
                 JSONSchema.one(
                     of: .reference(.component(named: "Cat")),

--- a/Tests/OpenAPIKit30RealSpecSuite/TomTomAPITests.swift
+++ b/Tests/OpenAPIKit30RealSpecSuite/TomTomAPITests.swift
@@ -82,13 +82,13 @@ final class TomTomAPICampatibilityTests: XCTestCase {
         XCTAssert(apiDoc.paths.contains(key: "/search/{versionNumber}/geometrySearch/{query}.{ext}"))
 
         // check for a known POST response
-        XCTAssertNotNil(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.post?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.pathItemValue?.post?.responses[200 as OpenAPI.Response.StatusCode])
 
         // and a known GET response
-        XCTAssertNotNil(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.get?.responses[200 as OpenAPI.Response.StatusCode])
+        XCTAssertNotNil(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.pathItemValue?.get?.responses[200 as OpenAPI.Response.StatusCode])
 
         // check for parameters
-        XCTAssertFalse(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.get?.parameters.isEmpty ?? true)
+        XCTAssertFalse(apiDoc.paths["/search/{versionNumber}/geometrySearch/{query}.{ext}"]?.pathItemValue?.get?.parameters.isEmpty ?? true)
     }
 
     func test_successfullyParsedComponents() throws {

--- a/Tests/OpenAPIKit30Tests/ComponentsTests.swift
+++ b/Tests/OpenAPIKit30Tests/ComponentsTests.swift
@@ -177,6 +177,9 @@ final class ComponentsTests: XCTestCase {
         let components = OpenAPI.Components(
             schemas: [
                 "hello": .boolean
+            ],
+            links: [
+                "linky": .init(operationId: "op 1")
             ]
         )
 
@@ -197,6 +200,13 @@ final class ComponentsTests: XCTestCase {
 
         XCTAssertThrowsError(try components.lookup(schema3)) { error in
             XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .cannotLookupRemoteReference)
+        }
+
+        let link1: Either<JSONReference<OpenAPI.Link>, OpenAPI.Link> = .reference(.component(named: "hello"))
+
+        XCTAssertThrowsError(try components.lookup(link1)) { error in
+            XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .missingOnLookup(name: "hello", key: "links"))
+            XCTAssertEqual((error as? OpenAPI.Components.ReferenceError)?.description, "Failed to look up a JSON Reference. 'hello' was not found in links.")
         }
 
         let reference1: JSONReference<JSONSchema> = .component(named: "hello")

--- a/Tests/OpenAPIKit30Tests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKit30Tests/Document/DocumentTests.swift
@@ -63,8 +63,8 @@ final class DocumentTests: XCTestCase {
                 .init(url: URL(string: "https://google.com")!)
             ],
             paths: [
-                "/hi/there": pi1,
-                "/hi": pi2
+                "/hi/there": .pathItem(pi1),
+                "/hi": .pathItem(pi2)
             ],
             components: .init(schemas: ["hello": .string])
         )

--- a/Tests/OpenAPIKit30Tests/EaseOfUseTests.swift
+++ b/Tests/OpenAPIKit30Tests/EaseOfUseTests.swift
@@ -267,7 +267,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
             info: apiInfo,
             servers: [server],
             paths: [
-                "/test/api/endpoint/{param}": testRoute
+                "/test/api/endpoint/{param}": .pathItem(testRoute)
             ],
             components: components,
             security: [],
@@ -430,13 +430,17 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
         let document = testDocument
 
         // get endpoints for each path
-        let endpoints = document.paths.mapValues { $0.endpoints }
+        let endpoints = document.paths.mapValues { $0.pathItemValue?.endpoints ?? [] }
 
         // count endpoints by HTTP method
         let endpointMethods = endpoints.values.flatMap { $0 }.map { $0.method }
         let countByMethod = Dictionary(grouping: endpointMethods, by: { $0 }).mapValues { $0.count }
         XCTAssertEqual(countByMethod[.get], 2)
         XCTAssertEqual(countByMethod[.post], 1)
+
+        let easyMode = document.routes.flatMap { $0.pathItem.endpoints }
+        XCTAssertEqual(endpoints.count, easyMode.count)
+        XCTAssertEqual(endpoints.values.flatMap { $0.self }, easyMode)
     }
 
     func test_resolveSecurity() {
@@ -453,7 +457,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
     func test_getResponseSchema() {
         let document = testDocument
 
-        let endpoint = document.paths["/widgets/{id}"]?.get
+        let endpoint = document.paths["/widgets/{id}"]?.pathItemValue?.get
         let response = endpoint?.responses[status: 200]?.responseValue
         let responseSchemaReference = response?.content[.json]?.schema
         // this response schema is a reference found in the Components Object. We dereference
@@ -466,7 +470,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
     func test_getRequestSchema() {
         let document = testDocument
 
-        let endpoint = document.paths["/widgets/{id}"]?.post
+        let endpoint = document.paths["/widgets/{id}"]?.pathItemValue?.post
         let request = endpoint?.requestBody?.requestValue
         let requestSchemaReference = request?.content[.json]?.schema
         // this request schema is defined inline but dereferencing still produces the schema
@@ -509,7 +513,7 @@ fileprivate let testDocument =  OpenAPI.Document(
     info: testInfo,
     servers: [testServer],
     paths: [
-        "/widgets/{id}": OpenAPI.PathItem(
+        "/widgets/{id}": .init(
             parameters: [
                 .parameter(
                     name: "id",
@@ -554,7 +558,7 @@ fileprivate let testDocument =  OpenAPI.Document(
                 ]
             )
         ),
-        "/docs": OpenAPI.PathItem(
+        "/docs": .init(
             get: OpenAPI.Operation(
                 tags: "Documentation",
                 responses: [

--- a/Tests/OpenAPIKit30Tests/EaseOfUseTests.swift
+++ b/Tests/OpenAPIKit30Tests/EaseOfUseTests.swift
@@ -439,7 +439,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
         XCTAssertEqual(countByMethod[.post], 1)
 
         let easyMode = document.routes.flatMap { $0.pathItem.endpoints }
-        XCTAssertEqual(endpoints.count, easyMode.count)
+        XCTAssertEqual(endpoints.reduce(0, { sum, next in sum + next.value.count }), easyMode.count)
         XCTAssertEqual(endpoints.values.flatMap { $0.self }, easyMode)
     }
 

--- a/Tests/OpenAPIKit30Tests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKit30Tests/Path Item/PathItemTests.swift
@@ -420,7 +420,8 @@ extension PathItemTests {
     func test_pathItemMap_encode() throws {
         let map: OpenAPI.PathItem.Map = [
             "/hello/world": .init(),
-            "hi/there": .init()
+            "hi/there": .init(),
+            "/reference/": .reference(.component(named: "pathRef"))
         ]
 
         let encodedMap = try orderUnstableTestStringFromEncoding(of: map)
@@ -434,6 +435,9 @@ extension PathItemTests {
               },
               "\\/hi\\/there" : {
 
+              },
+              "\\/reference\\/" : {
+                "$ref" : "#\\/components\\/pathItems\\/pathRef"
               }
             }
             """
@@ -449,6 +453,9 @@ extension PathItemTests {
           },
           "\\/hi\\/there" : {
 
+          },
+          "\\/reference\\/" : {
+            "$ref" : "#\\/components\\/pathItems\\/pathRef"
           }
         }
         """.data(using: .utf8)!
@@ -459,7 +466,8 @@ extension PathItemTests {
             map,
             [
                 "/hello/world": .init(),
-                "/hi/there": .init()
+                "/hi/there": .init(),
+                "/reference/": .reference(.component(named: "pathRef"))
             ]
         )
     }

--- a/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
@@ -1063,7 +1063,7 @@ final class SchemaObjectTests: XCTestCase {
             .with(allowedValues: ["hello"])
 
         XCTAssertEqual(boolean.allowedValues, [false])
-        XCTAssertEqual(object.allowedValues, [AnyCodable([:])])
+        XCTAssertEqual(object.allowedValues, [AnyCodable([String: String]())])
         XCTAssertEqual(array.allowedValues?[0].value as! [Bool], [false])
         XCTAssertEqual(number.allowedValues, [2.5])
         XCTAssertEqual(integer.allowedValues, [5])
@@ -1124,7 +1124,7 @@ final class SchemaObjectTests: XCTestCase {
             .with(defaultValue: "hello")
 
         XCTAssertEqual(boolean.defaultValue, false)
-        XCTAssertEqual(object.defaultValue, AnyCodable([:]))
+        XCTAssertEqual(object.defaultValue, AnyCodable([String: String]()))
         XCTAssertEqual(array.defaultValue, [false])
         XCTAssertEqual(number.defaultValue, 2.5)
         XCTAssertEqual(integer.defaultValue, 5)

--- a/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
@@ -629,7 +629,8 @@ final class BuiltinValidationTests: XCTestCase {
                                 ]
                             ),
                             .xml: .init(schemaReference: .component(named: "schema1"))
-                        ]
+                        ],
+                        links: ["linky": .reference(.component(named: "link1"))]
                     )
                 ]
             )
@@ -647,7 +648,7 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         XCTAssertThrowsError(try document.validate()) { error in
             let error = error as? ValidationErrorCollection
-            XCTAssertEqual(error?.values.count, 6)
+            XCTAssertEqual(error?.values.count, 7)
             XCTAssertEqual(error?.values[0].reason, "Failed to satisfy: Parameter reference can be found in components/parameters")
             XCTAssertEqual(error?.values[0].codingPathString, ".paths['/hello'].get.parameters[0]")
             XCTAssertEqual(error?.values[1].reason, "Failed to satisfy: Request reference can be found in components/requestBodies")
@@ -660,6 +661,8 @@ final class BuiltinValidationTests: XCTestCase {
             XCTAssertEqual(error?.values[4].codingPathString, ".paths['/hello'].get.responses.404.content['application/json'].examples.example1")
             XCTAssertEqual(error?.values[5].reason, "Failed to satisfy: JSONSchema reference can be found in components/schemas")
             XCTAssertEqual(error?.values[5].codingPathString, ".paths['/hello'].get.responses.404.content['application/xml'].schema")
+            XCTAssertEqual(error?.values[6].reason, "Failed to satisfy: Link reference can be found in components/links")
+            XCTAssertEqual(error?.values[6].codingPathString, ".paths['/hello'].get.responses.404.links.linky")
         }
     }
 
@@ -696,7 +699,8 @@ final class BuiltinValidationTests: XCTestCase {
                             ),
                             .xml: .init(schemaReference: .component(named: "schema1")),
                             .txt: .init(schemaReference: .external(URL(string: "https://website.com/file.json#/hello/world")!))
-                        ]
+                        ],
+                        links: ["linky": .reference(.component(named: "link1"))]
                     )
                 ]
             )
@@ -726,6 +730,9 @@ final class BuiltinValidationTests: XCTestCase {
                 ],
                 headers: [
                     "header1": .init(schema: .string)
+                ],
+                links: [
+                    "link1": .init(operationId: "op 1")
                 ]
             )
         )

--- a/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
@@ -639,7 +639,7 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": path
+                "/hello": .pathItem(path)
             ],
             components: .noComponents
         )
@@ -706,7 +706,7 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": path
+                "/hello": .pathItem(path)
             ],
             components: .init(
                 schemas: [

--- a/Tests/OpenAPIKit30Tests/Validator/Validation+ConvenienceTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/Validation+ConvenienceTests.swift
@@ -302,7 +302,7 @@ final class ValidationConvenienceTests: XCTestCase {
             )
         )
 
-        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!, codingPath: [])
+        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!.pathItemValue!, codingPath: [])
 
         // passses
         XCTAssertTrue(
@@ -348,19 +348,19 @@ final class ValidationConvenienceTests: XCTestCase {
 
         // passes
         XCTAssertTrue(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[0], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[0], thenApply: v)(context).isEmpty
         )
         // wrong name
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[1], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[1], thenApply: v)(context).isEmpty
         )
         // not found reference
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[2], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[2], thenApply: v)(context).isEmpty
         )
         // nil keypath
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.parameters.first, thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.pathItemValue?.parameters.first, thenApply: v)(context).isEmpty
         )
     }
 

--- a/Tests/OpenAPIKit30Tests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/ValidatorTests.swift
@@ -1432,7 +1432,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItemValue?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 
@@ -1471,7 +1471,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItemValue?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -429,7 +429,14 @@ fileprivate func assertEqualNewToOld(_ newDoc: OpenAPIKit.OpenAPI.Document, _ ol
     XCTAssertEqual(newDoc.paths.count, oldDoc.paths.count)
     for (path, newPathItem) in newDoc.paths {
         let oldPathItem = try XCTUnwrap(oldDoc.paths[path])
-        try assertEqualNewToOld(newPathItem.pathItemValue, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
+        switch (newPathItem, oldPathItem) {
+        case (.a(let ref), .a(let ref2)):
+            XCTAssertEqual(ref.absoluteString, ref2.absoluteString)
+        case (.b(let pathItem), .b(let pathItem2)):
+            try assertEqualNewToOld(pathItem, pathItem2)
+        default:
+            XCTFail("One path had a reference and the other had a concrete path item. \(newPathItem)    /    \(oldPathItem)")
+        }
     }
 
     // COMPONENTS

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -429,7 +429,7 @@ fileprivate func assertEqualNewToOld(_ newDoc: OpenAPIKit.OpenAPI.Document, _ ol
     XCTAssertEqual(newDoc.paths.count, oldDoc.paths.count)
     for (path, newPathItem) in newDoc.paths {
         let oldPathItem = try XCTUnwrap(oldDoc.paths[path])
-        try assertEqualNewToOld(newPathItem.pathItem, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
+        try assertEqualNewToOld(newPathItem.pathItemValue, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
     }
 
     // COMPONENTS

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -216,7 +216,7 @@ fileprivate func assertEqualOldToNew(_ newDoc: OpenAPIKit.OpenAPI.Document, _ ol
     XCTAssertEqual(newDoc.paths.count, oldDoc.paths.count)
     for (path, newPathItem) in newDoc.paths {
         let oldPathItem = try XCTUnwrap(oldDoc.paths[path])
-        try assertEqualOldToNew(newPathItem, oldPathItem)
+        try assertEqualOldToNew(newPathItem.pathItem, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
     }
 
     // COMPONENTS
@@ -266,7 +266,13 @@ fileprivate func assertEqualOldToNew(_ newParamArray: OpenAPIKit.OpenAPI.Paramet
     }
 }
 
-fileprivate func assertEqualOldToNew(_ newPathItem: OpenAPIKit.OpenAPI.PathItem, _ oldPathItem: OpenAPIKit30.OpenAPI.PathItem) throws {
+fileprivate func assertEqualOldToNew(_ newPathItem: OpenAPIKit.OpenAPI.PathItem?, _ oldPathItem: OpenAPIKit30.OpenAPI.PathItem?) throws {
+    guard let newPathItem = newPathItem else {
+        XCTAssertNil(oldPathItem)
+        return
+    }
+    let oldPathItem = try XCTUnwrap(oldPathItem)
+
     XCTAssertEqual(newPathItem.summary, oldPathItem.summary)
     XCTAssertEqual(newPathItem.description, oldPathItem.description)
     if let newServers = newPathItem.servers {

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -429,7 +429,7 @@ fileprivate func assertEqualNewToOld(_ newDoc: OpenAPIKit.OpenAPI.Document, _ ol
     XCTAssertEqual(newDoc.paths.count, oldDoc.paths.count)
     for (path, newPathItem) in newDoc.paths {
         let oldPathItem = try XCTUnwrap(oldDoc.paths[path])
-        try assertEqualOldToNew(newPathItem.pathItem, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
+        try assertEqualNewToOld(newPathItem.pathItem, oldPathItem) // TODO: switch back to not only testing the non-reference case once OpenAPIKit30 has gained the ability to reference path items as well.
     }
 
     // COMPONENTS
@@ -496,7 +496,7 @@ fileprivate func assertEqualNewToOld(_ newParamArray: OpenAPIKit.OpenAPI.Paramet
     }
 }
 
-fileprivate func assertEqualOldToNew(_ newPathItem: OpenAPIKit.OpenAPI.PathItem?, _ oldPathItem: OpenAPIKit30.OpenAPI.PathItem?) throws {
+fileprivate func assertEqualNewToOld(_ newPathItem: OpenAPIKit.OpenAPI.PathItem?, _ oldPathItem: OpenAPIKit30.OpenAPI.PathItem?) throws {
     guard let newPathItem = newPathItem else {
         XCTAssertNil(oldPathItem)
         return

--- a/Tests/OpenAPIKitErrorReportingTests/DocumentErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/DocumentErrorTests.swift
@@ -44,7 +44,7 @@ final class DocumentErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Could not parse `openapi` in the root Document object.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Inconsistency encountered when parsing `openapi` in the root Document object: Cannot initialize Version from invalid String value null.")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "openapi"
             ])

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -120,7 +120,7 @@ extension OperationErrorTests {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing..")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/one-item']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
                 "/one-item"

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -27,11 +27,10 @@ final class OperationErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
-                "/hello/world",
-                "get"
+                "/hello/world"
             ])
         }
     }
@@ -121,11 +120,10 @@ extension OperationErrorTests {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Expected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing.")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
-                "/one-item",
-                "get"
+                "/one-item"
             ])
         }
     }

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -27,7 +27,7 @@ final class OperationErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing..")
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/hello/world']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing..")
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
                 "paths",
                 "/hello/world"

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -51,6 +51,27 @@ final class PathsErrorTests: XCTestCase {
         }
     }
 
+    func test_wayOffMarkForPathItemOrReference() {
+        let documentYML =
+        """
+        openapi: "3.1.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world: {"boo": 123}
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/hello/world']. \n\nPathItem could not be decoded because:\nInconsistency encountered when parsing `Vendor Extension` under the `/hello/world` path: Found at least one vendor extension property that does not begin with the required 'x-' prefix. Invalid properties: [ boo ].."
+            )
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["paths", "/hello/world"])
+        }
+    }
+
     func test_wrongTypeParameter() {
         let documentYML =
         """

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -45,7 +45,7 @@ final class PathsErrorTests: XCTestCase {
 
             let openAPIError = OpenAPI.Error(from: error)
 
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nReference<PathItem> could not be decoded because:\nInconsistency encountered when parsing `$ref`: Expected a reference string, but found an empty string instead..."
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/hello/world']. \n\nReference<PathItem> could not be decoded because:\nInconsistency encountered when parsing `$ref`: Expected a reference string, but found an empty string instead..."
             )
             XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["paths", "/hello/world"])
         }

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -29,6 +29,28 @@ final class PathsErrorTests: XCTestCase {
         }
     }
 
+    func test_badPathReference() {
+        let documentYML =
+        """
+        openapi: "3.1.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                $ref: ''
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths. \n\nReference<PathItem> could not be decoded because:\nInconsistency encountered when parsing `$ref`: Expected a reference string, but found an empty string instead..."
+            )
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["paths", "/hello/world"])
+        }
+    }
+
     func test_wrongTypeParameter() {
         let documentYML =
         """

--- a/Tests/OpenAPIKitTests/ComponentsTests.swift
+++ b/Tests/OpenAPIKitTests/ComponentsTests.swift
@@ -120,6 +120,9 @@ final class ComponentsTests: XCTestCase {
                 "nine": [
                     OpenAPI.CallbackURL(rawValue: "{$url}")!: .pathItem(.init(post: .init(responses: [:])))
                 ]
+            ],
+            pathItems: [
+                "ten": .init(get: .init(responses: [:]))
             ]
         )
 
@@ -132,6 +135,7 @@ final class ComponentsTests: XCTestCase {
         let ref7 = try components.reference(named: "seven", ofType: OpenAPI.SecurityScheme.self)
         let ref8 = try components.reference(named: "eight", ofType: OpenAPI.Link.self)
         let ref9 = try components.reference(named: "nine", ofType: OpenAPI.Callbacks.self)
+        let ref10 = try components.reference(named: "ten", ofType: OpenAPI.PathItem.self)
 
         XCTAssertEqual(components[ref1], .string)
         XCTAssertEqual(components[ref2], .init(description: "hello", content: [:]))
@@ -147,6 +151,7 @@ final class ComponentsTests: XCTestCase {
                 OpenAPI.CallbackURL(rawValue: "{$url}")!: .pathItem(.init(post: .init(responses: [:])))
             ]
         )
+        XCTAssertEqual(components[ref10], .init(get: .init(responses: [:])))
     }
 
     func test_subscriptLookup() throws {
@@ -311,6 +316,9 @@ extension ComponentsTests {
                     )
                 ]
             ],
+            pathItems: [
+                "ten": .init(get: .init(responses: [200: .response(description: "response")]))
+            ],
             vendorExtensions: ["x-specialFeature": ["hello", "world"]]
         )
 
@@ -357,6 +365,17 @@ extension ComponentsTests {
                   },
                   "in" : "query",
                   "name" : "hi"
+                }
+              },
+              "pathItems" : {
+                "ten" : {
+                  "get" : {
+                    "responses" : {
+                      "200" : {
+                        "description" : "response"
+                      }
+                    }
+                  }
                 }
               },
               "requestBodies" : {
@@ -434,6 +453,17 @@ extension ComponentsTests {
               "name" : "hi"
             }
           },
+          "pathItems" : {
+            "ten" : {
+              "get" : {
+                "responses" : {
+                  "200" : {
+                    "description" : "response"
+                  }
+                }
+              }
+            }
+          },
           "requestBodies" : {
             "five" : {
               "content" : {
@@ -507,6 +537,9 @@ extension ComponentsTests {
                             )
                         )
                     ]
+                ],
+                pathItems: [
+                    "ten": .init(get: .init(responses: [200: .response(description: "response")]))
                 ],
                 vendorExtensions: ["x-specialFeature": ["hello", "world"]]
             )

--- a/Tests/OpenAPIKitTests/ComponentsTests.swift
+++ b/Tests/OpenAPIKitTests/ComponentsTests.swift
@@ -177,6 +177,9 @@ final class ComponentsTests: XCTestCase {
         let components = OpenAPI.Components(
             schemas: [
                 "hello": .boolean
+            ],
+            links: [
+                "linky": .init(operationId: "op 1")
             ]
         )
 
@@ -197,6 +200,13 @@ final class ComponentsTests: XCTestCase {
 
         XCTAssertThrowsError(try components.lookup(schema3)) { error in
             XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .cannotLookupRemoteReference)
+        }
+
+        let link1: Either<OpenAPI.Reference<OpenAPI.Link>, OpenAPI.Link> = .reference(.component(named: "hello"))
+
+        XCTAssertThrowsError(try components.lookup(link1)) { error in
+            XCTAssertEqual(error as? OpenAPI.Components.ReferenceError, .missingOnLookup(name: "hello", key: "links"))
+            XCTAssertEqual((error as? OpenAPI.Components.ReferenceError)?.description, "Failed to look up a JSON Reference. 'hello' was not found in links.")
         }
 
         let reference1: JSONReference<JSONSchema> = .component(named: "hello")

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -25,14 +25,14 @@ final class DocumentTests: XCTestCase {
                 .init(url: URL(string: "https://google.com")!)
             ],
             paths: [
-                "/hi/there": .init(
+                "/hi/there": .pathItem(.init(
                     parameters: [],
                     get: .init(
                         tags: "hi",
                         parameters: [],
                         responses: [:]
                     )
-                )
+                ))
             ],
             components: .init(schemas: ["hello": .string]),
             security: [],
@@ -41,7 +41,7 @@ final class DocumentTests: XCTestCase {
         )
     }
 
-    func test_getRoutes() {
+    func test_getRoutes() throws {
         let pi1 = OpenAPI.PathItem(
             parameters: [],
             get: .init(
@@ -63,14 +63,14 @@ final class DocumentTests: XCTestCase {
                 .init(url: URL(string: "https://google.com")!)
             ],
             paths: [
-                "/hi/there": pi1,
-                "/hi": pi2
+                "/hi/there": .pathItem(pi1),
+                "/hi": .pathItem(pi2)
             ],
             components: .init(schemas: ["hello": .string])
         )
 
         XCTAssertEqual(
-            test.routes,
+            try test.routes(),
             [
                 .init(path: "/hi/there", pathItem: pi1),
                 .init(path: "/hi", pathItem: pi2)
@@ -78,70 +78,70 @@ final class DocumentTests: XCTestCase {
         )
     }
 
-    func test_getAllOperationIds() {
+    func test_getAllOperationIds() throws {
         let t1 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .init(
-                    get: .init(operationId: nil, responses: [:])
+                "/hello": .pathItem(.init(
+                    get: .init(operationId: nil, responses: [:]))
                 ),
-                "/hello/world": .init(
-                    put: .init(operationId: nil, responses: [:])
+                "/hello/world": .pathItem(.init(
+                    put: .init(operationId: nil, responses: [:]))
                 )
             ],
             components: .noComponents
         )
 
-        XCTAssertEqual(t1.allOperationIds, [])
+        XCTAssertEqual(try t1.allOperationIds(), [])
 
         let t2 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .init(
-                    get: .init(operationId: "test", responses: [:])
+                "/hello": .pathItem(.init(
+                    get: .init(operationId: "test", responses: [:]))
                 ),
-                "/hello/world": .init(
-                    put: .init(operationId: nil, responses: [:])
+                "/hello/world": .pathItem(.init(
+                    put: .init(operationId: nil, responses: [:]))
                 )
             ],
             components: .noComponents
         )
 
-        XCTAssertEqual(t2.allOperationIds, ["test"])
+        XCTAssertEqual(try t2.allOperationIds(), ["test"])
 
         let t3 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .init(
-                    get: .init(operationId: "test", responses: [:])
+                "/hello": .pathItem(.init(
+                    get: .init(operationId: "test", responses: [:]))
                 ),
-                "/hello/world": .init(
-                    put: .init(operationId: "two", responses: [:])
+                "/hello/world": .pathItem(.init(
+                    put: .init(operationId: "two", responses: [:]))
                 )
             ],
             components: .noComponents
         )
 
-        XCTAssertEqual(t3.allOperationIds, ["test", "two"])
+        XCTAssertEqual(try t3.allOperationIds(), ["test", "two"])
 
         let t4 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .init(
-                    get: .init(operationId: nil, responses: [:])
+                "/hello": .pathItem(.init(
+                    get: .init(operationId: nil, responses: [:]))
                 ),
-                "/hello/world": .init(
-                    put: .init(operationId: "two", responses: [:])
+                "/hello/world": .pathItem(.init(
+                    put: .init(operationId: "two", responses: [:]))
                 )
             ],
             components: .noComponents
         )
 
-        XCTAssertEqual(t4.allOperationIds, ["two"])
+        XCTAssertEqual(try t4.allOperationIds(), ["two"])
     }
 
     func test_allServersEmpty() {
@@ -149,13 +149,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -171,13 +171,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -193,13 +193,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [s1, s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -215,13 +215,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s1, s2]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -237,13 +237,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [s1, s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s1, s2]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -260,13 +260,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -284,13 +284,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [s2, s4],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -308,13 +308,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     servers: [s2, s4],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -330,11 +330,11 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .init(
+                "/hello/world": .pathItem(.init(
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])]
                     )
-                )
+                ))
             ],
             components: .noComponents
         )
@@ -347,8 +347,8 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/test1": .init(),
-                "/test2": .init()
+                "/test1": .pathItem(.init()),
+                "/test2": .pathItem(.init())
             ],
             components: .noComponents
         )
@@ -567,7 +567,7 @@ extension DocumentTests {
         let document = OpenAPI.Document(
             info: .init(title: "API", version: "1.0"),
             servers: [],
-            paths: ["test": .init(summary: "hi")],
+            paths: ["test": .pathItem(.init(summary: "hi"))],
             components: .noComponents
         )
         let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
@@ -614,7 +614,7 @@ extension DocumentTests {
             OpenAPI.Document(
                 info: .init(title: "API", version: "1.0"),
                 servers: [],
-                paths: ["test": .init(summary: "hi")],
+                paths: ["test": .pathItem(.init(summary: "hi"))],
                 components: .noComponents
             )
         )

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -70,7 +70,7 @@ final class DocumentTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            try test.routes(),
+            test.routes,
             [
                 .init(path: "/hi/there", pathItem: pi1),
                 .init(path: "/hi", pathItem: pi2)
@@ -93,7 +93,7 @@ final class DocumentTests: XCTestCase {
             components: .noComponents
         )
 
-        XCTAssertEqual(try t1.allOperationIds(), [])
+        XCTAssertEqual(t1.allOperationIds, [])
 
         let t2 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
@@ -109,7 +109,7 @@ final class DocumentTests: XCTestCase {
             components: .noComponents
         )
 
-        XCTAssertEqual(try t2.allOperationIds(), ["test"])
+        XCTAssertEqual(t2.allOperationIds, ["test"])
 
         let t3 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
@@ -125,7 +125,7 @@ final class DocumentTests: XCTestCase {
             components: .noComponents
         )
 
-        XCTAssertEqual(try t3.allOperationIds(), ["test", "two"])
+        XCTAssertEqual(t3.allOperationIds, ["test", "two"])
 
         let t4 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
@@ -141,7 +141,7 @@ final class DocumentTests: XCTestCase {
             components: .noComponents
         )
 
-        XCTAssertEqual(try t4.allOperationIds(), ["two"])
+        XCTAssertEqual(t4.allOperationIds, ["two"])
     }
 
     func test_allServersEmpty() {

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -25,14 +25,14 @@ final class DocumentTests: XCTestCase {
                 .init(url: URL(string: "https://google.com")!)
             ],
             paths: [
-                "/hi/there": .pathItem(.init(
+                "/hi/there": .init(
                     parameters: [],
                     get: .init(
                         tags: "hi",
                         parameters: [],
                         responses: [:]
                     )
-                ))
+                )
             ],
             components: .init(schemas: ["hello": .string]),
             security: [],
@@ -41,7 +41,7 @@ final class DocumentTests: XCTestCase {
         )
     }
 
-    func test_getRoutes() throws {
+    func test_getRoutes() {
         let pi1 = OpenAPI.PathItem(
             parameters: [],
             get: .init(
@@ -78,17 +78,15 @@ final class DocumentTests: XCTestCase {
         )
     }
 
-    func test_getAllOperationIds() throws {
+    func test_getAllOperationIds() {
         let t1 = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(.init(
-                    get: .init(operationId: nil, responses: [:]))
-                ),
-                "/hello/world": .pathItem(.init(
+                "/hello": .init(
+                    get: .init(operationId: nil, responses: [:])),
+                "/hello/world": .init(
                     put: .init(operationId: nil, responses: [:]))
-                )
             ],
             components: .noComponents
         )
@@ -99,12 +97,10 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(.init(
-                    get: .init(operationId: "test", responses: [:]))
-                ),
-                "/hello/world": .pathItem(.init(
+                "/hello": .init(
+                    get: .init(operationId: "test", responses: [:])),
+                "/hello/world": .init(
                     put: .init(operationId: nil, responses: [:]))
-                )
             ],
             components: .noComponents
         )
@@ -115,12 +111,10 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(.init(
-                    get: .init(operationId: "test", responses: [:]))
-                ),
-                "/hello/world": .pathItem(.init(
+                "/hello": .init(
+                    get: .init(operationId: "test", responses: [:])),
+                "/hello/world": .init(
                     put: .init(operationId: "two", responses: [:]))
-                )
             ],
             components: .noComponents
         )
@@ -131,12 +125,10 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(.init(
-                    get: .init(operationId: nil, responses: [:]))
-                ),
-                "/hello/world": .pathItem(.init(
+                "/hello": .init(
+                    get: .init(operationId: nil, responses: [:])),
+                "/hello/world": .init(
                     put: .init(operationId: "two", responses: [:]))
-                )
             ],
             components: .noComponents
         )
@@ -149,13 +141,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -171,13 +163,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -193,13 +185,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [s1, s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: []
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -215,13 +207,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s1, s2]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -237,13 +229,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [s1, s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s1, s2]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -260,13 +252,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [s2],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -284,13 +276,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [s2, s4],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -308,13 +300,13 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     servers: [s2, s4],
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])],
                         servers: [s3]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -330,11 +322,11 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [s1, s2],
             paths: [
-                "/hello/world": .pathItem(.init(
+                "/hello/world": .init(
                     get: .init(
                         responses: [.default: .response(description: "test", content: [.json: .init(schema: .string)])]
                     )
-                ))
+                )
             ],
             components: .noComponents
         )
@@ -347,8 +339,8 @@ final class DocumentTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/test1": .pathItem(.init()),
-                "/test2": .pathItem(.init())
+                "/test1": .init(),
+                "/test2": .init()
             ],
             components: .noComponents
         )
@@ -567,7 +559,7 @@ extension DocumentTests {
         let document = OpenAPI.Document(
             info: .init(title: "API", version: "1.0"),
             servers: [],
-            paths: ["test": .pathItem(.init(summary: "hi"))],
+            paths: ["test": .init(summary: "hi")],
             components: .noComponents
         )
         let encodedDocument = try orderUnstableTestStringFromEncoding(of: document)
@@ -614,7 +606,7 @@ extension DocumentTests {
             OpenAPI.Document(
                 info: .init(title: "API", version: "1.0"),
                 servers: [],
-                paths: ["test": .pathItem(.init(summary: "hi"))],
+                paths: ["test": .init(summary: "hi")],
                 components: .noComponents
             )
         )
@@ -1077,7 +1069,7 @@ extension DocumentTests {
                 servers: [],
                 paths: [:],
                 webhooks:  [
-                    "webhook-test": .pathItem(.init(get: op, put: op, post: op, delete: op, options: op, head: op, patch: op, trace: op))
+                    "webhook-test": .init(get: op, put: op, post: op, delete: op, options: op, head: op, patch: op, trace: op)
                 ],
                 components: .noComponents,
                 externalDocs: .init(url: URL(string: "http://google.com")!)

--- a/Tests/OpenAPIKitTests/EaseOfUseTests.swift
+++ b/Tests/OpenAPIKitTests/EaseOfUseTests.swift
@@ -267,7 +267,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
             info: apiInfo,
             servers: [server],
             paths: [
-                "/test/api/endpoint/{param}": testRoute
+                "/test/api/endpoint/{param}": .pathItem(testRoute)
             ],
             components: components,
             security: [],
@@ -430,7 +430,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
         let document = testDocument
 
         // get endpoints for each path
-        let endpoints = document.paths.mapValues { $0.endpoints }
+        let endpoints = document.paths.mapValues { $0.pathItemValue?.endpoints ?? [] }
 
         // count endpoints by HTTP method
         let endpointMethods = endpoints.values.flatMap { $0 }.map { $0.method }
@@ -453,7 +453,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
     func test_getResponseSchema() {
         let document = testDocument
 
-        let endpoint = document.paths["/widgets/{id}"]?.get
+        let endpoint = document.paths["/widgets/{id}"]?.pathItemValue?.get
         let response = endpoint?.responses[status: 200]?.responseValue
         let responseSchemaReference = response?.content[.json]?.schema
         // this response schema is a reference found in the Components Object. We dereference
@@ -466,7 +466,7 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
     func test_getRequestSchema() {
         let document = testDocument
 
-        let endpoint = document.paths["/widgets/{id}"]?.post
+        let endpoint = document.paths["/widgets/{id}"]?.pathItemValue?.post
         let request = endpoint?.requestBody?.requestValue
         let requestSchemaReference = request?.content[.json]?.schema
         // this request schema is defined inline but dereferencing still produces the schema
@@ -509,7 +509,7 @@ fileprivate let testDocument =  OpenAPI.Document(
     info: testInfo,
     servers: [testServer],
     paths: [
-        "/widgets/{id}": OpenAPI.PathItem(
+        "/widgets/{id}": .init(
             parameters: [
                 .parameter(
                     name: "id",
@@ -554,7 +554,7 @@ fileprivate let testDocument =  OpenAPI.Document(
                 ]
             )
         ),
-        "/docs": OpenAPI.PathItem(
+        "/docs": .init(
             get: OpenAPI.Operation(
                 tags: "Documentation",
                 responses: [

--- a/Tests/OpenAPIKitTests/EaseOfUseTests.swift
+++ b/Tests/OpenAPIKitTests/EaseOfUseTests.swift
@@ -437,6 +437,10 @@ final class DeclarativeEaseOfUseTests: XCTestCase {
         let countByMethod = Dictionary(grouping: endpointMethods, by: { $0 }).mapValues { $0.count }
         XCTAssertEqual(countByMethod[.get], 2)
         XCTAssertEqual(countByMethod[.post], 1)
+
+        let easyMode = document.routes.flatMap { $0.pathItem.endpoints }
+        XCTAssertEqual(endpoints.reduce(0, { sum, next in sum + next.value.count }), easyMode.count)
+        XCTAssertEqual(endpoints.values.flatMap { $0.self }, easyMode)
     }
 
     func test_resolveSecurity() {

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -420,7 +420,8 @@ extension PathItemTests {
     func test_pathItemMap_encode() throws {
         let map: OpenAPI.PathItem.Map = [
             "/hello/world": .pathItem(.init()),
-            "hi/there": .pathItem(.init())
+            "hi/there": .pathItem(.init()),
+            "/reference/": .reference(.component(named: "pathRef"))
         ]
 
         let encodedMap = try orderUnstableTestStringFromEncoding(of: map)
@@ -434,6 +435,9 @@ extension PathItemTests {
               },
               "\\/hi\\/there" : {
 
+              },
+              "\\/reference\\/" : {
+                "$ref" : "#\\/components\\/pathItems\\/pathRef"
               }
             }
             """
@@ -449,6 +453,9 @@ extension PathItemTests {
           },
           "\\/hi\\/there" : {
 
+          },
+          "\\/reference\\/" : {
+            "$ref" : "#\\/components\\/pathItems\\/pathRef"
           }
         }
         """.data(using: .utf8)!
@@ -459,7 +466,8 @@ extension PathItemTests {
             map,
             [
                 "/hello/world": .pathItem(.init()),
-                "/hi/there": .pathItem(.init())
+                "/hi/there": .pathItem(.init()),
+                "/reference/": .reference(.component(named: "pathRef"))
             ]
         )
     }

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -134,7 +134,7 @@ final class PathItemTests: XCTestCase {
 
     func test_initializePathItemMap() {
         let _: OpenAPI.PathItem.Map = [
-            "hello/world": .pathItem(.init()),
+            "hello/world": .init(),
         ]
     }
 }
@@ -419,8 +419,8 @@ extension PathItemTests {
 
     func test_pathItemMap_encode() throws {
         let map: OpenAPI.PathItem.Map = [
-            "/hello/world": .pathItem(.init()),
-            "hi/there": .pathItem(.init()),
+            "/hello/world": .init(),
+            "hi/there": .init(),
             "/reference/": .reference(.component(named: "pathRef"))
         ]
 
@@ -465,8 +465,8 @@ extension PathItemTests {
         XCTAssertEqual(
             map,
             [
-                "/hello/world": .pathItem(.init()),
-                "/hi/there": .pathItem(.init()),
+                "/hello/world": .init(),
+                "/hi/there": .init(),
                 "/reference/": .reference(.component(named: "pathRef"))
             ]
         )

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -134,7 +134,7 @@ final class PathItemTests: XCTestCase {
 
     func test_initializePathItemMap() {
         let _: OpenAPI.PathItem.Map = [
-            "hello/world": .init(),
+            "hello/world": .pathItem(.init()),
         ]
     }
 }
@@ -419,8 +419,8 @@ extension PathItemTests {
 
     func test_pathItemMap_encode() throws {
         let map: OpenAPI.PathItem.Map = [
-            "/hello/world": .init(),
-            "hi/there": .init()
+            "/hello/world": .pathItem(.init()),
+            "hi/there": .pathItem(.init())
         ]
 
         let encodedMap = try orderUnstableTestStringFromEncoding(of: map)
@@ -458,8 +458,8 @@ extension PathItemTests {
         XCTAssertEqual(
             map,
             [
-                "/hello/world": .init(),
-                "/hi/there": .init()
+                "/hello/world": .pathItem(.init()),
+                "/hi/there": .pathItem(.init())
             ]
         )
     }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1142,7 +1142,7 @@ final class SchemaObjectTests: XCTestCase {
 
         XCTAssertNil(null.allowedValues)
         XCTAssertEqual(boolean.allowedValues, [false])
-        XCTAssertEqual(object.allowedValues, [AnyCodable([:])])
+        XCTAssertEqual(object.allowedValues, [AnyCodable([String: String]())])
         XCTAssertEqual(array.allowedValues?[0].value as! [Bool], [false])
         XCTAssertEqual(number.allowedValues, [2.5])
         XCTAssertEqual(integer.allowedValues, [5])
@@ -1207,7 +1207,7 @@ final class SchemaObjectTests: XCTestCase {
 
         XCTAssertNil(null.defaultValue)
         XCTAssertEqual(boolean.defaultValue, false)
-        XCTAssertEqual(object.defaultValue, AnyCodable([:]))
+        XCTAssertEqual(object.defaultValue, AnyCodable([String: String]()))
         XCTAssertEqual(array.defaultValue, [false])
         XCTAssertEqual(number.defaultValue, 2.5)
         XCTAssertEqual(integer.defaultValue, 5)

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -732,7 +732,8 @@ final class BuiltinValidationTests: XCTestCase {
                                 ]
                             ),
                             .xml: .init(schemaReference: .component(named: "schema1"))
-                        ]
+                        ],
+                        links: ["linky": .reference(.component(named: "link1"))]
                     )
                 ]
             )
@@ -742,7 +743,8 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(path)
+                "/hello": .pathItem(path),
+                "/world": .reference(.component(named: "path1"))
             ],
             components: .noComponents
         )
@@ -750,7 +752,7 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         XCTAssertThrowsError(try document.validate()) { error in
             let error = error as? ValidationErrorCollection
-            XCTAssertEqual(error?.values.count, 6)
+            XCTAssertEqual(error?.values.count, 8)
             XCTAssertEqual(error?.values[0].reason, "Failed to satisfy: Parameter reference can be found in components/parameters")
             XCTAssertEqual(error?.values[0].codingPathString, ".paths['/hello'].get.parameters[0]")
             XCTAssertEqual(error?.values[1].reason, "Failed to satisfy: Request reference can be found in components/requestBodies")
@@ -763,6 +765,10 @@ final class BuiltinValidationTests: XCTestCase {
             XCTAssertEqual(error?.values[4].codingPathString, ".paths['/hello'].get.responses.404.content['application/json'].examples.example1")
             XCTAssertEqual(error?.values[5].reason, "Failed to satisfy: JSONSchema reference can be found in components/schemas")
             XCTAssertEqual(error?.values[5].codingPathString, ".paths['/hello'].get.responses.404.content['application/xml'].schema")
+            XCTAssertEqual(error?.values[6].reason, "Failed to satisfy: Link reference can be found in components/links")
+            XCTAssertEqual(error?.values[6].codingPathString, ".paths['/hello'].get.responses.404.links.linky")
+            XCTAssertEqual(error?.values[7].reason, "Failed to satisfy: PathItem reference can be found in components/pathItems")
+            XCTAssertEqual(error?.values[7].codingPathString, ".paths['/world']")
         }
     }
 
@@ -799,7 +805,8 @@ final class BuiltinValidationTests: XCTestCase {
                             ),
                             .xml: .init(schemaReference: .component(named: "schema1")),
                             .txt: .init(schemaReference: .external(URL(string: "https://website.com/file.json#/hello/world")!))
-                        ]
+                        ],
+                        links: ["linky": .reference(.component(named: "link1"))]
                     )
                 ]
             )
@@ -809,7 +816,8 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": .pathItem(path)
+                "/hello": .pathItem(path),
+                "/world": .reference(.component(named: "path1"))
             ],
             components: .init(
                 schemas: [
@@ -829,6 +837,12 @@ final class BuiltinValidationTests: XCTestCase {
                 ],
                 headers: [
                     "header1": .init(schema: .string)
+                ],
+                links: [
+                    "link1": .init(operationId: "op 1")
+                ],
+                pathItems: [
+                    "path1": .init()
                 ]
             )
         )

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -742,7 +742,7 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": path
+                "/hello": .pathItem(path)
             ],
             components: .noComponents
         )
@@ -809,7 +809,7 @@ final class BuiltinValidationTests: XCTestCase {
             info: .init(title: "test", version: "1.0"),
             servers: [],
             paths: [
-                "/hello": path
+                "/hello": .pathItem(path)
             ],
             components: .init(
                 schemas: [

--- a/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
@@ -302,7 +302,7 @@ final class ValidationConvenienceTests: XCTestCase {
             )
         )
 
-        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!, codingPath: [])
+        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!.pathItem!, codingPath: [])
 
         // passses
         XCTAssertTrue(
@@ -348,19 +348,19 @@ final class ValidationConvenienceTests: XCTestCase {
 
         // passes
         XCTAssertTrue(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[0], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[0], thenApply: v)(context).isEmpty
         )
         // wrong name
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[1], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[1], thenApply: v)(context).isEmpty
         )
         // not found reference
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.parameters[2], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[2], thenApply: v)(context).isEmpty
         )
         // nil keypath
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.parameters.first, thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.pathItem?.parameters.first, thenApply: v)(context).isEmpty
         )
     }
 

--- a/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/Validation+ConvenienceTests.swift
@@ -302,7 +302,7 @@ final class ValidationConvenienceTests: XCTestCase {
             )
         )
 
-        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!.pathItem!, codingPath: [])
+        let context = ValidationContext<OpenAPI.PathItem>(document: document, subject: document.paths["/test"]!.pathItemValue!, codingPath: [])
 
         // passses
         XCTAssertTrue(
@@ -348,19 +348,19 @@ final class ValidationConvenienceTests: XCTestCase {
 
         // passes
         XCTAssertTrue(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[0], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[0], thenApply: v)(context).isEmpty
         )
         // wrong name
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[1], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[1], thenApply: v)(context).isEmpty
         )
         // not found reference
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItem?.parameters[2], thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test"]?.pathItemValue?.parameters[2], thenApply: v)(context).isEmpty
         )
         // nil keypath
         XCTAssertFalse(
-            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.pathItem?.parameters.first, thenApply: v)(context).isEmpty
+            unwrapAndLookup(\OpenAPI.Document.paths["/test2"]?.pathItemValue?.parameters.first, thenApply: v)(context).isEmpty
         )
     }
 

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1432,7 +1432,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.pathItem?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItemValue?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 
@@ -1471,7 +1471,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.pathItem?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItemValue?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 

--- a/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/ValidatorTests.swift
@@ -1432,7 +1432,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItem?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 
@@ -1471,7 +1471,7 @@ final class ValidatorTests: XCTestCase {
         let doc = try orderUnstableDecode(OpenAPI.Document.self, from: docData)
 
         XCTAssertEqual(
-            doc.paths["test"]?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
+            doc.paths["test"]?.pathItem?.get?.responses[200]?.responseValue?.content.keys.first?.warnings.first?.localizedDescription,
             "\'gzip\' could not be parsed as a Content Type. Content Types should have the format \'<type>/<subtype>\'"
         )
 


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/280

Todo:
- [x] Add support to the `OpenAPIKit` module (supports `PathItem` references in the Components Object)
- [x] Add support to the `OpenAPIKit30` module (does not support `PathItem` references in the Components Object)
- [x] Add net-new tests that cover encode/decoding path item references.
- [x] Add new error reporting tests for when a path is neither a reference nor a path item.
- [x] Double check that code changes in response to new structure make sense -- for example, does code that used to be able to loop over all path items without looking them up in the Components now want to loop over all accessible items ignoring the rest or throw an exception if a path item that cannot be looked up is encountered? What's the most backwards-compatible or ergonomic answer in each case? Add new functions to facilitate either?
- [x] Add default-enabled builtin validation that `PathItem` references are valid.
- [x] write up release notes that lay out breaking changes.


Release Notes
---------
This release fixes #280 by allowing Path Items to be references as well as inlined **Path Item Objects**. This applies to both the `OpenAPIKit30` (OpenAPI 3.0.x) and `OpenAPIKit` (OpenAPI 3.1.x) modules. However, OpenAPI 3.0.x did not allow **Path Item Objects** to be stored in the **Components Object** whereas OpenAPI 3.1.x does, so only _external_ **JSON References** to **Path Item Objects** are meaningful when working with OpenAPI 3.0.x.

## Noteworthy Differences
- `OpenAPI.Document` helpers that collect information not stored directly in the document now skip over _external_ **JSON References** to **Path Item Objects**. The use of these helpers is the same, but the distinction between _internal_ and _external_ references to **Path Item Objects** is important here (where before references to **Path Item Objects** were simply not expressible with OpenAPIKit). These helpers are `var routes: [Route]`, `var allOperationIds: [String]`, `var allServers: [OpenAPI.Server]`, and `var allTags: Set<String>`.
- Because the path to anything in a **Document** that exists as part of a **Path Item Object** or its children is now potentially behind a **JSON Reference**, the error messages for improperly formatted **Documents** have changed in some cases. They still reflect the same underlying problems, but the verbiage has changed.
- It is now possible to write reference entries to **Path Item Objects** into the **Paths** dictionary: `paths: [ "/hello": .reference(.component(named: "path1")) ]`. This _internal_ reference to the **Components Object** would only be valid for OpenAPI 3.1.x; _External_ references like the following are valid for OpenAPI 3.0.x as well as 3.1.x: `paths: [ "/hello": .reference(.external(URL(string: "https://website.com/hi")!)) ]`

## Breaking Changes
Constructing an entry in the `Document.paths` dictionary now requires specifying `Either` a **JSON Reference** to a **Path Item Object** or the **Path Item Object** itself -- this means that where you used to write something like:
```swift
paths: [
  "/hello/world": OpenAPI.PathItem(description: "hi", ...)
]
```
You will now need to wrap it in an `Either` constructor like:
```swift
paths: [
  "/hello/world": .pathItem(OpenAPI.PathItem(description: "hi", ...))
]
```
There is also a convenience initializer for `Either` in this context which means that you can also write:
```swift
paths: [
  "/hello/world": .init(description: "hi", ...)
]
```
You may already have been using the `.init` shorthand to construct `OpenAPI.PathItem`s in which case your code does not need to change.

Accessing an entry in the `Document.paths` dictionary now requires digging into an `Either` that may be a **JSON Reference** or a **Path Item Object** -- this means that where you used to write something like:
```swift
let pathItem = document.paths["hello/world"]
```
You will now need to decide between the following:
```swift
// access the path item (ignoring the possibility that it could be a reference)
let pathItemObject = document.paths["hello/world"]?.pathItemValue

// access the reference directly (ignoring the possibility that it could be a path item object):
let pathItemReference = document.paths["hello/world"]?.reference

// look the path item up in the Components Object (OpenAPIKit module only because this requires OpenAPI 3.1.x):
let pathItem = document.paths["hello/world"].flatMap { document.components[$0] }

// switch on the Either and handle it differently depending on the result:
switch document.paths["hello/world"] {
  case .a(let reference):
    break
  case .b(let pathItem):
    break
  case nil:
    break
}
```

NOTE: The error you will get in places where you need to make the above adjustments will look like:
```
Cannot convert value of type 'OpenAPI.PathItem' to expected dictionary value type 'Either<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>'
```