### PR TITLE
apply optional responses changes to OpenAPIKit module.

### DIFF
--- a/Sources/OpenAPIKit/Encoding and Decoding Errors/PathDecodingError.swift
+++ b/Sources/OpenAPIKit/Encoding and Decoding Errors/PathDecodingError.swift
@@ -130,10 +130,22 @@ extension OpenAPI.Error.Decoding.Path {
     }
 
     internal init(_ eitherError: EitherDecodeNoTypesMatchedError) {
-        if let eitherBranchToDigInto = Self.eitherBranchToDigInto(eitherError) {
-            self = Self(unwrapping: eitherBranchToDigInto)
-            return
-        }
+        // *IMPORTANT*
+        // -----------
+        // In theory the following commented-out code is desirable but in practice it never
+        // results in useful output because `eitherBranchToDigInto` checks for things that
+        // never occur on `PathItem`'s only `Either` type (the array of `Parameter`s). Because
+        // `Parameter` is such a simple type, it is never worth "digging" into more deeply.
+        //
+        // I intend to leave this code here commented out to be a guide if it the future the
+        // `PathItem` type does gain deeper `Either` properties because in that case the code
+        // below can simply be uncommented instead of needing to wrap my head around the situation
+        // from scratch.
+
+//        if let eitherBranchToDigInto = Self.eitherBranchToDigInto(eitherError) {
+//            self = Self(unwrapping: eitherBranchToDigInto)
+//            return
+//        }
 
         var codingPath = eitherError.codingPath.dropFirst()
         let route = OpenAPI.Path(rawValue: codingPath.removeFirst().stringValue)
@@ -144,16 +156,21 @@ extension OpenAPI.Error.Decoding.Path {
     }
 }
 
-extension OpenAPI.Error.Decoding.Path: DiggingError {
-    public init(unwrapping error: Swift.DecodingError) {
-        if let decodingError = error.underlyingError as? Swift.DecodingError {
-            self = Self(unwrapping: decodingError)
-        } else if let inconsistencyError = error.underlyingError as? InconsistencyError {
-            self = Self(inconsistencyError)
-        } else if let eitherError = error.underlyingError as? EitherDecodeNoTypesMatchedError {
-            self = Self(eitherError)
-        } else {
-            self = Self(error)
-        }
-    }
-}
+// *IMPORTANT*
+// -----------
+// See the note above in the `init(_ eitherError:)` initializer to understand why I want to
+// leave the following commented out code intact.
+
+//extension OpenAPI.Error.Decoding.Path: DiggingError {
+//    public init(unwrapping error: Swift.DecodingError) {
+//        if let decodingError = error.underlyingError as? Swift.DecodingError {
+//            self = Self(unwrapping: decodingError)
+//        } else if let inconsistencyError = error.underlyingError as? InconsistencyError {
+//            self = Self(inconsistencyError)
+//        } else if let eitherError = error.underlyingError as? EitherDecodeNoTypesMatchedError {
+//            self = Self(eitherError)
+//        } else {
+//            self = Self(error)
+//        }
+//    }
+//}

--- a/Sources/OpenAPIKit/Operation/Operation.swift
+++ b/Sources/OpenAPIKit/Operation/Operation.swift
@@ -273,7 +273,9 @@ extension OpenAPI.Operation: Encodable {
 
         try container.encodeIfPresent(requestBody, forKey: .requestBody)
 
-        try container.encode(responses, forKey: .responses)
+        if !responses.isEmpty {
+            try container.encode(responses, forKey: .responses)
+        }
 
         if !callbacks.isEmpty {
             try container.encode(callbacks, forKey: .callbacks)
@@ -312,7 +314,7 @@ extension OpenAPI.Operation: Decodable {
 
             requestBody = try container.decodeIfPresent(Either<OpenAPI.Reference<OpenAPI.Request>, OpenAPI.Request>.self, forKey: .requestBody)
 
-            responses = try container.decode(OpenAPI.Response.Map.self, forKey: .responses)
+            responses = try container.decodeIfPresent(OpenAPI.Response.Map.self, forKey: .responses) ?? [:]
 
             callbacks = try container.decodeIfPresent(OpenAPI.CallbacksMap.self, forKey: .callbacks) ?? [:]
 

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -157,23 +157,25 @@ extension Validation {
         )
     }
 
-    // MARK: - Included with `Validator()` by default
-
     /// Validate the OpenAPI Document's `Operations` all have at least
     /// one response.
     ///
-    /// The OpenAPI Specifcation requires that Responses Objects
-    /// contain [at least one response](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#responses-object).
-    /// The specification recommends that if there is only one response then
-    /// it be a successful response.
+    /// The OpenAPI Specifcation does not require that Responses Objects
+    /// contain at least one response but you may wish to validate that all 
+    /// operations contain at least one response in your own API.
     ///
-    /// - Important: This is included in validation by default.
+    /// The specification recommends that if there is only one response then
+    /// it be a successful response but this validation does not require that.
+    ///
+    /// - Important: This is not an included validation by default.
     public static var operationsContainResponses: Validation<OpenAPI.Response.Map> {
         .init(
             description: "Operations contain at least one response",
             check: \.count > 0
         )
     }
+
+    // MARK: - Included with `Validator()` by default
 
     // You can start with no validations (not even the defaults below)
     // by calling `Validator.blank`.

--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -168,10 +168,10 @@ extension Validation {
     /// it be a successful response but this validation does not require that.
     ///
     /// - Important: This is not an included validation by default.
-    public static var operationsContainResponses: Validation<OpenAPI.Response.Map> {
+    public static var operationsContainResponses: Validation<OpenAPI.Operation> {
         .init(
             description: "Operations contain at least one response",
-            check: \.count > 0
+            check: \.responses.count > 0
         )
     }
 

--- a/Sources/OpenAPIKit/Validator/Validator.swift
+++ b/Sources/OpenAPIKit/Validator/Validator.swift
@@ -170,7 +170,6 @@ public final class Validator {
     /// `Validator.blank`.
     ///
     /// The default validations are
-    /// - Operations must contain at least one response.
     /// - Document-level tag names are unique.
     /// - Parameters are unique within each Path Item.
     /// - Parameters are unique within each Operation.
@@ -184,7 +183,6 @@ public final class Validator {
     ///
     public convenience init() {
         self.init(validations: [
-            .init(.operationsContainResponses),
             .init(.documentTagNamesAreUnique),
             .init(.pathItemParametersAreUnique),
             .init(.operationParametersAreUnique),

--- a/Sources/OpenAPIKit30/Encoding and Decoding Errors/PathDecodingError.swift
+++ b/Sources/OpenAPIKit30/Encoding and Decoding Errors/PathDecodingError.swift
@@ -130,10 +130,6 @@ extension OpenAPI.Error.Decoding.Path {
     }
 
     internal init(_ eitherError: EitherDecodeNoTypesMatchedError) {
-        if let eitherBranchToDigInto = Self.eitherBranchToDigInto(eitherError) {
-            self = Self(unwrapping: eitherBranchToDigInto)
-            return
-        }
 
         var codingPath = eitherError.codingPath.dropFirst()
         let route = OpenAPI.Path(rawValue: codingPath.removeFirst().stringValue)
@@ -141,19 +137,5 @@ extension OpenAPI.Error.Decoding.Path {
         path = route
         context = .neither(eitherError)
         relativeCodingPath = Array(codingPath)
-    }
-}
-
-extension OpenAPI.Error.Decoding.Path: DiggingError {
-    public init(unwrapping error: Swift.DecodingError) {
-        if let decodingError = error.underlyingError as? Swift.DecodingError {
-            self = Self(unwrapping: decodingError)
-        } else if let inconsistencyError = error.underlyingError as? InconsistencyError {
-            self = Self(inconsistencyError)
-        } else if let eitherError = error.underlyingError as? EitherDecodeNoTypesMatchedError {
-            self = Self(eitherError)
-        } else {
-            self = Self(error)
-        }
     }
 }

--- a/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DiggingError.swift
+++ b/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/DiggingError.swift
@@ -9,6 +9,16 @@
 /// underlying context to attempt to pull out a more granular reason for the
 /// failure.
 ///
+/// In practice (currently) such digging only occurs when there is an `Either`
+/// that fails to decode and that presents an opportunity to do one of three things:
+/// 1. Present the error that neither of two things decoded successfully.
+/// 2. Present the error that thing 1 failed to decode.
+/// 3. Present the error that thing 2 failed to decode.
+/// The reason it ever makes sense to only present an error from one of the two
+/// branches is that sometimes we can heuristically determine that it was exceedingly
+/// unlikely the user intended to represent the thing from the other branch. This error
+/// protocol is all about determining whether that is the case or not.
+///
 /// This is a relevant concept with respect to `DecodingError`s in particular
 /// because they often have underlying causes.
 ///

--- a/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
@@ -700,7 +700,10 @@ final class BuiltinValidationTests: XCTestCase {
                             .xml: .init(schemaReference: .component(named: "schema1")),
                             .txt: .init(schemaReference: .external(URL(string: "https://website.com/file.json#/hello/world")!))
                         ],
-                        links: ["linky": .reference(.component(named: "link1"))]
+                        links: [
+                            "linky": .reference(.component(named: "link1")),
+                            "linky2": .reference(.external(URL(string: "https://linky.com")!))
+                        ]
                     )
                 ]
             )

--- a/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/OperationErrorTests.swift
@@ -11,30 +11,6 @@ import OpenAPIKit
 import Yams
 
 final class OperationErrorTests: XCTestCase {
-    func test_missingResponses() {
-        let documentYML =
-        """
-        openapi: "3.1.0"
-        info:
-            title: test
-            version: 1.0
-        paths:
-            /hello/world:
-                get: {}
-        """
-
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
-
-            let openAPIError = OpenAPI.Error(from: error)
-
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/hello/world']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/hello/world` but it is missing..")
-            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
-                "paths",
-                "/hello/world"
-            ])
-        }
-    }
-
     func test_wrongTypeTags() {
         let documentYML =
         """
@@ -91,39 +67,6 @@ final class OperationErrorTests: XCTestCase {
                 "get",
                 "servers",
                 "Index 1"
-            ])
-        }
-    }
-}
-
-extension OperationErrorTests {
-    func test_missingResponseFromSSWGPitchConversation() {
-        let documentYML =
-        """
-        openapi: 3.1.0
-        info:
-          title: API
-          version: 1.0.0
-        paths:
-          /all-items:
-            summary: Get all items
-            get:
-              responses:
-                "200":
-                  description: All items
-          /one-item:
-            get:
-              summary: Get one item
-        """
-
-        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
-
-            let openAPIError = OpenAPI.Error(from: error)
-
-            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a PathItem in Document.paths['/one-item']. \n\nPathItem could not be decoded because:\nExpected to find `responses` key for the **GET** endpoint under `/one-item` but it is missing..")
-            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
-                "paths",
-                "/one-item"
             ])
         }
     }

--- a/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/PathsErrorTests.swift
@@ -51,6 +51,8 @@ final class PathsErrorTests: XCTestCase {
         }
     }
 
+    /// Errors as bad vendor extension since "boo" is not a valid expected property and all unexpected properties are assumed to be extensions and
+    /// all extensions must begin with `x-`.
     func test_wayOffMarkForPathItemOrReference() {
         let documentYML =
         """

--- a/Tests/OpenAPIKitTests/ComponentsTests.swift
+++ b/Tests/OpenAPIKitTests/ComponentsTests.swift
@@ -595,44 +595,28 @@ extension ComponentsTests {
             "pathItems" : {
               "path-test" : {
                 "delete" : {
-                  "responses" : {
 
-                  }
                 },
                 "get" : {
-                  "responses" : {
 
-                  }
                 },
                 "head" : {
-                  "responses" : {
 
-                  }
                 },
                 "options" : {
-                  "responses" : {
 
-                  }
                 },
                 "patch" : {
-                  "responses" : {
 
-                  }
                 },
                 "post" : {
-                  "responses" : {
 
-                  }
                 },
                 "put" : {
-                  "responses" : {
 
-                  }
                 },
                 "trace" : {
-                  "responses" : {
 
-                  }
                 }
               }
             }
@@ -648,44 +632,20 @@ extension ComponentsTests {
             "pathItems" : {
               "path-test" : {
                 "delete" : {
-                  "responses" : {
-
-                  }
                 },
                 "get" : {
-                  "responses" : {
-
-                  }
                 },
                 "head" : {
-                  "responses" : {
-
-                  }
                 },
                 "options" : {
-                  "responses" : {
-
-                  }
                 },
                 "patch" : {
-                  "responses" : {
-
-                  }
                 },
                 "post" : {
-                  "responses" : {
-
-                  }
                 },
                 "put" : {
-                  "responses" : {
-
-                  }
                 },
                 "trace" : {
-                  "responses" : {
-
-                  }
                 }
               }
             }

--- a/Tests/OpenAPIKitTests/Document/DocumentTests.swift
+++ b/Tests/OpenAPIKitTests/Document/DocumentTests.swift
@@ -938,44 +938,28 @@ extension DocumentTests {
           "webhooks" : {
             "webhook-test" : {
               "delete" : {
-                "responses" : {
 
-                }
               },
               "get" : {
-                "responses" : {
 
-                }
               },
               "head" : {
-                "responses" : {
 
-                }
               },
               "options" : {
-                "responses" : {
 
-                }
               },
               "patch" : {
-                "responses" : {
 
-                }
               },
               "post" : {
-                "responses" : {
 
-                }
               },
               "put" : {
-                "responses" : {
 
-                }
               },
               "trace" : {
-                "responses" : {
 
-                }
               }
             }
           }
@@ -1024,36 +1008,20 @@ extension DocumentTests {
         "webhooks": {
           "webhook-test": {
             "delete": {
-              "responses": {
-              }
             },
             "get": {
-              "responses": {
-              }
             },
             "head": {
-              "responses": {
-              }
             },
             "options": {
-              "responses": {
-              }
             },
             "patch": {
-              "responses": {
-              }
             },
             "post": {
-              "responses": {
-              }
             },
             "put": {
-              "responses": {
-              }
             },
             "trace": {
-              "responses": {
-              }
             }
           }
         }

--- a/Tests/OpenAPIKitTests/Operation/OperationTests.swift
+++ b/Tests/OpenAPIKitTests/Operation/OperationTests.swift
@@ -72,27 +72,37 @@ extension OperationTests {
             encodedOperation,
             """
             {
-              "responses" : {
 
-              }
             }
             """
         )
     }
 
     func test_minimal_decode() throws {
-        let operationData =
+        let operationData1 =
         """
         {
           "responses" : {}
         }
         """.data(using: .utf8)!
 
-        let operation = try orderUnstableDecode(OpenAPI.Operation.self, from: operationData)
+        let operationData2 =
+        """
+        {
+        }
+        """.data(using: .utf8)!
+
+        let operation1 = try orderUnstableDecode(OpenAPI.Operation.self, from: operationData1)
+        let operation2 = try orderUnstableDecode(OpenAPI.Operation.self, from: operationData2)
 
         XCTAssertEqual(
-            operation,
+            operation1,
             OpenAPI.Operation(responses: [:])
+        )
+
+        XCTAssertEqual(
+            operation1,
+            operation2
         )
     }
 

--- a/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
+++ b/Tests/OpenAPIKitTests/Path Item/PathItemTests.swift
@@ -271,44 +271,28 @@ extension PathItemTests {
             """
             {
               "delete" : {
-                "responses" : {
 
-                }
               },
               "get" : {
-                "responses" : {
 
-                }
               },
               "head" : {
-                "responses" : {
 
-                }
               },
               "options" : {
-                "responses" : {
 
-                }
               },
               "patch" : {
-                "responses" : {
 
-                }
               },
               "post" : {
-                "responses" : {
 
-                }
               },
               "put" : {
-                "responses" : {
 
-                }
               },
               "trace" : {
-                "responses" : {
 
-                }
               }
             }
             """
@@ -320,44 +304,20 @@ extension PathItemTests {
         """
         {
           "delete" : {
-            "responses" : {
-
-            }
           },
           "get" : {
-            "responses" : {
-
-            }
           },
           "head" : {
-            "responses" : {
-
-            }
           },
           "options" : {
-            "responses" : {
-
-            }
           },
           "patch" : {
-            "responses" : {
-
-            }
           },
           "post" : {
-            "responses" : {
-
-            }
           },
           "put" : {
-            "responses" : {
-
-            }
           },
           "trace" : {
-            "responses" : {
-
-            }
           }
         }
         """.data(using: .utf8)!

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -430,7 +430,7 @@ final class BuiltinValidationTests: XCTestCase {
         XCTAssertThrowsError(try document.validate(using: validator)) { error in
             let error = error as? ValidationErrorCollection
             XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Operations contain at least one response")
-            XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello/world", "get", "responses"])
+            XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello/world", "get"])
         }
     }
 

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -806,7 +806,10 @@ final class BuiltinValidationTests: XCTestCase {
                             .xml: .init(schemaReference: .component(named: "schema1")),
                             .txt: .init(schemaReference: .external(URL(string: "https://website.com/file.json#/hello/world")!))
                         ],
-                        links: ["linky": .reference(.component(named: "link1"))]
+                        links: [
+                            "linky": .reference(.component(named: "link1")),
+                            "linky2": .reference(.external(URL(string: "https://linky.com")!))
+                        ]
                     )
                 ]
             )
@@ -817,7 +820,8 @@ final class BuiltinValidationTests: XCTestCase {
             servers: [],
             paths: [
                 "/hello": .pathItem(path),
-                "/world": .reference(.component(named: "path1"))
+                "/world": .reference(.component(named: "path1")),
+                "/external": .reference(.external(URL(string: "https://other-world.com")!))
             ],
             components: .init(
                 schemas: [

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -414,6 +414,44 @@ final class BuiltinValidationTests: XCTestCase {
         try document.validate(using: validator)
     }
 
+    func test_noResponsesOnOperationFails() {
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello/world": .init(
+                    get: .init(responses: [:])
+                )
+            ],
+            components: .noComponents
+        )
+
+        let validator = Validator.blank.validating(.operationsContainResponses)
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let error = error as? ValidationErrorCollection
+            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Operations contain at least one response")
+            XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello/world", "get", "responses"])
+        }
+    }
+
+    func test_oneResponseOnOperationSucceeds() throws {
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello/world": .init(
+                    get: .init(responses: [
+                        200: .response(description: "hi")
+                    ])
+                )
+            ],
+            components: .noComponents
+        )
+
+        let validator = Validator.blank.validating(.operationsContainResponses)
+        try document.validate(using: validator)
+    }
+
     func test_duplicateTagOnDocumentFails() {
         let document = OpenAPI.Document(
             info: .init(title: "test", version: "1.0"),
@@ -438,44 +476,6 @@ final class BuiltinValidationTests: XCTestCase {
             paths: [:],
             components: .noComponents,
             tags: ["hello", "world"]
-        )
-
-        // NOTE this is part of default validation
-        try document.validate()
-    }
-
-    func test_noResponsesOnOperationFails() {
-        let document = OpenAPI.Document(
-            info: .init(title: "test", version: "1.0"),
-            servers: [],
-            paths: [
-                "/hello/world": .init(
-                    get: .init(responses: [:])
-                )
-            ],
-            components: .noComponents
-        )
-
-        // NOTE this is part of default validation
-        XCTAssertThrowsError(try document.validate()) { error in
-            let error = error as? ValidationErrorCollection
-            XCTAssertEqual(error?.values.first?.reason, "Failed to satisfy: Operations contain at least one response")
-            XCTAssertEqual(error?.values.first?.codingPath.map { $0.stringValue }, ["paths", "/hello/world", "get", "responses"])
-        }
-    }
-
-    func test_oneResponseOnOperationSucceeds() throws {
-        let document = OpenAPI.Document(
-            info: .init(title: "test", version: "1.0"),
-            servers: [],
-            paths: [
-                "/hello/world": .init(
-                    get: .init(responses: [
-                        200: .response(description: "hi")
-                    ])
-                )
-            ],
-            components: .noComponents
         )
 
         // NOTE this is part of default validation

--- a/documentation/validation.md
+++ b/documentation/validation.md
@@ -549,7 +549,7 @@ try document.validate(using: validator)
 ### Tips and Quirks
 This section contains tips for using the validation framework and quirks of the framework that could cause some confusion.
 
-#### Validation is tied to encoding
+#### Validation of empty Arrays & Maps
 The validation framework is tied to the process of encoding an OpenAPI document. This generally
 provides some really nice benefits for free (like tracking the path under which a validation is
 being run).
@@ -562,4 +562,32 @@ A concrete example of this quirk is the `Response.Map` under a `PathItem`. If th
 (but not `OpenAPIKit30`) will omit the `responses` key from encoding. If you want to check that the responses are not 
 empty as is done in the built-in validation `operationsContainResponses` you need your validation context to be the whole 
 `Operation` not just the `Response.Map`.
+
+Here's a table of Array/Map types for which this quirk is relevant and which modules the quirk applies to:
+
+  | Property                             | Type                    | OpenAPIKit30 | OpenAPIKit |
+  |--------------------------------------|-------------------------|--------------|------------|
+  | `OpenAPI.Components.callbacks`       | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.examples`        | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.headers`         | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.links`           | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.parameters`      | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.pathItems`       | `ComponentDictionary`   |              | x          |
+  | `OpenAPI.Components.requestBodies`   | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.responses`       | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.schemas`         | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Components.securitySchemes` | `ComponentDictionary`   | x            | x          |
+  | `OpenAPI.Document.components`        | `Components`            | x            | x          |
+  | `OpenAPI.Document.security`          | `[SecurityRequirement]` | x            | x          |
+  | `OpenAPI.Document.servers`           | `[Server]`              | x            | x          |
+  | `OpenAPI.Document.webhooks`          | `OrderedDictionary`     |              | x          |
+  | `OpenAPI.Link.parameters`            | `OrderedDictionary`     | x            | x          |
+  | `OpenAPI.Operation.callbacks`        | `CallbacksMap`          | x            | x          |
+  | `OpenAPI.Operation.parameters`       | `Parameter.Array`       | x            | x          |
+  | `OpenAPI.Operation.responses`        | `Response.Map`          |              | x          |
+  | `OpenAPI.PathItem.parameters`        | `Parameter.Array`       | x            | x          |
+  | `OpenAPI.PathItem.responses`         | `Response.Map`          | x            | x          |
+  | `OpenAPI.Response.content`           | `Content.Map`           | x            | x          |
+  | `OpenAPI.Response.links`             | `Link.Map`              | x            | x          |
+  | `OpenAPI.Server.Variable.enum`       | `[String]`              | x            | x          |
 

--- a/documentation/validation.md
+++ b/documentation/validation.md
@@ -14,6 +14,7 @@
     - [A Valid OpenAPI Document](#a-valid-openapi-document)
     - [An Invalid OpenAPI Document](#an-invalid-openapi-document)
     - [Validation Code](#validation-code)
+- [Tips and Quirks](#tips-and-quirks)
 
 ### Executing Validations
 
@@ -544,3 +545,21 @@ let validator = Validator()
 
 try document.validate(using: validator)
 ```
+
+### Tips and Quirks
+This section contains tips for using the validation framework and quirks of the framework that could cause some confusion.
+
+#### Validation is tied to encoding
+The validation framework is tied to the process of encoding an OpenAPI document. This generally
+provides some really nice benefits for free (like tracking the path under which a validation is
+being run).
+
+One place where this can cause confusion is where certain values within an OpenAPIKit type are omitted from encoding
+when they are empty. Because of this, using those types as the `Context` for a validation will only work if the type is
+not empty and cannot be used to assert that the type is or is not empty.
+
+A concrete example of this quirk is the `Response.Map` under a `PathItem`. If this map is empty, the `OpenAPIKit` module
+(but not `OpenAPIKit30`) will omit the `responses` key from encoding. If you want to check that the responses are not 
+empty as is done in the built-in validation `operationsContainResponses` you need your validation context to be the whole 
+`Operation` not just the `Response.Map`.
+


### PR DESCRIPTION
Closes https://github.com/mattpolzin/OpenAPIKit/issues/193.

Todo:
- [x] Test that documents with the responses keyword omitted are parsed successfully.
- [x] Update tests for encoding to show that empty responses gets encoded as omitting the responses keyword.