### PR TITLE
Add context for `null` schemas

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -16,7 +16,7 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
     public typealias IntegerContext = JSONSchema.IntegerContext
     public typealias StringContext = JSONSchema.StringContext
 
-    case null
+    case null(CoreContext<JSONTypeFormat.AnyFormat>)
     case boolean(CoreContext<JSONTypeFormat.BooleanFormat>)
     case number(CoreContext<JSONTypeFormat.NumberFormat>, NumericContext)
     case integer(CoreContext<JSONTypeFormat.IntegerFormat>, IntegerContext)
@@ -43,8 +43,8 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
     /// not true.
     public var jsonSchema: JSONSchema {
         switch self {
-        case .null:
-            return .null
+        case .null(let coreContext):
+            return .null(coreContext)
         case .boolean(let context):
             return .boolean(context)
         case .object(let coreContext, let objectContext):
@@ -72,8 +72,8 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
 
     func optionalSchemaObject() -> DereferencedJSONSchema {
         switch self {
-        case .null:
-            return .null
+        case .null(let coreContext):
+            return .null(coreContext.optionalContext())
         case .boolean(let context):
             return .boolean(context.optionalContext())
         case .object(let contextA, let contextB):
@@ -146,8 +146,8 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
     /// Returns a version of this `DereferencedJSONSchema` that has the given description.
     public func with(description: String) -> DereferencedJSONSchema {
         switch self {
-        case .null:
-            return .null
+        case .null(let coreContext):
+            return .null(coreContext.with(description: description))
         case .boolean(let context):
             return .boolean(context.with(description: description))
         case .object(let coreContext, let objectContext):
@@ -391,8 +391,8 @@ extension JSONSchema: LocallyDereferenceable {
         dereferencedFromComponentNamed name: String?
     ) throws -> DereferencedJSONSchema {
         switch value {
-        case .null:
-            return .null
+        case .null(let coreContext):
+            return .null(coreContext)
         case .reference(let reference, let context):
             var dereferenced = try reference._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
             if !context.required {

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -120,8 +120,8 @@ internal struct FragmentCombiner {
         } else {
             // the only case where starting with a fragment breaks down is when you actually
             // should end up with plain old `.null`
-            guard fragment != .null else {
-                self.combinedFragment = .null
+            if case let .null(coreContext) = fragment.value {
+                self.combinedFragment = .null(coreContext)
                 return
             }
             // combination can turn `required: false` into `required: true`
@@ -154,8 +154,8 @@ internal struct FragmentCombiner {
             }
             try combine(component)
 
-        case (.null, .null):
-            self.combinedFragment = .null
+        case (.null(let leftCoreContext), .null(let rightCoreContext)):
+            self.combinedFragment = .null(try leftCoreContext.combined(with: rightCoreContext))
 
         case (.fragment(let leftCoreContext), .fragment(let rightCoreContext)):
             self.combinedFragment = .fragment(try leftCoreContext.combined(with: rightCoreContext))

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -37,7 +37,9 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
 
     /// The null type, which replaces the functionality of the `nullable` property from
     /// previous versions of the OpenAPI specification.
-    public static let null: Self = .init(schema: .null(.init(nullable: true)))
+    public static func null(_ core: CoreContext<JSONTypeFormat.AnyFormat> = .init(nullable: true)) -> Self {
+        .init(schema: .null(core.nullableContext()))
+    }
     public static func boolean(_ core: CoreContext<JSONTypeFormat.BooleanFormat>) -> Self {
         .init(schema: .boolean(core))
     }
@@ -1695,9 +1697,10 @@ extension JSONSchema {
     public static func reference(
         _ reference: JSONReference<JSONSchema>,
         required: Bool = true,
+        title: String? = nil,
         description: String? = nil
     ) -> JSONSchema {
-        return .reference(reference, .init(required: required, description: description))
+        return .reference(reference, .init(required: required, title: title, description: description))
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -37,7 +37,7 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
 
     /// The null type, which replaces the functionality of the `nullable` property from
     /// previous versions of the OpenAPI specification.
-    public static let null: Self = .init(schema: .null)
+    public static let null: Self = .init(schema: .null(.init(nullable: true)))
     public static func boolean(_ core: CoreContext<JSONTypeFormat.BooleanFormat>) -> Self {
         .init(schema: .boolean(core))
     }
@@ -79,7 +79,7 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
     public enum Schema: Equatable {
         /// The null type, which replaces the functionality of the `nullable` property from
         /// previous versions of the OpenAPI specification.
-        case null
+        case null(CoreContext<JSONTypeFormat.AnyFormat>)
         case boolean(CoreContext<JSONTypeFormat.BooleanFormat>)
         case number(CoreContext<JSONTypeFormat.NumberFormat>, NumericContext)
         case integer(CoreContext<JSONTypeFormat.IntegerFormat>, IntegerContext)
@@ -160,53 +160,19 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
 
     // See `JSONSchemaContext`
     public var required: Bool {
-        switch value {
-        case .null:
-            #warning("TODO: not sure about this -- maybe null type should get a context still")
-            return false
-        case .boolean(let context as JSONSchemaContext),
-             .object(let context as JSONSchemaContext, _),
-             .array(let context as JSONSchemaContext, _),
-             .number(let context as JSONSchemaContext, _),
-             .integer(let context as JSONSchemaContext, _),
-             .string(let context as JSONSchemaContext, _),
-             .fragment(let context as JSONSchemaContext),
-             .all(of: _, core: let context as JSONSchemaContext),
-             .one(of: _, core: let context as JSONSchemaContext),
-             .any(of: _, core: let context as JSONSchemaContext),
-             .not(_, core: let context as JSONSchemaContext):
-            return context.required
-        case .reference(_, let context):
-            return context.required
-        }
+        return coreContext?.required ?? true
     }
 
     // See `JSONSchemaContext`
     public var description: String? {
-        switch value {
-        case .boolean(let context as JSONSchemaContext),
-             .object(let context as JSONSchemaContext, _),
-             .array(let context as JSONSchemaContext, _),
-             .number(let context as JSONSchemaContext, _),
-             .integer(let context as JSONSchemaContext, _),
-             .string(let context as JSONSchemaContext, _),
-             .fragment(let context as JSONSchemaContext),
-             .all(of: _, core: let context as JSONSchemaContext),
-             .one(of: _, core: let context as JSONSchemaContext),
-             .any(of: _, core: let context as JSONSchemaContext),
-             .not(_, core: let context as JSONSchemaContext):
-            return context.description
-        case .reference(_, let referenceContext):
-            return referenceContext.description
-        case .null:
-            return nil
-        }
+        return coreContext?.description
     }
 
     // See `JSONSchemaContext`
     public var discriminator: OpenAPI.Discriminator? {
         switch value {
-        case .boolean(let context as JSONSchemaContext),
+        case .null(let context as JSONSchemaContext),
+             .boolean(let context as JSONSchemaContext),
              .object(let context as JSONSchemaContext, _),
              .array(let context as JSONSchemaContext, _),
              .number(let context as JSONSchemaContext, _),
@@ -218,14 +184,13 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings, VendorExtendable {
              .any(of: _, core: let context as JSONSchemaContext),
              .not(_, core: let context as JSONSchemaContext):
             return context.discriminator
-        case .reference, .null:
+        case .reference:
             return nil
         }
     }
 
     // See `JSONSchemaContext`
     public var nullable: Bool {
-        guard self != .null else { return true }
         return coreContext?.nullable ?? false
     }
 
@@ -365,7 +330,8 @@ extension JSONSchema {
     ///
     public var coreContext: JSONSchemaContext? {
         switch value {
-        case .boolean(let context as JSONSchemaContext),
+        case .null(let context as JSONSchemaContext),
+             .boolean(let context as JSONSchemaContext),
              .object(let context as JSONSchemaContext, _),
              .array(let context as JSONSchemaContext, _),
              .number(let context as JSONSchemaContext, _),
@@ -375,12 +341,9 @@ extension JSONSchema {
              .all(of: _, core: let context as JSONSchemaContext),
              .one(of: _, core: let context as JSONSchemaContext),
              .any(of: _, core: let context as JSONSchemaContext),
-             .not(_, core: let context as JSONSchemaContext):
+             .not(_, core: let context as JSONSchemaContext),
+             .reference(_, let context as JSONSchemaContext):
             return context
-        case .reference(_, let context as JSONSchemaContext):
-            return context
-        case .null:
-            return nil
         }
     }
 
@@ -516,8 +479,12 @@ extension JSONSchema {
                 schema: .reference(reference, context.optionalContext()),
                 vendorExtensions: vendorExtensions
             )
-        case .null:
-            return self
+        case .null(let context):
+            return .init(
+                warnings: warnings,
+                schema: .null(context.optionalContext()),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 
@@ -596,8 +563,12 @@ extension JSONSchema {
                 schema: .reference(reference, context.requiredContext()),
                 vendorExtensions: vendorExtensions
             )
-        case .null:
-            return self
+        case .null(let context):
+            return .init(
+                warnings: warnings,
+                schema: .null(context.requiredContext()),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 
@@ -745,8 +716,18 @@ extension JSONSchema {
                 schema: .not(schema, core: core.with(allowedValues: allowedValues)),
                 vendorExtensions: vendorExtensions
             )
-        case .reference, .null:
-            return self
+        case .reference(let schema, let core):
+            return .init(
+                warnings: warnings,
+                schema: .reference(schema, core.with(allowedValues: allowedValues)),
+                vendorExtensions: vendorExtensions
+            )
+        case .null(let core):
+            return .init(
+                warnings: warnings,
+                schema: .null(core.with(allowedValues: allowedValues)),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 
@@ -819,8 +800,18 @@ extension JSONSchema {
                 schema: .not(schema, core: core.with(defaultValue: defaultValue)),
                 vendorExtensions: vendorExtensions
             )
-        case .reference, .null:
-            return self
+        case .reference(let schema, let core):
+            return .init(
+                warnings: warnings,
+                schema: .reference(schema, core.with(defaultValue: defaultValue)),
+                vendorExtensions: vendorExtensions
+            )
+        case .null(let core):
+            return .init(
+                warnings: warnings,
+                schema: .null(core.with(defaultValue: defaultValue)),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 
@@ -900,8 +891,18 @@ extension JSONSchema {
                 schema: .not(schema, core: core.with(examples: examples)),
                 vendorExtensions: vendorExtensions
             )
-        case .reference, .null:
-            throw Self.Error.exampleNotSupported
+        case .reference(let schema, let core):
+            return .init(
+                warnings: warnings,
+                schema: .reference(schema, core.with(examples: examples)),
+                vendorExtensions: vendorExtensions
+            )
+        case .null(let core):
+            return .init(
+                warnings: warnings,
+                schema: .null(core.with(examples: examples)),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 
@@ -1054,21 +1055,12 @@ extension JSONSchema {
                 schema: .reference(ref, referenceContext.with(description: description)),
                 vendorExtensions: vendorExtensions
             )
-        case .null:
-            return self
-        }
-    }
-}
-
-extension JSONSchema {
-    internal enum Error: Swift.Error, CustomStringConvertible, Equatable {
-        case exampleNotSupported
-
-        public var description: String {
-            switch self {
-            case .exampleNotSupported:
-                return "examples not supported for `.allOf`, `.oneOf`, `.anyOf`, `.not`, `.null` or for JSON references ($ref)."
-            }
+        case .null(let referenceContext):
+            return .init(
+                warnings: warnings,
+                schema: .null(referenceContext.with(description: description)),
+                vendorExtensions: vendorExtensions
+            )
         }
     }
 }
@@ -1758,9 +1750,10 @@ extension JSONSchema: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         switch value {
-        case .null:
+        case .null(let coreContext):
             var container = encoder.container(keyedBy: NullCodingKeys.self)
             try container.encode(JSONType.null.rawValue, forKey: .type)
+            try coreContext.encode(to: encoder)
 
         case .boolean(let context):
             try context.encode(to: encoder)
@@ -1925,7 +1918,8 @@ extension JSONSchema: Decodable {
         }
 
         if typeHint == .null {
-            value = .null
+            let coreContext = try CoreContext<JSONTypeFormat.AnyFormat>(from: decoder)
+            value = .null(coreContext)
 
         } else if typeHint == .integer || typeHint == .number || (typeHint == nil && !numericOrIntegerContainer.allKeys.isEmpty) {
             if typeHint == .integer {

--- a/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
@@ -125,8 +125,8 @@ final class DereferencedSchemaObjectTests: XCTestCase {
         XCTAssertEqual(t20, .all(of: [.string(.init(), .init())], core: .init(discriminator: .init(propertyName: "test"))))
         XCTAssertEqual(t20?.discriminator, .init(propertyName: "test"))
 
-        let t21 = JSONSchema.null.dereferenced()
-        XCTAssertEqual(t21, .null)
+        let t21 = JSONSchema.null().dereferenced()
+        XCTAssertEqual(t21, .null(.init(nullable: true)))
 
         // bonus tests around simplifying:
         let t22 = try JSONSchema.all(of: []).dereferenced()?.simplified()
@@ -259,8 +259,8 @@ final class DereferencedSchemaObjectTests: XCTestCase {
         XCTAssertEqual(t23, .string(.init(discriminator: .init(propertyName: "test")), .init()))
         XCTAssertEqual(t23.discriminator, .init(propertyName: "test"))
 
-        let t24 = try JSONSchema.null.dereferenced(in: components)
-        XCTAssertEqual(t24, .null)
+        let t24 = try JSONSchema.null().dereferenced(in: components)
+        XCTAssertEqual(t24, .null(.init(nullable: true)))
     }
 
     func test_optionalReferenceMissing() {
@@ -514,7 +514,7 @@ final class DereferencedSchemaObjectTests: XCTestCase {
     }
 
     func test_withDescription() throws {
-        let null = JSONSchema.null.dereferenced()!.with(description: "test")
+        let null = JSONSchema.null().dereferenced()!.with(description: "test")
         let object = JSONSchema.object.dereferenced()!.with(description: "test")
         let array = JSONSchema.array.dereferenced()!.with(description: "test")
 
@@ -542,7 +542,7 @@ final class DereferencedSchemaObjectTests: XCTestCase {
         XCTAssertEqual(any.description, "test")
         XCTAssertEqual(not.description, "test")
 
-        XCTAssertNil(null.description)
+        XCTAssertEqual(null.description, "test")
     }
 
 }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -11,7 +11,7 @@ import OpenAPIKit
 
 final class SchemaObjectTests: XCTestCase {
     func test_jsonTypeFormat() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -156,7 +156,7 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertFalse(fragment.isEmpty)
 
         let others: [JSONSchema] = [
-            .null,
+            .null(),
             .boolean(.init(format: .unspecified, required: true)),
             .object(.init(format: .unspecified, required: true), .init(properties: [:])),
             .array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true)))),
@@ -186,7 +186,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_booleanTypeChecks() {
-        let null: JSONSchema = .null
+        let null: JSONSchema = .null()
         let fragment: JSONSchema = .fragment
         let boolean: JSONSchema = .boolean
         let number: JSONSchema = .number
@@ -288,8 +288,8 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_required() {
-        let null = JSONSchema.null
-        let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
+        let null = JSONSchema.null()
+        let boolean = JSONSchema.boolean(.init(required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
         let number = JSONSchema.number(.init(format: .unspecified, required: true), .init())
@@ -302,7 +302,7 @@ final class SchemaObjectTests: XCTestCase {
         let not = JSONSchema.not(boolean)
         let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
 
-        XCTAssertFalse(null.required)
+        XCTAssertTrue(null.required)
         XCTAssertTrue(boolean.required)
         XCTAssertTrue(object.required)
         XCTAssertTrue(array.required)
@@ -318,7 +318,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_optional() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(format: .unspecified, required: false))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: false))
         let object = JSONSchema.object(.init(format: .unspecified, required: false), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: false), .init(items: .boolean(.init(format: .unspecified, required: false))))
@@ -351,7 +351,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_nullable() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, nullable: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, nullable: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, nullable: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -379,7 +379,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_notNullable() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(nullable: false))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -393,7 +393,9 @@ final class SchemaObjectTests: XCTestCase {
         let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
         let fragment = JSONSchema.fragment(.init(description: nil))
 
+        // .null is ALWAYS nullable by definition, no matter what CoreContext it was created with.
         XCTAssertTrue(null.nullable)
+
         XCTAssertFalse(boolean.nullable)
         XCTAssertFalse(object.nullable)
         XCTAssertFalse(array.nullable)
@@ -409,7 +411,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_readableAndWritable() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -455,7 +457,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_readOnly() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(permissions: .readOnly))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, permissions: .readOnly))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, permissions: .readOnly), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, permissions: .readOnly), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -468,9 +470,8 @@ final class SchemaObjectTests: XCTestCase {
         let oneOf = JSONSchema.one(of: [], core: .init(permissions: .readOnly))
         let not = JSONSchema.not(.string, core: .init(permissions: .readOnly))
 
-        XCTAssertFalse(null.readOnly)
+        XCTAssertTrue(null.readOnly)
         XCTAssertFalse(null.writeOnly)
-
         XCTAssertTrue(boolean.readOnly)
         XCTAssertFalse(boolean.writeOnly)
         XCTAssertTrue(object.readOnly)
@@ -497,7 +498,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_writeOnly() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(permissions: .writeOnly))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, permissions: .writeOnly))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, permissions: .writeOnly), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, permissions: .writeOnly), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -511,8 +512,7 @@ final class SchemaObjectTests: XCTestCase {
         let not = JSONSchema.not(.string, core: .init(permissions: .writeOnly))
 
         XCTAssertFalse(null.readOnly)
-        XCTAssertFalse(null.writeOnly)
-
+        XCTAssertTrue(null.writeOnly)
         XCTAssertFalse(boolean.readOnly)
         XCTAssertTrue(boolean.writeOnly)
         XCTAssertFalse(object.readOnly)
@@ -538,7 +538,7 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertTrue(not.writeOnly)
     }
     func test_notDeprecated() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -569,7 +569,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_deprecated() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(deprecated: true))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, deprecated: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, deprecated: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, deprecated: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -582,7 +582,7 @@ final class SchemaObjectTests: XCTestCase {
         let oneOf = JSONSchema.one(of: [], core: .init(deprecated: true))
         let not = JSONSchema.not(.string, core: .init(deprecated: true))
 
-        XCTAssertFalse(null.deprecated)
+        XCTAssertTrue(null.deprecated)
         XCTAssertTrue(boolean.deprecated)
         XCTAssertTrue(object.deprecated)
         XCTAssertTrue(array.deprecated)
@@ -598,7 +598,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_title() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(title: "hello"))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, title: "hello"))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, title: "hello"), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, title: "hello"), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -610,9 +610,10 @@ final class SchemaObjectTests: XCTestCase {
         let anyOf = JSONSchema.any(of: [boolean], core: .init(title: "hello"))
         let oneOf = JSONSchema.one(of: [boolean], core: .init(title: "hello"))
         let not = JSONSchema.not(boolean, core: .init(title: "hello"))
-        let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
+        let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!), title: "hello")
         let fragment = JSONSchema.fragment(.init(title: "hello"))
 
+        XCTAssertEqual(null.title, "hello")
         XCTAssertEqual(boolean.title, "hello")
         XCTAssertEqual(object.title, "hello")
         XCTAssertEqual(array.title, "hello")
@@ -625,13 +626,11 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(oneOf.title, "hello")
         XCTAssertEqual(not.title, "hello")
         XCTAssertEqual(fragment.title, "hello")
-
-        XCTAssertNil(reference.title)
-        XCTAssertNil(null.title)
+        XCTAssertEqual(reference.title, "hello")
     }
 
     func test_description() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(description: "hello"))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, description: "hello"))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, description: "hello"), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, description: "hello"), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -647,6 +646,7 @@ final class SchemaObjectTests: XCTestCase {
         let fragment = JSONSchema.fragment(.init(description: nil))
         let fragmentWithDescription = JSONSchema.fragment(.init(description: "hello"))
 
+        XCTAssertEqual(null.description, "hello")
         XCTAssertEqual(boolean.description, "hello")
         XCTAssertEqual(object.description, "hello")
         XCTAssertEqual(array.description, "hello")
@@ -662,11 +662,10 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(reference.description, "hello")
 
         XCTAssertNil(fragment.description)
-        XCTAssertNil(null.description)
     }
 
     func test_discriminator() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, discriminator: .init(propertyName: "name")))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, discriminator: .init(propertyName: "name")), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, discriminator: .init(propertyName: "name")), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -701,7 +700,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_externalDocs() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(externalDocs:.init(url: URL(string: "http://google.com")!)))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, externalDocs: .init(url: URL(string: "http://google.com")!)))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, externalDocs: .init(url: URL(string: "http://google.com")!)), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, externalDocs: .init(url: URL(string: "http://google.com")!)), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -716,6 +715,7 @@ final class SchemaObjectTests: XCTestCase {
         let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
         let fragment = JSONSchema.fragment(.init(externalDocs: .init(url: URL(string: "http://google.com")!)))
 
+        XCTAssertEqual(null.externalDocs, .init(url: URL(string: "http://google.com")!))
         XCTAssertEqual(boolean.externalDocs, .init(url: URL(string: "http://google.com")!))
         XCTAssertEqual(object.externalDocs, .init(url: URL(string: "http://google.com")!))
         XCTAssertEqual(array.externalDocs, .init(url: URL(string: "http://google.com")!))
@@ -730,11 +730,10 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(fragment.externalDocs, .init(url: URL(string: "http://google.com")!))
 
         XCTAssertNil(reference.externalDocs)
-        XCTAssertNil(null.externalDocs)
     }
 
     func test_coreContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -762,12 +761,11 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(oneOf.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
         XCTAssertEqual(not.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
         XCTAssertEqual(reference.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init())
-
-        XCTAssertNil(null.coreContext)
+        XCTAssertEqual(null.coreContext as? JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>, .init(nullable: true))
     }
 
     func test_objectContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [ "hello": .string]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -799,7 +797,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_arrayContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean))
@@ -832,7 +830,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_numberContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean))
@@ -864,7 +862,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_integerContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean))
@@ -896,7 +894,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_stringContextAccessor() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true), .init(items: .boolean))
@@ -957,7 +955,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_requiredToOptional() {
-        let null = JSONSchema.null.optionalSchemaObject()
+        let null = JSONSchema.null().optionalSchemaObject()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
             .optionalSchemaObject()
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
@@ -1008,7 +1006,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_optionalToRequired() {
-        let null = JSONSchema.null.requiredSchemaObject()
+        let null = JSONSchema.null().requiredSchemaObject()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: false))
             .requiredSchemaObject()
         let object = JSONSchema.object(.init(format: .unspecified, required: false), .init(properties: [:]))
@@ -1033,7 +1031,7 @@ final class SchemaObjectTests: XCTestCase {
             .requiredSchemaObject()
         let fragment = JSONSchema.fragment(.init(required: false)).requiredSchemaObject()
 
-        XCTAssertFalse(null.required)
+        XCTAssertTrue(null.required)
         XCTAssertTrue(boolean.required)
         XCTAssertTrue(object.required)
         XCTAssertTrue(array.required)
@@ -1059,7 +1057,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_notNullableToNullable() {
-        let null = JSONSchema.null.nullableSchemaObject()
+        let null = JSONSchema.null().nullableSchemaObject()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
             .nullableSchemaObject()
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
@@ -1101,7 +1099,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_withInitalAllowedValues() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(allowedValues: [nil]))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, allowedValues: [false]))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, allowedValues: [[:]]), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, allowedValues: [[false]]), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -1110,7 +1108,7 @@ final class SchemaObjectTests: XCTestCase {
         let string = JSONSchema.string(.init(format: .unspecified, required: true, allowedValues: ["hello"]), .init())
         let fragment = JSONSchema.fragment(.init(allowedValues: [false]))
 
-        XCTAssertNil(null.allowedValues)
+        XCTAssertEqual(null.allowedValues?[0].description, "nil")
         XCTAssertEqual(boolean.allowedValues, [false])
         XCTAssertEqual(object.allowedValues, [[:]])
         XCTAssertEqual(array.allowedValues?[0].value as! [Bool], [false])
@@ -1121,7 +1119,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_withAddedAllowedValues() {
-        let null = JSONSchema.null.with(allowedValues: [nil])
+        let null = JSONSchema.null().with(allowedValues: [nil])
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
             .with(allowedValues: [false])
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
@@ -1148,7 +1146,7 @@ final class SchemaObjectTests: XCTestCase {
         let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
             .with(allowedValues: ["hello"])
 
-        XCTAssertNil(null.allowedValues)
+        XCTAssertEqual(null.allowedValues, [nil])
         XCTAssertEqual(boolean.allowedValues, [false])
         XCTAssertEqual(object.allowedValues, [AnyCodable([String: String]())])
         XCTAssertEqual(array.allowedValues?[0].value as! [Bool], [false])
@@ -1161,12 +1159,11 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(oneOf.allowedValues, ["hello"])
         XCTAssertEqual(not.allowedValues, ["hello"])
         XCTAssertEqual(fragment.allowedValues, [false])
-
-        XCTAssertNil(reference.allowedValues)
+        XCTAssertEqual(reference.allowedValues, ["hello"])
     }
 
     func test_withInitalDefaultValue() {
-        let null = JSONSchema.null
+        let null = JSONSchema.null(.init(defaultValue: nil))
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true, defaultValue: false))
         let object = JSONSchema.object(.init(format: .unspecified, required: true, defaultValue: [:]), .init(properties: [:]))
         let array = JSONSchema.array(.init(format: .unspecified, required: true, defaultValue: [false]), .init(items: .boolean(.init(format: .unspecified, required: true))))
@@ -1186,7 +1183,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_withAddedDefaultValue() {
-        let null = JSONSchema.null.with(defaultValue: nil)
+        let null = JSONSchema.null().with(defaultValue: nil)
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
             .with(defaultValue: false)
         let object = JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
@@ -1213,7 +1210,7 @@ final class SchemaObjectTests: XCTestCase {
         let reference = JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
             .with(defaultValue: "hello")
 
-        XCTAssertNil(null.defaultValue)
+        XCTAssertEqual(null.defaultValue!, nil)
         XCTAssertEqual(boolean.defaultValue, false)
         XCTAssertEqual(object.defaultValue, AnyCodable([String: String]()))
         XCTAssertEqual(array.defaultValue, [false])
@@ -1233,9 +1230,9 @@ final class SchemaObjectTests: XCTestCase {
     func test_withInitialExample() {
         let object = JSONSchema.object(.init(format: .unspecified, required: true, examples: [[:]]), .init(properties: [:]))
         let fragment = JSONSchema.fragment(.init(examples: ["hi"]))
+        let null = JSONSchema.null(.init(examples: ["null"]))
 
         // nonsense
-        let null = JSONSchema.null
         let all = JSONSchema.all(of: [])
         let one = JSONSchema.one(of: [])
         let any = JSONSchema.any(of: [])
@@ -1246,8 +1243,9 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(object.examples.count, 1)
         XCTAssertEqual(fragment.examples[0].value as? String, "hi")
         XCTAssertEqual(fragment.examples.count, 1)
+        XCTAssertEqual(null.examples.count, 1)
+        XCTAssertEqual(null.examples[0].value as? String, "null")
 
-        XCTAssertTrue(null.examples.isEmpty)
         XCTAssertTrue(all.examples.isEmpty)
         XCTAssertTrue(one.examples.isEmpty)
         XCTAssertTrue(any.examples.isEmpty)
@@ -1256,6 +1254,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_withAddedExample() throws {
+        let null = try JSONSchema.null().with(example: nil)
         let object = try JSONSchema.object(.init(format: .unspecified, required: true), .init(properties: [:]))
             .with(example: AnyCodable([String: String]()))
         let array = try JSONSchema.array(.init(), .init())
@@ -1281,11 +1280,9 @@ final class SchemaObjectTests: XCTestCase {
         let not = try JSONSchema.not(object)
             .with(example: ["hello"])
         let fragment = try JSONSchema.fragment(.init()).with(example: "hi")
+        let reference = try JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!),.init()).with(example: "hi")
 
-        XCTAssertThrowsError(try JSONSchema.null.with(example: nil))
-        XCTAssertThrowsError(try JSONSchema.reference(.external(URL(string: "hello/world.json#/hello")!))
-            .with(example: ["hello"]))
-
+        XCTAssertEqual(null.examples[0].description, "nil")
         XCTAssertEqual(object.examples[0].value as? [String: String], [:])
         XCTAssertEqual(object.examples.count, 1)
         XCTAssertEqual(array.examples[0].value as? [String], ["hello"])
@@ -1312,10 +1309,12 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(not.examples.count, 1)
         XCTAssertEqual(fragment.examples[0].value as? String, "hi")
         XCTAssertEqual(fragment.examples.count, 1)
+        XCTAssertEqual(reference.examples[0].value as? String, "hi")
+        XCTAssertEqual(reference.examples.count, 1)
     }
 
     func test_withDiscriminator() throws {
-        let null = JSONSchema.null.with(discriminator: .init(propertyName: "test"))
+        let null = JSONSchema.null().with(discriminator: .init(propertyName: "test"))
         let object = JSONSchema.object.with(discriminator: .init(propertyName: "test"))
         let array = JSONSchema.array.with(discriminator: .init(propertyName: "test"))
 
@@ -1349,7 +1348,7 @@ final class SchemaObjectTests: XCTestCase {
     }
 
     func test_withDescription() throws {
-        let null = JSONSchema.null.with(description: "test")
+        let null = JSONSchema.null().with(description: "test")
         let object = JSONSchema.object.with(description: "test")
         let array = JSONSchema.array.with(description: "test")
 
@@ -1364,6 +1363,7 @@ final class SchemaObjectTests: XCTestCase {
         let not = JSONSchema.not(.string).with(description: "test")
         let reference = JSONSchema.reference(.component(named: "test")).with(description: "test")
 
+        XCTAssertEqual(null.description, "test")
         XCTAssertEqual(object.description, "test")
         XCTAssertEqual(array.description, "test")
 
@@ -1378,8 +1378,6 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(any.description, "test")
         XCTAssertEqual(not.description, "test")
         XCTAssertEqual(reference.description, "test")
-
-        XCTAssertNil(null.description)
     }
 
     func test_minObjectProperties() {
@@ -1660,11 +1658,11 @@ extension SchemaObjectTests {
 
         let decoded = try orderUnstableDecode(JSONSchema.self, from: nullTypeData)
 
-        XCTAssertEqual(decoded, .null)
+        XCTAssertEqual(decoded, .null())
     }
 
     func test_encodeNullType() throws {
-        let nullType = JSONSchema.null
+        let nullType = JSONSchema.null()
 
         let encoded = try orderUnstableTestStringFromEncoding(of: nullType)
 

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1477,6 +1477,30 @@ extension SchemaObjectTests {
         XCTAssertThrowsError(try orderUnstableDecode(JSONSchema.self, from: readOnlyWriteOnlyData))
     }
 
+    func test_decodingWithVendorExtensionsTurnedOff() throws {
+        let vendorExtendedData = """
+        {
+            "type": "object",
+            "x-hello": "hi"
+        }
+        """.data(using: .utf8)!
+
+        let nonVendorExtendedData = """
+        {
+            "type": "object"
+        }
+        """.data(using: .utf8)!
+
+        VendorExtensionsConfiguration.isEnabled = false
+
+        let vendorExtended = try orderUnstableDecode(JSONSchema.self, from: vendorExtendedData)
+        let nonVendorExtended = try orderUnstableDecode(JSONSchema.self, from: nonVendorExtendedData)
+
+        XCTAssertEqual(vendorExtended, nonVendorExtended)
+
+        VendorExtensionsConfiguration.isEnabled = true
+    }
+
     func test_decodingWarnsForTypeAndPropertyConflict() throws {
         // has type "object" but "items" property that belongs with the "array" type.
         let badSchema = """

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
@@ -32,11 +32,11 @@ final class SchemaFragmentCombiningTests: XCTestCase {
 
     func test_resolvingSingleNull() {
         let fragments: [JSONSchema] = [
-            .null
+            .null()
         ]
         XCTAssertEqual(
             try fragments.combined(resolvingAgainst: .noComponents),
-            .null
+            .null(.init(nullable: true))
         )
     }
 
@@ -263,7 +263,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndBoolean() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .boolean()
             ],
             .boolean(.init(nullable: true))
@@ -273,7 +273,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndInteger() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .integer()
             ],
             .integer(.init(nullable: true), .init())
@@ -283,7 +283,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndNumber() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .number()
             ],
             .number(.init(nullable: true), .init())
@@ -293,7 +293,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndString() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .string()
             ],
             .string(.init(nullable: true), .init())
@@ -303,7 +303,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndArray() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .array()
             ],
             .array(.init(nullable: true), DereferencedJSONSchema.ArrayContext.init(.init())!)
@@ -313,7 +313,7 @@ final class SchemaFragmentCombiningTests: XCTestCase {
     func test_nullAndObject() throws {
         try assertOrderIndependentCombinedEqual(
             [
-                .null,
+                .null(),
                 .object()
             ],
             .object(.init(nullable: true), DereferencedJSONSchema.ObjectContext.init(.init(properties: [:]))!)


### PR DESCRIPTION
There are some keywords (and also the concept of "required") that need to exist for `null` schemas just like any other schema types.