### PR TITLE
keep inferred when updating any other property of a core context using a helper function

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -296,7 +296,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -315,7 +316,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -334,7 +336,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -353,7 +356,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -372,7 +376,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -391,7 +396,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: [example],
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -410,7 +416,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -429,7 +436,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -448,7 +456,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 
@@ -467,7 +476,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
-            vendorExtensions: vendorExtensions
+            vendorExtensions: vendorExtensions,
+            _inferred: inferred
         )
     }
 }

--- a/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit30/Schema Object/JSONSchemaContext.swift
@@ -273,7 +273,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -291,7 +292,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -309,7 +311,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -327,7 +330,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -345,7 +349,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -363,7 +368,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 
@@ -381,7 +387,8 @@ extension JSONSchema.CoreContext {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            example: example
+            example: example,
+            _inferred: inferred
         )
     }
 }

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -762,7 +762,28 @@ final class DocumentConversionTests: XCTestCase {
     }
 
     func test_JSONSchemaFragment() throws {
-        // TODO: write test
+        let inferredFragment = OpenAPIKit30.JSONSchema.fragment(.init(_inferred: true))
+
+        let oldDoc = OpenAPIKit30.OpenAPI.Document(
+            info: .init(title: "Hello", version: "1.0.0"),
+            servers: [],
+            paths: [:],
+            components: .init(
+                schemas: [
+                    "schema1": inferredFragment,
+                ]
+            )
+        )
+
+        let newDoc = oldDoc.convert(to: .v3_1_0)
+
+        try assertEqualNewToOld(newDoc, oldDoc)
+
+        let newInferredFragment = try XCTUnwrap(newDoc.components.schemas["schema1"])
+
+        try assertEqualNewToOld(newInferredFragment, inferredFragment)
+
+        // TODO: write more tests
     }
 
     func test_Operation() throws {
@@ -1192,6 +1213,7 @@ fileprivate func assertEqualNewToOld(_ newCoreContext: OpenAPIKit.JSONSchemaCont
     XCTAssertEqual(newCoreContext.readOnly, oldCoreContext.readOnly)
     XCTAssertEqual(newCoreContext.writeOnly, oldCoreContext.writeOnly)
     XCTAssertEqual(newCoreContext.deprecated, oldCoreContext.deprecated)
+    XCTAssertEqual(newCoreContext.inferred, oldCoreContext.inferred)
 }
 
 fileprivate func assertEqualNewToOld(_ newStringContext: OpenAPIKit.JSONSchema.StringContext, _ oldStringContext: OpenAPIKit30.JSONSchema.StringContext) {


### PR DESCRIPTION
The inferred-ness of a schema was being lost when using helper functions to modify single properties of that schema's core context.

This PR fixes that bug.