### PR TITLE
Improve integer max/min parsing and inconsistency errors

### DIFF
--- a/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
+++ b/Sources/OpenAPIKit/Encoding and Decoding Errors/DocumentDecodingError.swift
@@ -67,9 +67,9 @@ extension OpenAPI.Error.Decoding.Document {
         case .other(let decodingError):
             return decodingError.relativeCodingPathString
         case .inconsistency(let error):
-            return error.codingPath.isEmpty
-                ? ""
-                : error.codingPath.dropLast().stringValue
+            return error.codingPath.isEmpty ? ""
+                : error.pathIncludesSubject ? error.codingPath.dropLast().stringValue
+                  : error.codingPath.stringValue
         case .path(let pathError):
             return pathError.relativeCodingPathString
         case .neither(let eitherError):

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -988,8 +988,9 @@ extension JSONSchema.IntegerContext: Decodable {
                 guard let integer = Int(exactly: floatVal) else {
                     throw InconsistencyError(
                         subjectName: max ? "maximum" : "minimum",
-                        details: "Expected an Integer literal but found a floating point value",
-                        codingPath: decoder.codingPath
+                        details: "Expected an Integer literal but found a floating point value (\(String(describing: floatVal)))",
+                        codingPath: decoder.codingPath,
+                        pathIncludesSubject: false
                     )
                 }
                 return Bound(value: integer, exclusive: exclusive)

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -977,14 +977,19 @@ extension JSONSchema.IntegerContext: Decodable {
             // the following acrobatics thanks to some libraries (namely Yams) not
             // being willing to decode floating point representations of whole numbers
             // as integer values.
-        let exclusiveMaximumAttempt = try container.decodeIfPresent(Double.self, forKey: .exclusiveMaximum)
-        let exclusiveMinimumAttempt = try container.decodeIfPresent(Double.self, forKey: .exclusiveMinimum)
+        let exclusiveIntegerMaximumAttempt = try? container.decodeIfPresent(Int.self, forKey: .exclusiveMaximum)
+        let exclusiveIntegerMinimumAttempt = try? container.decodeIfPresent(Int.self, forKey: .exclusiveMinimum)
+        let exclusiveDoubleMaximumAttempt = try container.decodeIfPresent(Double.self, forKey: .exclusiveMaximum)
+        let exclusiveDoubleMinimumAttempt = try container.decodeIfPresent(Double.self, forKey: .exclusiveMinimum)
 
-        let maximumAttempt = try container.decodeIfPresent(Double.self, forKey: .maximum)
-        let minimumAttempt = try container.decodeIfPresent(Double.self, forKey: .minimum)
+        let maximumIntegerAttempt = try? container.decodeIfPresent(Int.self, forKey: .maximum)
+        let minimumIntegerAttempt = try? container.decodeIfPresent(Int.self, forKey: .minimum)
+        let maximumDoubleAttempt = try container.decodeIfPresent(Double.self, forKey: .maximum)
+        let minimumDoubleAttempt = try container.decodeIfPresent(Double.self, forKey: .minimum)
 
-        func boundFromAttempt(_ attempt: Double?, max: Bool, exclusive: Bool) throws -> Bound? {
-            return try attempt.map { floatVal in
+        func boundFrom(integer intAttempt: Int?, double doubleAttempt: Double?, max: Bool, exclusive: Bool) throws -> Bound? {
+            let value = try intAttempt
+                ?? doubleAttempt.map { floatVal in
                 guard let integer = Int(exactly: floatVal) else {
                     throw InconsistencyError(
                         subjectName: max ? "maximum" : "minimum",
@@ -993,15 +998,16 @@ extension JSONSchema.IntegerContext: Decodable {
                         pathIncludesSubject: false
                     )
                 }
-                return Bound(value: integer, exclusive: exclusive)
+                return integer
             }
+            return value.map { Bound(value: $0, exclusive: exclusive) }
         }
 
-        maximum = try boundFromAttempt(exclusiveMaximumAttempt, max: true, exclusive: true)
-        ?? boundFromAttempt(maximumAttempt, max: true, exclusive: false)
+        maximum = try boundFrom(integer: exclusiveIntegerMaximumAttempt, double: exclusiveDoubleMaximumAttempt, max: true, exclusive: true)
+        ?? boundFrom(integer: maximumIntegerAttempt, double: maximumDoubleAttempt, max: true, exclusive: false)
 
-        minimum = try boundFromAttempt(exclusiveMinimumAttempt, max: false, exclusive: true)
-        ?? boundFromAttempt(minimumAttempt, max: false, exclusive: false)
+        minimum = try boundFrom(integer: exclusiveIntegerMinimumAttempt, double: exclusiveDoubleMinimumAttempt, max: false, exclusive: true)
+        ?? boundFrom(integer: minimumIntegerAttempt, double: minimumDoubleAttempt, max: false, exclusive: false)
     }
 }
 

--- a/Sources/OpenAPIKit30/Encoding and Decoding Errors/DocumentDecodingError.swift
+++ b/Sources/OpenAPIKit30/Encoding and Decoding Errors/DocumentDecodingError.swift
@@ -67,9 +67,9 @@ extension OpenAPI.Error.Decoding.Document {
         case .other(let decodingError):
             return decodingError.relativeCodingPathString
         case .inconsistency(let error):
-            return error.codingPath.isEmpty
-                ? ""
-                : error.codingPath.dropLast().stringValue
+            return error.codingPath.isEmpty ? ""
+                : error.pathIncludesSubject ? error.codingPath.dropLast().stringValue
+                  : error.codingPath.stringValue
         case .path(let pathError):
             return pathError.relativeCodingPathString
         case .neither(let eitherError):

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
@@ -843,8 +843,9 @@ extension JSONSchema.IntegerContext: Decodable {
             guard let integer = Int(exactly: floatMax) else {
                 throw InconsistencyError(
                     subjectName: "maximum",
-                    details: "Expected an Integer literal but found a floating point value",
-                    codingPath: decoder.codingPath
+                    details: "Expected an Integer literal but found a floating point value (\(String(describing: floatMax)))",
+                    codingPath: decoder.codingPath,
+                    pathIncludesSubject: false
                 )
             }
             return integer
@@ -854,8 +855,9 @@ extension JSONSchema.IntegerContext: Decodable {
             guard let integer = Int(exactly: floatMin) else {
                 throw InconsistencyError(
                     subjectName: "minimum",
-                    details: "Expected an Integer literal but found a floating point value",
-                    codingPath: decoder.codingPath
+                    details: "Expected an Integer literal but found a floating point value (\(String(describing: floatMin)))",
+                    codingPath: decoder.codingPath,
+                    pathIncludesSubject: false
                 )
             }
             return integer

--- a/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/InconsistencyError.swift
+++ b/Sources/OpenAPIKitCore/Encoding and Decoding Errors And Warnings/InconsistencyError.swift
@@ -12,6 +12,7 @@ public struct InconsistencyError: Swift.Error, CustomStringConvertible, OpenAPIE
     public let subjectName: String
     public let details: String
     public let codingPath: [CodingKey]
+    public let pathIncludesSubject: Bool
 
     public var contextString: String { "" }
     public var errorCategory: ErrorCategory { .inconsistency(details: details) }
@@ -20,9 +21,10 @@ public struct InconsistencyError: Swift.Error, CustomStringConvertible, OpenAPIE
 
     public var description: String { localizedDescription }
 
-    public init(subjectName: String, details: String, codingPath: [CodingKey]) {
+    public init(subjectName: String, details: String, codingPath: [CodingKey], pathIncludesSubject: Bool = true) {
         self.subjectName = subjectName
         self.details = details
         self.codingPath = codingPath
+        self.pathIncludesSubject = pathIncludesSubject
     }
 }

--- a/Tests/OpenAPIKit30ErrorReportingTests/SchemaErrorTests.swift
+++ b/Tests/OpenAPIKit30ErrorReportingTests/SchemaErrorTests.swift
@@ -1,0 +1,51 @@
+//
+//  SchemaErrorTests.swift
+//  
+//
+//  Created by Mathew Polzin.
+//
+
+import Foundation
+import XCTest
+import OpenAPIKit30
+import Yams
+
+final class SchemaErrorTests: XCTestCase {
+    func test_nonIntegerMaximumForIntegerSchema() {
+        let documentYML =
+        """
+        openapi: "3.0.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                get:
+                    responses:
+                        '200':
+                            description: hello
+                            content:
+                                'application/json':
+                                    schema:
+                                        type: integer
+                                        maximum: 1.234
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a JSONSchema in .content['application/json'].schema for the status code '200' response of the **GET** endpoint under `/hello/world`. \n\nJSONSchema could not be decoded because:\nInconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value (1.234)..")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
+                "paths",
+                "/hello/world",
+                "get",
+                "responses",
+                "200",
+                "content",
+                "application/json",
+                "schema"
+            ])
+        }
+    }
+}

--- a/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/JSONSchemaTests.swift
@@ -4099,16 +4099,19 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "maximum": 1, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "maximum": 2, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "maximum": 1.0}"#.data(using: .utf8)!
+        let integerWithLargestPossibleMaxData = #"{"type": "integer", "maximum": 9223372036854775807}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
         let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integerWithLargestPossibleMax = try orderUnstableDecode(JSONSchema.self, from: integerWithLargestPossibleMaxData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(maximum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(maximum: (1, exclusive:false))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [1, 2]), .init(maximum: (2, exclusive:false))))
         XCTAssertEqual(integerWithWholeNumberFloat, JSONSchema.integer(maximum: (1, exclusive: false)))
+        XCTAssertEqual(integerWithLargestPossibleMax, JSONSchema.integer(maximum: (9223372036854775807, exclusive: false)))
     }
 
     func test_encodeIntegerWithExclusiveMaximum() {
@@ -4151,18 +4154,21 @@ extension SchemaObjectTests {
             ])
     }
 
-    func test_decodeIntegerWithExclusiveMaximum() {
+    func test_decodeIntegerWithExclusiveMaximum() throws {
         let integerData = #"{"type": "integer", "maximum": 1, "exclusiveMaximum": true}"#.data(using: .utf8)!
         let nullableIntegerData = #"{"type": "integer", "maximum": 1, "exclusiveMaximum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "maximum": 5, "exclusiveMaximum": true, "enum": [2, 3]}"#.data(using: .utf8)!
+        let integerWithLargestPossibleMaxData = #"{"type": "integer", "exclusiveMaximum": true, "maximum": 9223372036854775807}"#.data(using: .utf8)!
 
-        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithLargestPossibleMax = try orderUnstableDecode(JSONSchema.self, from: integerWithLargestPossibleMaxData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(maximum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(maximum: (1, exclusive:true))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [2, 3]), .init(maximum: (5, exclusive:true))))
+        XCTAssertEqual(integerWithLargestPossibleMax, JSONSchema.integer(maximum: (9223372036854775807, exclusive: true)))
     }
 
     func test_encodeIntegerWithMinimum() {
@@ -4206,16 +4212,19 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": "integer", "minimum": 1, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "minimum": 1, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "minimum": 1.0}"#.data(using: .utf8)!
+        let integerWithSmallestPossibleMinData = #"{"type": "integer", "minimum": -9223372036854775808}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
         let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integerWithSmallestPossibleMin = try orderUnstableDecode(JSONSchema.self, from: integerWithSmallestPossibleMinData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [1, 2]), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(integerWithWholeNumberFloat, JSONSchema.integer(minimum: (1, exclusive: false)))
+        XCTAssertEqual(integerWithSmallestPossibleMin, JSONSchema.integer(minimum: (-9223372036854775808, exclusive: false)))
     }
 
     func test_encodeIntegerWithExclusiveMinimum() {
@@ -4258,18 +4267,21 @@ extension SchemaObjectTests {
             ])
     }
 
-    func test_decodeIntegerWithExclusiveMinimum() {
+    func test_decodeIntegerWithExclusiveMinimum() throws {
         let integerData = #"{"type": "integer", "minimum": 1, "exclusiveMinimum": true}"#.data(using: .utf8)!
         let nullableIntegerData = #"{"type": "integer", "minimum": 1, "exclusiveMinimum": true, "nullable": true}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "minimum": 1, "exclusiveMinimum": true, "enum": [2, 3]}"#.data(using: .utf8)!
+        let integerWithSmallestPossibleMinData = #"{"type": "integer", "exclusiveMinimum": true, "minimum": -9223372036854775808}"#.data(using: .utf8)!
 
-        let integer = try! orderUnstableDecode(JSONSchema.self, from: integerData)
-        let nullableInteger = try! orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
-        let allowedValueInteger = try! orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
+        let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
+        let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithSmallestPossibleMin = try orderUnstableDecode(JSONSchema.self, from: integerWithSmallestPossibleMinData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(minimum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(minimum: (1, exclusive:true))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [2, 3]), .init(minimum: (1, exclusive:true))))
+        XCTAssertEqual(integerWithSmallestPossibleMin, JSONSchema.integer(minimum: (-9223372036854775808, exclusive: true)))
     }
 
     func test_encodeString() {

--- a/Tests/OpenAPIKit30Tests/Schema Object/SchemaObjectYamsTests.swift
+++ b/Tests/OpenAPIKit30Tests/Schema Object/SchemaObjectYamsTests.swift
@@ -40,7 +40,7 @@ final class SchemaObjectYamsTests: XCTestCase {
         """
 
         XCTAssertThrowsError(try YAMLDecoder().decode(JSONSchema.self, from: integerString)) { error in
-            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value.")
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value (10.2).")
         }
 
         let integerString2 =
@@ -50,7 +50,7 @@ final class SchemaObjectYamsTests: XCTestCase {
         """
 
         XCTAssertThrowsError(try YAMLDecoder().decode(JSONSchema.self, from: integerString2)) { error in
-            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `minimum`: Expected an Integer literal but found a floating point value.")
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `minimum`: Expected an Integer literal but found a floating point value (1.1).")
         }
     }
 }

--- a/Tests/OpenAPIKitErrorReportingTests/SchemaErrorTests.swift
+++ b/Tests/OpenAPIKitErrorReportingTests/SchemaErrorTests.swift
@@ -1,0 +1,51 @@
+//
+//  SchemaErrorTests.swift
+//  
+//
+//  Created by Mathew Polzin.
+//
+
+import Foundation
+import XCTest
+import OpenAPIKit
+import Yams
+
+final class SchemaErrorTests: XCTestCase {
+    func test_nonIntegerMaximumForIntegerSchema() {
+        let documentYML =
+        """
+        openapi: "3.1.0"
+        info:
+            title: test
+            version: 1.0
+        paths:
+            /hello/world:
+                get:
+                    responses:
+                        '200':
+                            description: hello
+                            content:
+                                'application/json':
+                                    schema:
+                                        type: integer
+                                        maximum: 1.234
+        """
+
+        XCTAssertThrowsError(try testDecoder.decode(OpenAPI.Document.self, from: documentYML)) { error in
+
+            let openAPIError = OpenAPI.Error(from: error)
+
+            XCTAssertEqual(openAPIError.localizedDescription, "Found neither a $ref nor a JSONSchema in .content['application/json'].schema for the status code '200' response of the **GET** endpoint under `/hello/world`. \n\nJSONSchema could not be decoded because:\nInconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value (1.234)..")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, [
+                "paths",
+                "/hello/world",
+                "get",
+                "responses",
+                "200",
+                "content",
+                "application/json",
+                "schema"
+            ])
+        }
+    }
+}

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -4593,16 +4593,19 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": ["integer", "null"], "maximum": 1}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "maximum": 2, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "maximum": 1.0}"#.data(using: .utf8)!
+        let integerWithLargestPossibleMaxData = #"{"type": "integer", "maximum": 9223372036854775807}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
         let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integerWithLargestPossibleMax = try orderUnstableDecode(JSONSchema.self, from: integerWithLargestPossibleMaxData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(maximum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(maximum: (1, exclusive:false))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [1, 2]), .init(maximum: (2, exclusive:false))))
         XCTAssertEqual(integerWithWholeNumberFloat, JSONSchema.integer(maximum: (1, exclusive: false)))
+        XCTAssertEqual(integerWithLargestPossibleMax, JSONSchema.integer(maximum: (9223372036854775807, exclusive: false)))
     }
 
     func test_encodeIntegerWithExclusiveMaximum() {
@@ -4645,14 +4648,17 @@ extension SchemaObjectTests {
         let integerData = #"{"type": "integer", "exclusiveMaximum": 1}"#.data(using: .utf8)!
         let nullableIntegerData = #"{"type": ["integer", "null"], "exclusiveMaximum": 1}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "exclusiveMaximum": 5, "enum": [2, 3]}"#.data(using: .utf8)!
+        let integerWithLargestPossibleMaxData = #"{"type": "integer", "exclusiveMaximum": 9223372036854775807}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithLargestPossibleMax = try orderUnstableDecode(JSONSchema.self, from: integerWithLargestPossibleMaxData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(maximum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(maximum: (1, exclusive:true))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [2, 3]), .init(maximum: (5, exclusive:true))))
+        XCTAssertEqual(integerWithLargestPossibleMax, JSONSchema.integer(maximum: (9223372036854775807, exclusive: true)))
     }
 
     func test_encodeIntegerWithMinimum() {
@@ -4696,16 +4702,19 @@ extension SchemaObjectTests {
         let nullableIntegerData = #"{"type": ["integer", "null"], "minimum": 1}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "minimum": 1, "enum": [1, 2]}"#.data(using: .utf8)!
         let integerWithWholeNumberFloatData = #"{"type": "integer", "minimum": 1.0}"#.data(using: .utf8)!
+        let integerWithSmallestPossibleMinData = #"{"type": "integer", "minimum": -9223372036854775808}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
         let integerWithWholeNumberFloat = try orderUnstableDecode(JSONSchema.self, from: integerWithWholeNumberFloatData)
+        let integerWithSmallestPossibleMin = try orderUnstableDecode(JSONSchema.self, from: integerWithSmallestPossibleMinData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [1, 2]), .init(minimum: (1, exclusive:false))))
         XCTAssertEqual(integerWithWholeNumberFloat, JSONSchema.integer(minimum: (1, exclusive: false)))
+        XCTAssertEqual(integerWithSmallestPossibleMin, JSONSchema.integer(minimum: (-9223372036854775808, exclusive: false)))
     }
 
     func test_encodeIntegerWithExclusiveMinimum() {
@@ -4748,14 +4757,17 @@ extension SchemaObjectTests {
         let integerData = #"{"type": "integer", "exclusiveMinimum": 1}"#.data(using: .utf8)!
         let nullableIntegerData = #"{"type": ["integer", "null"], "exclusiveMinimum": 1}"#.data(using: .utf8)!
         let allowedValueIntegerData = #"{"type": "integer", "exclusiveMinimum": 1, "enum": [2, 3]}"#.data(using: .utf8)!
+        let integerWithSmallestPossibleMinData = #"{"type": "integer", "exclusiveMinimum": -9223372036854775808}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
+        let integerWithSmallestPossibleMin = try orderUnstableDecode(JSONSchema.self, from: integerWithSmallestPossibleMinData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init(minimum: (1, exclusive:true))))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init(minimum: (1, exclusive:true))))
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [2, 3]), .init(minimum: (1, exclusive:true))))
+        XCTAssertEqual(integerWithSmallestPossibleMin, JSONSchema.integer(minimum: (-9223372036854775808, exclusive: true)))
     }
 
     func test_encodeString() {

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaObjectYamsTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaObjectYamsTests.swift
@@ -40,7 +40,7 @@ final class SchemaObjectYamsTests: XCTestCase {
         """
 
         XCTAssertThrowsError(try YAMLDecoder().decode(JSONSchema.self, from: integerString)) { error in
-            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value.")
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `maximum`: Expected an Integer literal but found a floating point value (10.2).")
         }
 
         let integerString2 =
@@ -50,7 +50,7 @@ final class SchemaObjectYamsTests: XCTestCase {
         """
 
         XCTAssertThrowsError(try YAMLDecoder().decode(JSONSchema.self, from: integerString2)) { error in
-            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `minimum`: Expected an Integer literal but found a floating point value.")
+            XCTAssertEqual(OpenAPI.Error(from: error).localizedDescription, "Inconsistency encountered when parsing `minimum`: Expected an Integer literal but found a floating point value (1.1).")
         }
     }
 }


### PR DESCRIPTION
Fixes a bug where decoding max or min 64 bit integer values would fail when being done via Double.