### PR TITLE
Bugfix/294 dereferencing callbacks

### DIFF
--- a/Sources/OpenAPIKit/Callbacks.swift
+++ b/Sources/OpenAPIKit/Callbacks.swift
@@ -26,4 +26,14 @@ extension OpenAPI {
     /// A dictionary of Dereferenced map of callbacks.
     public typealias DereferencedCallbacksMap = OrderedDictionary<String, DereferencedCallbacks>
 }
+
+extension OpenAPI.CallbackURL: LocallyDereferenceable {
+    public func _dereferenced(
+        in components: OpenAPI.Components,
+        following references: Set<AnyHashable>,
+        dereferencedFromComponentNamed name: String?
+    ) throws -> OpenAPI.CallbackURL {
+        self
+    }
 }
+

--- a/Sources/OpenAPIKit/Callbacks.swift
+++ b/Sources/OpenAPIKit/Callbacks.swift
@@ -19,4 +19,11 @@ extension OpenAPI {
 
     /// A map of named collections of Callback Objects (`OpenAPI.Callbacks`).
     public typealias CallbacksMap = OrderedDictionary<String, Either<OpenAPI.Reference<Callbacks>, Callbacks>>
+
+    /// A dictionary of Dereferenced of callbacks.
+    public typealias DereferencedCallbacks = OrderedDictionary<CallbackURL, DereferencedPathItem>
+
+    /// A dictionary of Dereferenced map of callbacks.
+    public typealias DereferencedCallbacksMap = OrderedDictionary<String, DereferencedCallbacks>
+}
 }

--- a/Sources/OpenAPIKit/Operation/DereferencedOperation.swift
+++ b/Sources/OpenAPIKit/Operation/DereferencedOperation.swift
@@ -20,6 +20,9 @@ public struct DereferencedOperation: Equatable {
     public let requestBody: DereferencedRequest?
     /// A dereferenced map of responses.
     public let responses: DereferencedResponse.Map
+    /// A dereferenced map of callbacks.
+    public let callbacks: OpenAPI.DereferencedCallbacksMap
+    
     /// An array of dereferenced security requirements.
     ///
     /// If defined, overrides the security requirements in the
@@ -69,6 +72,12 @@ public struct DereferencedOperation: Equatable {
                 resolvingIn: components,
                 following: references
             )
+        }
+
+        self.callbacks = try operation.callbacks.mapValues { callback in
+            try callback._dereferenced(in: components,
+                                       following: references,
+                                       dereferencedFromComponentNamed: nil)
         }
 
         self.underlyingOperation = operation

--- a/Sources/OpenAPIKit/Utility/OrderedDictionry+LocallyDereferenceable.swift
+++ b/Sources/OpenAPIKit/Utility/OrderedDictionry+LocallyDereferenceable.swift
@@ -25,9 +25,9 @@ extension OrderedDictionary: LocallyDereferenceable where Key: LocallyDereferenc
                               dereferencedFromComponentNamed name: String?) throws -> OpenAPIKitCore.OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf> {
 
         try reduce(into: OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf>()) { result, element in
-            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
 
-            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
             result[key] = value
         }
 

--- a/Sources/OpenAPIKit/Utility/OrderedDictionry+LocallyDereferenceable.swift
+++ b/Sources/OpenAPIKit/Utility/OrderedDictionry+LocallyDereferenceable.swift
@@ -1,0 +1,35 @@
+//
+//  OrderedDictionry+LocallyDereferenceable.swift
+//  
+//
+//  Created by Alberto Lagos on 11-09-23.
+//
+
+import OpenAPIKitCore
+import Foundation
+
+/// A Swift extension for dereferencing an `OrderedDictionary` conforming to the `LocallyDereferenceable` protocol.
+///
+/// - Parameters:
+///   - components: The OpenAPI components containing definitions.
+///   - references: A set of references to track dereferenced items.
+///   - name: The name of the component from which the dereferencing is initiated.
+///
+/// - Returns: A dereferenced `OrderedDictionary` containing keys and values of dereferenced types.
+///
+/// - Throws: An error if dereferencing fails for any element.
+extension OrderedDictionary: LocallyDereferenceable where Key: LocallyDereferenceable, Key.DereferencedSelf: Hashable, Value: LocallyDereferenceable {
+
+    public func _dereferenced(in components: OpenAPI.Components,
+                              following references: Set<AnyHashable>,
+                              dereferencedFromComponentNamed name: String?) throws -> OpenAPIKitCore.OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf> {
+
+        try reduce(into: OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf>()) { result, element in
+            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+
+            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            result[key] = value
+        }
+
+    }
+}

--- a/Sources/OpenAPIKit30/Callbacks.swift
+++ b/Sources/OpenAPIKit30/Callbacks.swift
@@ -18,4 +18,20 @@ extension OpenAPI {
 
     /// A map of named collections of Callback Objects (`OpenAPI.Callbacks`).
     public typealias CallbacksMap = OrderedDictionary<String, Either<JSONReference<Callbacks>, Callbacks>>
+
+    /// A dictionary of Dereferenced of callbacks.
+    public typealias DereferencedCallbacks = OrderedDictionary<CallbackURL, DereferencedPathItem>
+
+    /// A dictionary of Dereferenced map of callbacks.
+    public typealias DereferencedCallbacksMap = OrderedDictionary<String, DereferencedCallbacks>
+}
+
+extension OpenAPI.CallbackURL: LocallyDereferenceable {
+    public func _dereferenced(
+        in components: OpenAPI.Components,
+        following references: Set<AnyHashable>,
+        dereferencedFromComponentNamed name: String?
+    ) throws -> OpenAPI.CallbackURL {
+        self
+    }
 }

--- a/Sources/OpenAPIKit30/Operation/DereferencedOperation.swift
+++ b/Sources/OpenAPIKit30/Operation/DereferencedOperation.swift
@@ -20,6 +20,9 @@ public struct DereferencedOperation: Equatable {
     public let requestBody: DereferencedRequest?
     /// A dereferenced map of responses.
     public let responses: DereferencedResponse.Map
+    /// A dereferenced map of callbacks.
+    public let callbacks: OpenAPI.DereferencedCallbacksMap
+
     /// An array of dereferenced security requirements.
     ///
     /// If defined, overrides the security requirements in the
@@ -69,6 +72,12 @@ public struct DereferencedOperation: Equatable {
                 resolvingIn: components,
                 following: references
             )
+        }
+
+        self.callbacks = try operation.callbacks.mapValues { callback in
+            try callback._dereferenced(in: components,
+                                       following: references,
+                                       dereferencedFromComponentNamed: nil)
         }
 
         self.underlyingOperation = operation

--- a/Sources/OpenAPIKit30/Utility/OrderedDictionry+LocallyDereferenceable.swift
+++ b/Sources/OpenAPIKit30/Utility/OrderedDictionry+LocallyDereferenceable.swift
@@ -25,9 +25,9 @@ extension OrderedDictionary: LocallyDereferenceable where Key: LocallyDereferenc
                               dereferencedFromComponentNamed name: String?) throws -> OpenAPIKitCore.OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf> {
 
         try reduce(into: OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf>()) { result, element in
-            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
 
-            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil)
             result[key] = value
         }
 

--- a/Sources/OpenAPIKit30/Utility/OrderedDictionry+LocallyDereferenceable.swift
+++ b/Sources/OpenAPIKit30/Utility/OrderedDictionry+LocallyDereferenceable.swift
@@ -1,0 +1,35 @@
+//
+//  OrderedDictionry+LocallyDereferenceable.swift
+//  
+//
+//  Created by Alberto Lagos on 11-09-23.
+//
+
+import OpenAPIKitCore
+import Foundation
+
+/// A Swift extension for dereferencing an `OrderedDictionary` conforming to the `LocallyDereferenceable` protocol.
+///
+/// - Parameters:
+///   - components: The OpenAPI components containing definitions.
+///   - references: A set of references to track dereferenced items.
+///   - name: The name of the component from which the dereferencing is initiated.
+///
+/// - Returns: A dereferenced `OrderedDictionary` containing keys and values of dereferenced types.
+///
+/// - Throws: An error if dereferencing fails for any element.
+extension OrderedDictionary: LocallyDereferenceable where Key: LocallyDereferenceable, Key.DereferencedSelf: Hashable, Value: LocallyDereferenceable {
+
+    public func _dereferenced(in components: OpenAPI.Components,
+                              following references: Set<AnyHashable>,
+                              dereferencedFromComponentNamed name: String?) throws -> OpenAPIKitCore.OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf> {
+
+        try reduce(into: OrderedDictionary<Key.DereferencedSelf, Value.DereferencedSelf>()) { result, element in
+            let key = try element.key._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+
+            let value = try element.value._dereferenced(in: components, following: references, dereferencedFromComponentNamed: name)
+            result[key] = value
+        }
+
+    }
+}

--- a/Tests/OpenAPIKit30Tests/Operation/DereferencedOperationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Operation/DereferencedOperationTests.swift
@@ -164,4 +164,39 @@ final class DereferencedOperationTests: XCTestCase {
             ).dereferenced(in: .noComponents)
         )
     }
+
+    func test_dereferencedCallback() throws {
+        let components = OpenAPI.Components(
+            callbacks: [
+                "callback": [
+                    OpenAPI.CallbackURL(rawValue: "{$url}")!: .init(
+                        description: "Example of pathItem",
+                        post: .init(tags: "op callback", responses: [:])
+                    )
+                ]
+            ]
+        )
+
+        let t1 = try OpenAPI.Operation(
+            responses: [:],
+            callbacks: [
+                "callback": .reference(.component(named: "callback"))
+            ]
+        ).dereferenced(in: components)
+        XCTAssertEqual(t1.callbacks.count, 1)
+        XCTAssertEqual(t1.callbacks["callback"]?.keys[0], OpenAPI.CallbackURL(rawValue: "{$url}"))
+        XCTAssertEqual(t1.callbacks["callback"]?.values[0].description, "Example of pathItem")
+        XCTAssertEqual(t1.callbacks["callback"]?.values[0][.post]?.tags, ["op callback"])
+    }
+
+    func test_callbackReferenceMissing() throws {
+        XCTAssertThrowsError(
+            try OpenAPI.Operation(
+                responses: [:],
+                callbacks: [
+                    "callback": .reference(.component(named: "callback"))
+                ]
+            ).dereferenced(in: .noComponents)
+        )
+    }
 }


### PR DESCRIPTION
In this PR I add the callbacks when dereferencing a document.

The approach that I took was basically defining **DereferencedCallbacks** & **DereferencedCallbackMap** And making **OrderedDictionary** conforming to **LocallyDereferenceable** So we can dereferencing Callbacks easily.

This also means that **CallbackURL** is now conforming to **LocallyDereferenceable** But basically return itself.