### PR TITLE
fix bug where headers were not allowed to define explode when decoding

### DIFF
--- a/Sources/OpenAPIKit/Header/Header.swift
+++ b/Sources/OpenAPIKit/Header/Header.swift
@@ -170,6 +170,7 @@ extension OpenAPI.Header {
 
         // the following are parsed as part of Schema
         case style
+        case explode
         case allowReserved
         case example
         case examples
@@ -184,6 +185,7 @@ extension OpenAPI.Header {
                 .content,
                 .schema,
                 .style,
+                .explode,
                 .allowReserved,
                 .example,
                 .examples
@@ -208,6 +210,8 @@ extension OpenAPI.Header {
                 self = .schema
             case "style":
                 self = .style
+            case "explode":
+                self = .explode
             case "allowReserved":
                 self = .allowReserved
             case "example":
@@ -233,6 +237,8 @@ extension OpenAPI.Header {
                 return "schema"
             case .style:
                 return "style"
+            case .explode:
+                return "explode"
             case .allowReserved:
                 return "allowReserved"
             case .example:

--- a/Tests/OpenAPIKitTests/Header/HeaderTests.swift
+++ b/Tests/OpenAPIKitTests/Header/HeaderTests.swift
@@ -511,6 +511,67 @@ extension HeaderTests {
         )
     }
 
+    func test_header_withStyleAndExplode_encode() throws {
+        let header = OpenAPI.Header(
+            schema: .init(
+                .array(items: .string),
+                style: .form,
+                explode: false
+            ),
+            required: true
+        )
+
+        let encodedHeader = try orderUnstableTestStringFromEncoding(of: header)
+
+        assertJSONEquivalent(
+            encodedHeader,
+            """
+            {
+              "explode" : false,
+              "required" : true,
+              "schema" : {
+                "items" : {
+                  "type" : "string"
+                },
+                "type" : "array"
+              },
+              "style" : "form"
+            }
+            """
+        )
+    }
+
+    func test_header_withStyleAndExplode_decode() throws {
+        let headerData =
+        """
+        {
+          "explode" : false,
+          "required" : true,
+          "schema" : {
+            "items" : {
+              "type" : "string"
+            },
+            "type" : "array"
+          },
+          "style" : "form"
+        }
+        """.data(using: .utf8)!
+
+        let header = try orderUnstableDecode(OpenAPI.Header.self, from: headerData)
+
+        XCTAssertEqual(
+            header,
+            OpenAPI.Header(
+                schema: .init(
+                    .array(items: .string),
+                    style: .form,
+                    explode: false
+                ),
+                required: true
+            )
+        )
+    }
+
     func test_header_errorForBothContentAndSchema_decode() {
         let headerData =
         """


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/OpenAPIKit/issues/300.