### PR TITLE
Support schema reference description overrides

### DIFF
--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -385,6 +385,16 @@ extension OpenAPI {
     }
 }
 
+public extension JSONReference {
+    /// Create an OpenAPI.Reference from the given JSONReference.
+    func openAPIReference(withDescription description: String? = nil) -> OpenAPI.Reference<ReferenceType> {
+        OpenAPI.Reference(
+            self,
+            description: description
+        )
+    }
+}
+
 /// `SummaryOverridable` exists to provide a parent protocol to `OpenAPIDescribable`
 /// and `OpenAPISummarizable`. The structure is designed to provide default no-op
 /// implementations of both the members of this protocol to all types that implement either

--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -401,6 +401,7 @@ extension JSONSchema: LocallyDereferenceable {
             if let refDescription = context.description {
                 dereferenced = dereferenced.with(description: refDescription)
             }
+            // TODO: consider which other core context properties to override here as with description ^
             return dereferenced
         case .boolean(let context):
             return .boolean(context)

--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -142,6 +142,36 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
 
     // See `JSONSchemaContext`
     public var deprecated: Bool { jsonSchema.deprecated }
+
+    /// Returns a version of this `DereferencedJSONSchema` that has the given description.
+    public func with(description: String) -> DereferencedJSONSchema {
+        switch self {
+        case .null:
+            return .null
+        case .boolean(let context):
+            return .boolean(context.with(description: description))
+        case .object(let coreContext, let objectContext):
+            return .object(coreContext.with(description: description), objectContext)
+        case .array(let coreContext, let arrayContext):
+            return .array(coreContext.with(description: description), arrayContext)
+        case .number(let coreContext, let numberContext):
+            return .number(coreContext.with(description: description), numberContext)
+        case .integer(let coreContext, let integerContext):
+            return .integer(coreContext.with(description: description), integerContext)
+        case .string(let coreContext, let stringContext):
+            return .string(coreContext.with(description: description), stringContext)
+        case .all(of: let schemas, core: let coreContext):
+            return .all(of: schemas, core: coreContext.with(description: description))
+        case .one(of: let schemas, core: let coreContext):
+            return .one(of: schemas, core: coreContext.with(description: description))
+        case .any(of: let schemas, core: let coreContext):
+            return .any(of: schemas, core: coreContext.with(description: description))
+        case .not(let schema, core: let coreContext):
+            return .not(schema, core: coreContext.with(description: description))
+        case .fragment(let context):
+            return .fragment(context.with(description: description))
+        }
+    }
 }
 
 extension DereferencedJSONSchema {
@@ -367,6 +397,9 @@ extension JSONSchema: LocallyDereferenceable {
             var dereferenced = try reference._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
             if !context.required {
                 dereferenced = dereferenced.optionalSchemaObject()
+            }
+            if let refDescription = context.description {
+                dereferenced = dereferenced.with(description: refDescription)
             }
             return dereferenced
         case .boolean(let context):

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -1053,7 +1053,13 @@ extension JSONSchema {
                 schema: .fragment(fragment.with(description: description)),
                 vendorExtensions: vendorExtensions
             )
-        case .reference, .null:
+        case .reference(let ref, let referenceContext):
+            return .init(
+                warnings: warnings,
+                schema: .reference(ref, referenceContext.with(description: description)),
+                vendorExtensions: vendorExtensions
+            )
+        case .null:
             return self
         }
     }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -196,7 +196,9 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
              .any(of: _, core: let context as JSONSchemaContext),
              .not(_, core: let context as JSONSchemaContext):
             return context.description
-        case .reference, .null:
+        case .reference(_, let referenceContext):
+            return referenceContext.description
+        case .null:
             return nil
         }
     }

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -634,7 +634,11 @@ extension OpenAPIKit30.JSONSchema: To31 {
         case .not(let not, core: let core):
             schema = .not(not.to31(), core: core.to31())
         case .reference(let ref, let context):
-            schema = .reference(ref.to31(), context)
+            let coreContext: OpenAPIKit.JSONSchema.CoreContext<OpenAPIKit.JSONTypeFormat.AnyFormat>
+            coreContext = .init(
+                required: context.required
+            )
+            schema = .reference(ref.to31(), coreContext)
         case .fragment(let core):
             schema = .fragment(core.to31())
         }

--- a/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
+++ b/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
@@ -37,15 +37,10 @@ extension Shared {
 
     /// The context that only applies to `.reference` schemas.
     public struct ReferenceContext: Equatable {
-        /// A description that overrides any description that may be
-        /// found in the referenced schema.
-        public let description: String?
-
         public let required: Bool
 
-        public init(required: Bool = true, description: String? = nil) {
+        public init(required: Bool = true) {
             self.required = required
-            self.description = description
         }
 
         public func requiredContext() -> ReferenceContext {
@@ -54,10 +49,6 @@ extension Shared {
 
         public func optionalContext() -> ReferenceContext {
             return .init(required: false)
-        }
-
-        public func with(description: String) -> ReferenceContext {
-            return .init(required: required, description: description)
         }
     }
 }

--- a/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
+++ b/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
@@ -55,6 +55,10 @@ extension Shared {
         public func optionalContext() -> ReferenceContext {
             return .init(required: false)
         }
+
+        public func with(description: String) -> ReferenceContext {
+            return .init(required: required, description: description)
+        }
     }
 }
 

--- a/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
+++ b/Sources/OpenAPIKitCore/Shared/JSONSchemaSimpleContexts.swift
@@ -37,10 +37,15 @@ extension Shared {
 
     /// The context that only applies to `.reference` schemas.
     public struct ReferenceContext: Equatable {
+        /// A description that overrides any description that may be
+        /// found in the referenced schema.
+        public let description: String?
+
         public let required: Bool
 
-        public init(required: Bool = true) {
+        public init(required: Bool = true, description: String? = nil) {
             self.required = required
+            self.description = description
         }
 
         public func requiredContext() -> ReferenceContext {

--- a/Tests/OpenAPIKitTests/JSONReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/JSONReferenceTests.swift
@@ -128,6 +128,48 @@ final class JSONReferenceTests: XCTestCase {
         XCTAssertEqual(JSONReference<OpenAPI.Callbacks>.component(named: "hello").absoluteString, "#/components/callbacks/hello")
         XCTAssertEqual(JSONReference<OpenAPI.PathItem>.component(named: "hello").absoluteString, "#/components/pathItems/hello")
     }
+
+    func test_toOpenAPIReference() {
+        let t1 = JSONReference<JSONSchema>.component(named: "hello")
+        let t2 = JSONReference<OpenAPI.Response>.component(named: "hello")
+        let t3 = JSONReference<OpenAPI.Parameter>.component(named: "hello")
+        let t4 = JSONReference<OpenAPI.Example>.component(named: "hello")
+        let t5 = JSONReference<OpenAPI.Request>.component(named: "hello")
+        let t6 = JSONReference<OpenAPI.Header>.component(named: "hello")
+        let t7 = JSONReference<OpenAPI.SecurityScheme>.component(named: "hello")
+        let t8 = JSONReference<OpenAPI.Callbacks>.component(named: "hello")
+        let t9 = JSONReference<OpenAPI.PathItem>.component(named: "hello")
+
+        XCTAssertEqual(t1.openAPIReference().jsonReference, t1)
+        XCTAssertEqual(t2.openAPIReference().jsonReference, t2)
+        XCTAssertEqual(t3.openAPIReference().jsonReference, t3)
+        XCTAssertEqual(t4.openAPIReference().jsonReference, t4)
+        XCTAssertEqual(t5.openAPIReference().jsonReference, t5)
+        XCTAssertEqual(t6.openAPIReference().jsonReference, t6)
+        XCTAssertEqual(t7.openAPIReference().jsonReference, t7)
+        XCTAssertEqual(t8.openAPIReference().jsonReference, t8)
+        XCTAssertEqual(t9.openAPIReference().jsonReference, t9)
+
+        XCTAssertNil(t1.openAPIReference().description)
+        XCTAssertNil(t2.openAPIReference().description)
+        XCTAssertNil(t3.openAPIReference().description)
+        XCTAssertNil(t4.openAPIReference().description)
+        XCTAssertNil(t5.openAPIReference().description)
+        XCTAssertNil(t6.openAPIReference().description)
+        XCTAssertNil(t7.openAPIReference().description)
+        XCTAssertNil(t8.openAPIReference().description)
+        XCTAssertNil(t9.openAPIReference().description)
+
+        XCTAssertEqual(t1.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t2.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t3.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t4.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t5.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t6.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t7.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t8.openAPIReference(withDescription: "hi").description, "hi")
+        XCTAssertEqual(t9.openAPIReference(withDescription: "hi").description, "hi")
+    }
 }
 
 // MARK: Codable

--- a/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
@@ -281,6 +281,14 @@ final class DereferencedSchemaObjectTests: XCTestCase {
         XCTAssertEqual(t1, .string(.init(), .init()))
     }
 
+    func test_throwingReferenceWithOverriddenDescription() throws {
+        let components = OpenAPI.Components(
+            schemas: ["test": .string]
+        )
+        let t1 = try JSONSchema.reference(.component(named: "test"), description: "hello").dereferenced(in: components)
+        XCTAssertEqual(t1, .string(.init(description: "hello"), .init()))
+    }
+
     func test_optionalObjectWithoutReferences() {
         let t1 = JSONSchema.object(properties: ["test": .string]).dereferenced()
         XCTAssertEqual(
@@ -504,4 +512,37 @@ final class DereferencedSchemaObjectTests: XCTestCase {
             )
         }
     }
+
+    func test_withDescription() throws {
+        let null = JSONSchema.null.dereferenced()!.with(description: "test")
+        let object = JSONSchema.object.dereferenced()!.with(description: "test")
+        let array = JSONSchema.array.dereferenced()!.with(description: "test")
+
+        let boolean = JSONSchema.boolean.dereferenced()!.with(description: "test")
+        let number = JSONSchema.number.dereferenced()!.with(description: "test")
+        let integer = JSONSchema.integer.dereferenced()!.with(description: "test")
+        let string = JSONSchema.string.dereferenced()!.with(description: "test")
+        let fragment = JSONSchema.fragment(.init()).dereferenced()!.with(description: "test")
+        let all = JSONSchema.all(of: .string).dereferenced()!.with(description: "test")
+        let one = JSONSchema.one(of: .string).dereferenced()!.with(description: "test")
+        let any = JSONSchema.any(of: .string).dereferenced()!.with(description: "test")
+        let not = JSONSchema.not(.string).dereferenced()!.with(description: "test")
+
+        XCTAssertEqual(object.description, "test")
+        XCTAssertEqual(array.description, "test")
+
+        XCTAssertEqual(boolean.description, "test")
+        XCTAssertEqual(number.description, "test")
+        XCTAssertEqual(integer.description, "test")
+        XCTAssertEqual(string.description, "test")
+        XCTAssertEqual(fragment.description, "test")
+
+        XCTAssertEqual(all.description, "test")
+        XCTAssertEqual(one.description, "test")
+        XCTAssertEqual(any.description, "test")
+        XCTAssertEqual(not.description, "test")
+
+        XCTAssertNil(null.description)
+    }
+
 }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -643,7 +643,7 @@ final class SchemaObjectTests: XCTestCase {
         let anyOf = JSONSchema.any(of: [boolean], core: .init(description: "hello"))
         let oneOf = JSONSchema.one(of: [boolean], core: .init(description: "hello"))
         let not = JSONSchema.not(boolean, core: .init(description: "hello"))
-        let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
+        let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!), description: "hello")
         let fragment = JSONSchema.fragment(.init(description: nil))
         let fragmentWithDescription = JSONSchema.fragment(.init(description: "hello"))
 
@@ -659,8 +659,8 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(anyOf.description, "hello")
         XCTAssertEqual(oneOf.description, "hello")
         XCTAssertEqual(not.description, "hello")
+        XCTAssertEqual(reference.description, "hello")
 
-        XCTAssertNil(reference.description)
         XCTAssertNil(fragment.description)
         XCTAssertNil(null.description)
     }
@@ -1346,6 +1346,40 @@ final class SchemaObjectTests: XCTestCase {
 
         XCTAssertNil(null.discriminator)
         XCTAssertNil(reference.discriminator)
+    }
+
+    func test_withDescription() throws {
+        let null = JSONSchema.null.with(description: "test")
+        let object = JSONSchema.object.with(description: "test")
+        let array = JSONSchema.array.with(description: "test")
+
+        let boolean = JSONSchema.boolean.with(description: "test")
+        let number = JSONSchema.number.with(description: "test")
+        let integer = JSONSchema.integer.with(description: "test")
+        let string = JSONSchema.string.with(description: "test")
+        let fragment = JSONSchema.fragment(.init()).with(description: "test")
+        let all = JSONSchema.all(of: .string).with(description: "test")
+        let one = JSONSchema.one(of: .string).with(description: "test")
+        let any = JSONSchema.any(of: .string).with(description: "test")
+        let not = JSONSchema.not(.string).with(description: "test")
+        let reference = JSONSchema.reference(.component(named: "test")).with(description: "test")
+
+        XCTAssertEqual(object.description, "test")
+        XCTAssertEqual(array.description, "test")
+
+        XCTAssertEqual(boolean.description, "test")
+        XCTAssertEqual(number.description, "test")
+        XCTAssertEqual(integer.description, "test")
+        XCTAssertEqual(string.description, "test")
+        XCTAssertEqual(fragment.description, "test")
+
+        XCTAssertEqual(all.description, "test")
+        XCTAssertEqual(one.description, "test")
+        XCTAssertEqual(any.description, "test")
+        XCTAssertEqual(not.description, "test")
+        XCTAssertEqual(reference.description, "test")
+
+        XCTAssertNil(null.description)
     }
 
     func test_minObjectProperties() {
@@ -5731,6 +5765,26 @@ extension SchemaObjectTests {
         XCTAssertEqual(
             nodeRef,
             JSONSchema.reference(.component(named: "requiredBool"))
+        )
+    }
+
+    func test_encodeReferenceDescription() {
+        let nodeRef = JSONSchema.reference(.component(named: "requiredBool"), description: "hello")
+
+        testEncodingPropertyLines(entity: nodeRef, propertyLines: [
+            "\"description\" : \"hello\"",
+            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\""
+        ])
+    }
+
+    func test_decodeReferenceDescription() throws {
+        let nodeRefData = ##"{ "$ref": "#/components/schemas/requiredBool", "description": "hello" }"##.data(using: .utf8)!
+
+        let nodeRef = try orderUnstableDecode(JSONSchema.self, from: nodeRefData)
+
+        XCTAssertEqual(
+            nodeRef,
+            JSONSchema.reference(.component(named: "requiredBool"), description: "hello")
         )
     }
 

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -761,8 +761,8 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(anyOf.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
         XCTAssertEqual(oneOf.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
         XCTAssertEqual(not.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
+        XCTAssertEqual(reference.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
 
-        XCTAssertNil(reference.coreContext)
         XCTAssertNil(null.coreContext)
     }
 

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -5788,6 +5788,69 @@ extension SchemaObjectTests {
         )
     }
 
+    func test_encodeReferenceDeprecated() {
+        let nodeRef = JSONSchema.reference(.component(named: "requiredBool"), .init(deprecated: true))
+
+        testEncodingPropertyLines(entity: nodeRef, propertyLines: [
+            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\",",
+            "\"deprecated\" : true"
+        ])
+    }
+
+    func test_decodeReferenceDeprecated() throws {
+        let nodeRefData = ##"{ "$ref": "#/components/schemas/requiredBool", "deprecated": true }"##.data(using: .utf8)!
+
+        let nodeRef = try orderUnstableDecode(JSONSchema.self, from: nodeRefData)
+
+        XCTAssertEqual(
+            nodeRef,
+            JSONSchema.reference(.component(named: "requiredBool"), .init(deprecated: true))
+        )
+    }
+
+    func test_encodeReferenceDefault() {
+        let nodeRef = JSONSchema.reference(.component(named: "requiredBool"), .init(defaultValue: "hello"))
+
+        testEncodingPropertyLines(entity: nodeRef, propertyLines: [
+            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\",",
+            "\"default\" : \"hello\""
+        ])
+    }
+
+    func test_decodeReferenceDefault() throws {
+        let nodeRefData = ##"{ "$ref": "#/components/schemas/requiredBool", "default": "hello" }"##.data(using: .utf8)!
+
+        let nodeRef = try orderUnstableDecode(JSONSchema.self, from: nodeRefData)
+
+        XCTAssertEqual(
+            nodeRef,
+            JSONSchema.reference(.component(named: "requiredBool"), .init(defaultValue: "hello"))
+        )
+    }
+
+
+    func test_encodeReferenceExamples() {
+        let nodeRef = JSONSchema.reference(.component(named: "requiredBool"), .init(examples: ["hello"]))
+
+        testEncodingPropertyLines(entity: nodeRef, propertyLines: [
+            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\",",
+            "\"examples\" : [",
+            "  \"hello\"",
+            "]",
+        ])
+    }
+
+    func test_decodeReferenceExamples() throws {
+        let nodeRefData = ##"{ "$ref": "#/components/schemas/requiredBool", "examples": ["hello"] }"##.data(using: .utf8)!
+
+        let nodeRef = try orderUnstableDecode(JSONSchema.self, from: nodeRefData)
+
+        XCTAssertEqual(
+            nodeRef,
+            JSONSchema.reference(.component(named: "requiredBool"), .init(examples: ["hello"]))
+        )
+    }
+
     func test_encodeReferenceOptionality() {
         let optionalReference = JSONSchema.reference(.component(named: "optionalBool"))
             .optionalSchemaObject()

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -5772,8 +5772,8 @@ extension SchemaObjectTests {
         let nodeRef = JSONSchema.reference(.component(named: "requiredBool"), description: "hello")
 
         testEncodingPropertyLines(entity: nodeRef, propertyLines: [
-            "\"description\" : \"hello\"",
-            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\""
+            "\"$ref\" : \"#\\/components\\/schemas\\/requiredBool\",",
+            "\"description\" : \"hello\""
         ])
     }
 


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/298.

**Implementation**
This PR replaces the `JSONSchema` `reference` case's `ReferenceContext` with a `CoreContext` (only for the `OpenAPIKit` module, not the `OpenAPIKit30` module) and it uses that core context's `description` to override the `description` within a referenced schema when calling the `dereferenced()` or `dereferenced(in:)` methods on `JSONSchema`. This carries through, naturally, to dereferencing performed on parent values all the way up to the execution of `locallyDereferenced()` on `OpenAPI.Document`.

There is also a new `openAPIReference(withDescription description: String? = nil)` method on `JSONReference` to make it easy to elevate a `JSONReference` to an `OpenAPI.Reference`. OpenAPIKit does not use this internally at the moment, but turning a `JSONReference` into an `OpenAPI.Reference` is a really nice way to carry the "override the referenced description" around so that whenever the reference _is_ looked up the description is overridden without further effort.

**Alternatives Considered**
It was briefly considered to store an `OpenAPI.Reference` on a `JSONSchema` directly in place of the current `JSONReference`. This would take care of packaging up the `description` (if present) when parsing which would be the easiest solution from the perspective of downstream implementations. I decided against this implementation both because it is a larger breaking change and, at least as importantly, because `OpenAPI.Reference` _is not_ the same thing as a `JSONReference` with an overridden description; it also parses `summary` and generally holds different semantics. It is elegant that the newest OpenAPI specification completely embeds the JSON Schema specification and can therefore say "anything in the schema is specified in this other specification." I wanted to embrace that here as well which means keeping "OpenAPI" things out of the `JSONSchema` core representation.

It was also considered to add `description` to the `JSONReference` type. This was decided against because currently the `JSONReference` type is _only_ the `$ref` part of a schema and given that JSON References are more broadly understood even than in the context of the JSON Schema specification, it is nice to keep reference stuff in `JSONReference` and non reference stuff (like the behavior of overriding `description`) outside of `JSONReference`. Adding more properties to `JSONReference` also would have been a more disruptive change from a maintenance perspective.

Lastly, it is more correct to allow for all of the `CoreContext` fields alongside schema references even though the built-in dereferencing logic does not incorporate all of the fields at this time. In fact, JSON Schema now allows even more than the core context fields and it has now gained a caveat in the specification that it is not even always possible to dereference documents and get reasonable results because of the full allowance of keywords alongside `$ref`. OpenAPIKit will need to make some decisions in the future about how to operate in that reality.