### PR TITLE
fix "nullable" decoding

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -135,7 +135,9 @@ extension JSONSchemaContext {
 
 extension JSONSchema {
     /// The context that applies to all schemas.
-    public struct CoreContext<Format: OpenAPIFormat>: JSONSchemaContext, Equatable {
+    public struct CoreContext<Format: OpenAPIFormat>: JSONSchemaContext, HasWarnings {
+        public let warnings: [OpenAPI.Warning]
+
         public let format: Format
         public let required: Bool // default true
         public let nullable: Bool // default false
@@ -229,6 +231,7 @@ extension JSONSchema {
             vendorExtensions: [String: AnyCodable] = [:],
             _inferred: Bool = false
         ) {
+            self.warnings = []
             self.format = format
             self.required = required
             self.nullable = nullable
@@ -260,6 +263,7 @@ extension JSONSchema {
             examples: [String],
             vendorExtensions: [String: AnyCodable] = [:]
         ) {
+            self.warnings = []
             self.format = format
             self.required = required
             self.nullable = nullable
@@ -275,6 +279,24 @@ extension JSONSchema {
             self.vendorExtensions = vendorExtensions
             self.inferred = false
         }
+    }
+}
+
+extension JSONSchema.CoreContext: Equatable {
+    public static func == (lhs: JSONSchema.CoreContext<Format>, rhs: JSONSchema.CoreContext<Format>) -> Bool {
+        lhs.format == rhs.format
+        && lhs.required == rhs.required
+        && lhs.nullable == rhs.nullable
+        && lhs._permissions == rhs._permissions
+        && lhs._deprecated == rhs._deprecated
+        && lhs.title == rhs.title
+        && lhs.description == rhs.description
+        && lhs.externalDocs == rhs.externalDocs
+        && lhs.discriminator == rhs.discriminator
+        && lhs.allowedValues == rhs.allowedValues
+        && lhs.defaultValue == rhs.defaultValue
+        && lhs.vendorExtensions == rhs.vendorExtensions
+        && lhs.inferred == rhs.inferred
     }
 }
 
@@ -850,12 +872,15 @@ extension JSONSchema.CoreContext: Encodable {
 
 extension JSONSchema.CoreContext: Decodable {
     public init(from decoder: Decoder) throws {
+        var warnings: [OpenAPI.Warning] = []
+
         let container = try decoder.container(keyedBy: JSONSchema.ContextCodingKeys.self)
 
         format = try container.decodeIfPresent(Format.self, forKey: .format) ?? .unspecified
 
-        let nullable = try Self.decodeNullable(from: container)
+        let (nullable, nullableWarnings) = try Self.decodeNullable(from: container)
         self.nullable = nullable
+        warnings += nullableWarnings
 
         // default to `true` at decoding site.
         // It is the responsibility of decoders farther upstream
@@ -914,6 +939,8 @@ extension JSONSchema.CoreContext: Decodable {
         // full JSON Schema.
         vendorExtensions = [:]
         inferred = false
+
+        self.warnings = warnings
     }
 
     /// Support both `enum` and `const` when decoding allowed values for the schema.
@@ -928,17 +955,32 @@ extension JSONSchema.CoreContext: Decodable {
     }
 
     /// Decode whether or not this is a nullable JSONSchema.
-    private static func decodeNullable(from container: KeyedDecodingContainer<JSONSchema.ContextCodingKeys>) throws -> Bool {
-        if let nullable = try? container.decodeIfPresent(Bool.self, forKey: .nullable), nullable {
-            return true
+    private static func decodeNullable(from container: KeyedDecodingContainer<JSONSchema.ContextCodingKeys>) throws -> (Bool, [OpenAPI.Warning]) {
+        let nullable: Bool
+        var warnings: [OpenAPI.Warning] = []
+
+        if let _nullable = try? container.decodeIfPresent(Bool.self, forKey: .nullable) {
+            nullable = _nullable
+            warnings.append(
+                .underlyingError(
+                      InconsistencyError(
+                          subjectName: "OpenAPI Schema",
+                          details: "Found 'nullable' property. This property is not supported by OpenAPI v3.1.0. OpenAPIKit has translated it into 'type: [\"null\", ...]'.",
+                          codingPath: container.codingPath
+                      )
+                  )
+            )
+            
         }
-        if let types = try? container.decodeIfPresent([JSONType].self, forKey: .type) {
-            return types.contains(JSONType.null)
+        else if let types = try? container.decodeIfPresent([JSONType].self, forKey: .type) {
+            nullable = types.contains(JSONType.null)
         }
-        if let type = try? container.decodeIfPresent(JSONType.self, forKey: .type) {
-            return type == JSONType.null
+        else if let type = try? container.decodeIfPresent(JSONType.self, forKey: .type) {
+            nullable = type == JSONType.null
+        } else {
+          nullable = false
         }
-        return false
+        return (nullable, warnings)
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -768,6 +768,7 @@ extension JSONSchema {
     // not nested because Context is a generic type
     internal enum ContextCodingKeys: String, CodingKey {
         case type
+        case nullable
         case format
         case title
         case description
@@ -928,6 +929,9 @@ extension JSONSchema.CoreContext: Decodable {
 
     /// Decode whether or not this is a nullable JSONSchema.
     private static func decodeNullable(from container: KeyedDecodingContainer<JSONSchema.ContextCodingKeys>) throws -> Bool {
+        if let nullable = try? container.decodeIfPresent(Bool.self, forKey: .nullable), nullable {
+            return true
+        }
         if let types = try? container.decodeIfPresent([JSONType].self, forKey: .type) {
             return types.contains(JSONType.null)
         }

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1933,7 +1933,8 @@ extension SchemaObjectTests {
 
     func test_decodeBoolean() throws {
         let booleanData = #"{"type": "boolean"}"#.data(using: .utf8)!
-        let nullableBooleanData = #"{"type": ["boolean", "null"]}"#.data(using: .utf8)!
+        let booleanOrNullData = #"{"type": ["boolean", "null"]}"#.data(using: .utf8)!
+        let nullableBooleanData = #"{"type": "boolean", "nullable": true}"#.data(using: .utf8)!
         let readOnlyBooleanData = #"{"type": "boolean", "readOnly": true}"#.data(using: .utf8)!
         let writeOnlyBooleanData = #"{"type": "boolean", "writeOnly": true}"#.data(using: .utf8)!
         let deprecatedBooleanData = #"{"type": "boolean", "deprecated": true}"#.data(using: .utf8)!
@@ -1943,6 +1944,7 @@ extension SchemaObjectTests {
         let discriminatorBooleanData = #"{"type": "boolean", "discriminator": { "propertyName": "hello" }}"#.data(using: .utf8)!
 
         let boolean = try orderUnstableDecode(JSONSchema.self, from: booleanData)
+        let booleanOrNull = try orderUnstableDecode(JSONSchema.self, from: booleanOrNullData)
         let nullableBoolean = try orderUnstableDecode(JSONSchema.self, from: nullableBooleanData)
         let readOnlyBoolean = try orderUnstableDecode(JSONSchema.self, from: readOnlyBooleanData)
         let writeOnlyBoolean = try orderUnstableDecode(JSONSchema.self, from: writeOnlyBooleanData)
@@ -1953,6 +1955,7 @@ extension SchemaObjectTests {
         let discriminatorBoolean = try orderUnstableDecode(JSONSchema.self, from: discriminatorBooleanData)
 
         XCTAssertEqual(boolean, JSONSchema.boolean(.init(format: .generic)))
+        XCTAssertEqual(booleanOrNull, JSONSchema.boolean(.init(format: .generic, nullable: true)))
         XCTAssertEqual(nullableBoolean, JSONSchema.boolean(.init(format: .generic, nullable: true)))
         XCTAssertEqual(readOnlyBoolean, JSONSchema.boolean(.init(format: .generic, permissions: .readOnly)))
         XCTAssertEqual(writeOnlyBoolean, JSONSchema.boolean(.init(format: .generic, permissions: .writeOnly)))


### PR DESCRIPTION
The `"nullable"` keyword is inconsistently handled. Decoding logic exists, but when the `"type"` keyword is recognized, the `[..., "null"]` array pattern takes precedence. This change fixes that, so both work.