### PR TITLE
Use `OrderedDictionary` for discriminator mapping

### DIFF
--- a/Sources/OpenAPIKitCore/Shared/Discriminator.swift
+++ b/Sources/OpenAPIKitCore/Shared/Discriminator.swift
@@ -11,10 +11,10 @@ extension Shared {
     /// See [OpenAPI Discriminator Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#discriminator-object).
     public struct Discriminator: Equatable {
         public let propertyName: String
-        public let mapping: [String: String]?
+        public let mapping: OrderedDictionary<String, String>?
 
         public init(propertyName: String,
-                    mapping: [String: String]? = nil) {
+                    mapping: OrderedDictionary<String, String>? = nil) {
             self.propertyName = propertyName
             self.mapping = mapping
         }
@@ -37,7 +37,7 @@ extension Shared.Discriminator: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         propertyName = try container.decode(String.self, forKey: .propertyName)
-        mapping = try container.decodeIfPresent([String: String].self, forKey: .mapping)
+        mapping = try container.decodeIfPresent(OrderedDictionary<String, String>.self, forKey: .mapping)
     }
 }
 


### PR DESCRIPTION
Hi 👋 

Thank you for creating this library!

Im generating a OpenAPISpec in code then encode it using `Yams` which preserves the order in which keys are encoded.

Since the order of keys of a `Swift.Dictionary` is not stable the generated api-spec always has some small diffs (the mapping of the discriminator is reordered)

This addresses this by using a `OrderedDictionary`