### PR TITLE
Add JSONSchema support for anchors

### DIFF
--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -135,6 +135,12 @@ public enum DereferencedJSONSchema: Equatable, JSONSchemaContext {
     public var examples: [AnyCodable] { jsonSchema.examples }
 
     // See `JSONSchemaContext`
+    public var anchor: String? { jsonSchema.anchor }
+
+    // See `JSONSchemaContext`
+    public var dynamicAnchor: String? { jsonSchema.dynamicAnchor }
+
+    // See `JSONSchemaContext`
     public var inferred: Bool { jsonSchema.inferred }
 
     // See `JSONSchemaContext`

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -1084,7 +1084,9 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let context = JSONSchema.CoreContext<JSONTypeFormat.BooleanFormat>(
             format: format,
@@ -1098,7 +1100,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         return .boolean(context)
     }
@@ -1117,7 +1121,9 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .boolean(
             format: format,
@@ -1131,7 +1137,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
     }
 
@@ -1154,7 +1162,9 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let context = JSONSchema.CoreContext<JSONTypeFormat.AnyFormat>(
             format: format,
@@ -1168,7 +1178,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         return .fragment(context)
     }
@@ -1187,7 +1199,9 @@ extension JSONSchema {
         externalDocs: OpenAPI.ExternalDocumentation? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .fragment(
             format: format,
@@ -1201,7 +1215,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
     }
 
@@ -1232,7 +1248,9 @@ extension JSONSchema {
         contentEncoding: OpenAPI.ContentEncoding? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.StringFormat>(
             format: format,
@@ -1246,7 +1264,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         let stringContext = JSONSchema.StringContext(
             maxLength: maxLength,
@@ -1277,7 +1297,9 @@ extension JSONSchema {
         contentEncoding: OpenAPI.ContentEncoding? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .string(
             format: format,
@@ -1296,7 +1318,9 @@ extension JSONSchema {
             contentEncoding: contentEncoding,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
     }
 
@@ -1322,7 +1346,9 @@ extension JSONSchema {
         minimum: (Double, exclusive: Bool)? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.NumberFormat>(
             format: format,
@@ -1336,7 +1362,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         let numbericContext = JSONSchema.NumericContext(
             multipleOf: multipleOf,
@@ -1363,7 +1391,9 @@ extension JSONSchema {
         minimum: (Double, exclusive: Bool)? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .number(
             format: format,
@@ -1380,7 +1410,9 @@ extension JSONSchema {
             minimum: minimum,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
     }
 
@@ -1406,7 +1438,9 @@ extension JSONSchema {
         minimum: (Int, exclusive: Bool)? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let genericContext = JSONSchema.CoreContext<JSONTypeFormat.IntegerFormat>(
             format: format,
@@ -1420,7 +1454,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         let integerContext = JSONSchema.IntegerContext(
             multipleOf: multipleOf,
@@ -1447,7 +1483,9 @@ extension JSONSchema {
         minimum: (Int, exclusive: Bool)? = nil,
         allowedValues: AnyCodable...,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .integer(
             format: format,
@@ -1464,7 +1502,9 @@ extension JSONSchema {
             minimum: minimum,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
     }
 
@@ -1491,7 +1531,9 @@ extension JSONSchema {
         additionalProperties: Either<Bool, JSONSchema>? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let coreContext = JSONSchema.CoreContext<JSONTypeFormat.ObjectFormat>(
             format: format,
@@ -1505,7 +1547,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
         let objectContext = JSONSchema.ObjectContext(
             properties: properties,
@@ -1539,7 +1583,9 @@ extension JSONSchema {
         items: JSONSchema? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
-        examples: [AnyCodable] = []
+        examples: [AnyCodable] = [],
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         let coreContext = JSONSchema.CoreContext<JSONTypeFormat.ArrayFormat>(
             format: format,
@@ -1553,7 +1599,9 @@ extension JSONSchema {
             externalDocs: externalDocs,
             allowedValues: allowedValues,
             defaultValue: defaultValue,
-            examples: examples
+            examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor
         )
 
         let arrayContext = JSONSchema.ArrayContext(
@@ -1585,7 +1633,9 @@ extension JSONSchema {
         required: Bool = true,
         title: String? = nil,
         description: String? = nil,
-        discriminator: OpenAPI.Discriminator? = nil
+        discriminator: OpenAPI.Discriminator? = nil,
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .all(
             of: schemas,
@@ -1593,7 +1643,9 @@ extension JSONSchema {
                 required: required,
                 title: title,
                 description: description,
-                discriminator: discriminator
+                discriminator: discriminator,
+                anchor: anchor,
+                dynamicAnchor: dynamicAnchor
             )
         )
     }
@@ -1613,7 +1665,9 @@ extension JSONSchema {
         required: Bool = true,
         title: String? = nil,
         description: String? = nil,
-        discriminator: OpenAPI.Discriminator? = nil
+        discriminator: OpenAPI.Discriminator? = nil,
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .one(
             of: schemas,
@@ -1621,7 +1675,9 @@ extension JSONSchema {
                 required: required,
                 title: title,
                 description: description,
-                discriminator: discriminator
+                discriminator: discriminator,
+                anchor: anchor,
+                dynamicAnchor: dynamicAnchor
             )
         )
     }
@@ -1641,7 +1697,9 @@ extension JSONSchema {
         required: Bool = true,
         title: String? = nil,
         description: String? = nil,
-        discriminator: OpenAPI.Discriminator? = nil
+        discriminator: OpenAPI.Discriminator? = nil,
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .any(
             of: schemas,
@@ -1649,7 +1707,9 @@ extension JSONSchema {
                 required: required,
                 title: title,
                 description: description,
-                discriminator: discriminator
+                discriminator: discriminator,
+                anchor: anchor,
+                dynamicAnchor: dynamicAnchor
             )
         )
     }
@@ -1666,7 +1726,9 @@ extension JSONSchema {
         required: Bool = true,
         title: String? = nil,
         description: String? = nil,
-        discriminator: OpenAPI.Discriminator? = nil
+        discriminator: OpenAPI.Discriminator? = nil,
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
         return .not(
             schema,
@@ -1674,7 +1736,9 @@ extension JSONSchema {
                 required: required,
                 title: title,
                 description: description,
-                discriminator: discriminator
+                discriminator: discriminator,
+                anchor: anchor,
+                dynamicAnchor: dynamicAnchor
             )
         )
     }
@@ -1684,9 +1748,14 @@ extension JSONSchema {
         _ reference: JSONReference<JSONSchema>,
         required: Bool = true,
         title: String? = nil,
-        description: String? = nil
+        description: String? = nil,
+        anchor: String? = nil,
+        dynamicAnchor: String? = nil
     ) -> JSONSchema {
-        return .reference(reference, .init(required: required, title: title, description: description))
+        return .reference(
+            reference,
+            .init(required: required, title: title, description: description, anchor: anchor, dynamicAnchor: dynamicAnchor)
+        )
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -227,6 +227,17 @@ public struct JSONSchema: JSONSchemaContext, HasWarnings {
     }
 
     // See `JSONSchemaContext`
+    public var anchor: String? {
+        return coreContext.anchor
+    }
+
+    // See `JSONSchemaContext`
+    public var dynamicAnchor: String? {
+        return coreContext.dynamicAnchor
+
+    }
+
+    // See `JSONSchemaContext`
     public var inferred: Bool {
         return coreContext.inferred
     }

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -316,22 +316,25 @@ extension JSONSchema {
 
 extension JSONSchema.CoreContext: Equatable {
     public static func == (lhs: JSONSchema.CoreContext<Format>, rhs: JSONSchema.CoreContext<Format>) -> Bool {
-        lhs.format == rhs.format
-        && lhs.required == rhs.required
-        && lhs.nullable == rhs.nullable
-        && lhs._permissions == rhs._permissions
-        && lhs._deprecated == rhs._deprecated
-        && lhs.title == rhs.title
-        && lhs.description == rhs.description
-        && lhs.externalDocs == rhs.externalDocs
-        && lhs.discriminator == rhs.discriminator
-        && lhs.allowedValues == rhs.allowedValues
-        && lhs.defaultValue == rhs.defaultValue
-        && lhs.examples == rhs.examples
-        && lhs.anchor == rhs.anchor
-        && lhs.dynamicAnchor == rhs.dynamicAnchor
-        && lhs.vendorExtensions == rhs.vendorExtensions
-        && lhs.inferred == rhs.inferred
+      // Split the conditionals up for the sake of the Swift 5.4 compiler.
+      let step1 = lhs.format == rhs.format
+          && lhs.required == rhs.required
+          && lhs.nullable == rhs.nullable
+          && lhs._permissions == rhs._permissions
+          && lhs._deprecated == rhs._deprecated
+          && lhs.title == rhs.title
+          && lhs.description == rhs.description
+          && lhs.externalDocs == rhs.externalDocs
+          && lhs.discriminator == rhs.discriminator
+
+      return step1 
+          && lhs.allowedValues == rhs.allowedValues
+          && lhs.defaultValue == rhs.defaultValue
+          && lhs.examples == rhs.examples
+          && lhs.anchor == rhs.anchor
+          && lhs.dynamicAnchor == rhs.dynamicAnchor
+          && lhs.vendorExtensions == rhs.vendorExtensions
+          && lhs.inferred == rhs.inferred
     }
 }
 

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -123,14 +123,32 @@ public protocol JSONSchemaContext {
     /// `true` if this schema is deprecated, `false` otherwise.
     var deprecated: Bool { get }
 
+    /// An anchor, if the schema defines one.
+    /// See [Defining location-independent identifiers](https://json-schema.org/draft/2020-12/json-schema-core#name-defining-location-independe)
+    var anchor: String? { get }
+
+    /// A dynamic anchor, if the schema defines one.
+    /// See [Dynamic References with "$dynamicRef"](https://json-schema.org/draft/2020-12/json-schema-core#name-dynamic-references-with-dyn)
+    var dynamicAnchor: String? { get }
+
     /// Vendor Extensions (a.k.a. Specification Extensions) for the schema
     var vendorExtensions: [String: AnyCodable] { get }
 }
 
 extension JSONSchemaContext {
+
+    // TODO: Remove the default implementations of the following in v4 of OpenAPIKit.
+    //       They are only here to make their addition non-breaking.
+
     // Default implementation to make addition of this new property which is only
     // supposed to be set internally a non-breaking addition.
     public var inferred: Bool { false }
+
+    // Default implementation to make addition non-breaking
+    public var anchor: String? { nil }
+
+    // Default implementation to make addition non-breaking
+    public var dynamicAnchor: String? { nil }
 }
 
 extension JSONSchema {
@@ -163,6 +181,12 @@ extension JSONSchema {
         ///
         /// An empty examples array is omitted from encoding.
         public let examples: [AnyCodable]
+
+        /// An anchor, if the schema defines one.
+        public let anchor: String?
+
+        /// A dynamic anchor, if the schema defines one.
+        public let dynamicAnchor: String?
 
         /// Dictionary of vendor extensions.
         ///
@@ -228,6 +252,8 @@ extension JSONSchema {
             allowedValues: [AnyCodable]? = nil,
             defaultValue: AnyCodable? = nil,
             examples: [AnyCodable] = [],
+            anchor: String? = nil,
+            dynamicAnchor: String? = nil,
             vendorExtensions: [String: AnyCodable] = [:],
             _inferred: Bool = false
         ) {
@@ -244,6 +270,8 @@ extension JSONSchema {
             self.allowedValues = allowedValues
             self.defaultValue = defaultValue
             self.examples = examples
+            self.anchor = anchor
+            self.dynamicAnchor = dynamicAnchor
             self.vendorExtensions = vendorExtensions
             self.inferred = _inferred
         }
@@ -261,6 +289,8 @@ extension JSONSchema {
             allowedValues: [AnyCodable]? = nil,
             defaultValue: AnyCodable? = nil,
             examples: [String],
+            anchor: String? = nil,
+            dynamicAnchor: String? = nil,
             vendorExtensions: [String: AnyCodable] = [:]
         ) {
             self.warnings = []
@@ -276,6 +306,8 @@ extension JSONSchema {
             self.allowedValues = allowedValues
             self.defaultValue = defaultValue
             self.examples = examples.map(AnyCodable.init)
+            self.anchor = anchor
+            self.dynamicAnchor = dynamicAnchor
             self.vendorExtensions = vendorExtensions
             self.inferred = false
         }
@@ -295,6 +327,9 @@ extension JSONSchema.CoreContext: Equatable {
         && lhs.discriminator == rhs.discriminator
         && lhs.allowedValues == rhs.allowedValues
         && lhs.defaultValue == rhs.defaultValue
+        && lhs.examples == rhs.examples
+        && lhs.anchor == rhs.anchor
+        && lhs.dynamicAnchor == rhs.dynamicAnchor
         && lhs.vendorExtensions == rhs.vendorExtensions
         && lhs.inferred == rhs.inferred
     }
@@ -318,6 +353,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -338,6 +375,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -358,6 +397,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -378,6 +419,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -398,6 +441,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -418,6 +463,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: [example],
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -438,6 +485,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -458,6 +507,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -478,6 +529,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -498,6 +551,8 @@ extension JSONSchema.CoreContext {
             allowedValues: allowedValues,
             defaultValue: defaultValue,
             examples: examples,
+            anchor: anchor,
+            dynamicAnchor: dynamicAnchor,
             vendorExtensions: vendorExtensions,
             _inferred: inferred
         )
@@ -801,10 +856,11 @@ extension JSONSchema {
         case defaultValue = "default"
         case example // deprecated in favor of examples
         case examples
+        case anchor = "$anchor"
+        case dynamicAnchor = "$dynamicAnchor"
         case readOnly
         case writeOnly
         case deprecated
-//      case constantValue = "const"
     }
 }
 
@@ -832,6 +888,8 @@ extension JSONSchema.CoreContext: Encodable {
         if !examples.isEmpty {
             try container.encode(examples, forKey: .examples)
         }
+        try container.encodeIfPresent(anchor, forKey: .anchor)
+        try container.encodeIfPresent(dynamicAnchor, forKey: .dynamicAnchor)
 
         // deprecated is false if omitted
         if deprecated {
@@ -934,6 +992,8 @@ extension JSONSchema.CoreContext: Decodable {
         } else {
             examples = try container.decodeIfPresent([AnyCodable].self, forKey: .examples) ?? []
         }
+        anchor = try container.decodeIfPresent(String.self, forKey: .anchor)
+        dynamicAnchor = try container.decodeIfPresent(String.self, forKey: .dynamicAnchor)
         // vendor extensions get decoded by the JSONSchema because although vendor extensions
         // apply to all schemas (core context) they are more accurately in the context of the
         // full JSON Schema.

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -6577,7 +6577,9 @@ extension SchemaObjectTests {
             allowedValues: [
                 true,
                 false
-            ]
+            ],
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
 
         let t1 = JSONSchema.boolean(format: .generic)
@@ -6599,7 +6601,9 @@ extension SchemaObjectTests {
             allowedValues: [
                 true,
                 false
-            ]
+            ],
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
 
         let t1 = JSONSchema.fragment(format: .generic)
@@ -6631,7 +6635,9 @@ extension SchemaObjectTests {
         )
         let _ = JSONSchema.number(
             format: .double,
-            allowedValues: 5.5
+            allowedValues: 5.5,
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
 
         let t3 = JSONSchema.number(format: .generic)
@@ -6659,7 +6665,9 @@ extension SchemaObjectTests {
         )
         let _ = JSONSchema.integer(
             required: true,
-            allowedValues: 1, 2, 3
+            allowedValues: 1, 2, 3,
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
 
         let t1 = JSONSchema.integer(format: .extended(.uint32))
@@ -6678,7 +6686,9 @@ extension SchemaObjectTests {
         let _: JSONSchema = .string
         let _ = JSONSchema.string(
             required: true,
-            nullable: true
+            nullable: true,
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
         let _ = JSONSchema.string(
             required: false,
@@ -6716,7 +6726,9 @@ extension SchemaObjectTests {
             allowedValues: [
                 [ "hello": true],
                 [ "hello": false]
-            ]
+            ],
+            anchor: "test",
+            dynamicAnchor: "test2"
         )
         let addProp1 = JSONSchema.object(
             additionalProperties: .init(true)
@@ -6758,6 +6770,11 @@ extension SchemaObjectTests {
 
     func test_array() {
 
+        let _ = JSONSchema.array(
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1 = JSONSchema.array(format: .generic)
         XCTAssertEqual(t1, JSONSchema.array(format: .init(rawValue: "")))
 
@@ -6766,6 +6783,12 @@ extension SchemaObjectTests {
     }
 
     func test_allOf() {
+        let _ = JSONSchema.all(
+            of: .string, .integer,
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1: JSONSchema = .all(of:
             .object(.init(), .init(properties: ["hello": .string])),
             .object(.init(), .init(properties: ["world": .boolean]))
@@ -6781,6 +6804,12 @@ extension SchemaObjectTests {
     }
 
     func test_oneOf() {
+        let _ = JSONSchema.one(
+            of: .string, .integer,
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1: JSONSchema = .one(of:
             .object(properties: ["hello": .string]),
             .object(properties: ["world": .boolean])
@@ -6795,6 +6824,12 @@ extension SchemaObjectTests {
     }
 
     func test_anyOf() {
+        let _ = JSONSchema.any(
+            of: .string, .integer,
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1: JSONSchema = .any(of:
             .object(properties: ["hello": .string]),
             .object(properties: ["world": .boolean])
@@ -6809,6 +6844,12 @@ extension SchemaObjectTests {
     }
 
     func test_not() {
+        let _ = JSONSchema.not(
+            .string,
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1: JSONSchema = .not(.string)
         let t2: JSONSchema = .not(.string, core: .init())
 
@@ -6816,6 +6857,12 @@ extension SchemaObjectTests {
     }
 
     func test_reference() {
+        let _ = JSONSchema.reference(
+            .component(named: "test"),
+            anchor: "test",
+            dynamicAnchor: "test2"
+        )
+
         let t1: JSONSchema = .reference(.internal(.component(name: "test")), .init(required: true))
         let t2: JSONSchema = .reference(.internal(.component(name: "test")), required: true)
 

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -624,6 +624,7 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertFalse(not.readOnly)
         XCTAssertTrue(not.writeOnly)
     }
+
     func test_notDeprecated() {
         let null = JSONSchema.null()
         let boolean = JSONSchema.boolean(.init(format: .unspecified, required: true))
@@ -817,6 +818,72 @@ final class SchemaObjectTests: XCTestCase {
         XCTAssertEqual(fragment.externalDocs, .init(url: URL(string: "http://google.com")!))
 
         XCTAssertNil(reference.externalDocs)
+    }
+
+    func test_anchor() throws {
+        let null = JSONSchema.null(.init(anchor: "test"))
+        let object = JSONSchema.object(.init(anchor: "test"), .init(properties: [:]))
+        let array = JSONSchema.array(.init(anchor: "test"), .init())
+
+        let boolean = JSONSchema.boolean(.init(anchor: "test"))
+        let number = JSONSchema.number(.init(anchor: "test"), .init())
+        let integer = JSONSchema.integer(.init(anchor: "test"), .init())
+        let string = JSONSchema.string(.init(anchor: "test"), .init())
+        let fragment = JSONSchema.fragment(.init(anchor: "test"))
+        let all = JSONSchema.all(of: [.string], core: .init(anchor: "test"))
+        let one = JSONSchema.one(of: [.string], core: .init(anchor: "test"))
+        let any = JSONSchema.any(of: [.string], core: .init(anchor: "test"))
+        let not = JSONSchema.not(.string, core: .init(anchor: "test"))
+        let reference = JSONSchema.reference(.component(named: "test"), .init(anchor: "test"))
+
+        XCTAssertEqual(null.anchor, "test")
+        XCTAssertEqual(object.anchor, "test")
+        XCTAssertEqual(array.anchor, "test")
+
+        XCTAssertEqual(boolean.anchor, "test")
+        XCTAssertEqual(number.anchor, "test")
+        XCTAssertEqual(integer.anchor, "test")
+        XCTAssertEqual(string.anchor, "test")
+        XCTAssertEqual(fragment.anchor, "test")
+
+        XCTAssertEqual(all.anchor, "test")
+        XCTAssertEqual(one.anchor, "test")
+        XCTAssertEqual(any.anchor, "test")
+        XCTAssertEqual(not.anchor, "test")
+        XCTAssertEqual(reference.anchor, "test")
+    }
+
+    func test_dynamicAnchor() throws {
+        let null = JSONSchema.null(.init(dynamicAnchor: "test"))
+        let object = JSONSchema.object(.init(dynamicAnchor: "test"), .init(properties: [:]))
+        let array = JSONSchema.array(.init(dynamicAnchor: "test"), .init())
+
+        let boolean = JSONSchema.boolean(.init(dynamicAnchor: "test"))
+        let number = JSONSchema.number(.init(dynamicAnchor: "test"), .init())
+        let integer = JSONSchema.integer(.init(dynamicAnchor: "test"), .init())
+        let string = JSONSchema.string(.init(dynamicAnchor: "test"), .init())
+        let fragment = JSONSchema.fragment(.init(dynamicAnchor: "test"))
+        let all = JSONSchema.all(of: [.string], core: .init(dynamicAnchor: "test"))
+        let one = JSONSchema.one(of: [.string], core: .init(dynamicAnchor: "test"))
+        let any = JSONSchema.any(of: [.string], core: .init(dynamicAnchor: "test"))
+        let not = JSONSchema.not(.string, core: .init(dynamicAnchor: "test"))
+        let reference = JSONSchema.reference(.component(named: "test"), .init(dynamicAnchor: "test"))
+
+        XCTAssertEqual(null.dynamicAnchor, "test")
+        XCTAssertEqual(object.dynamicAnchor, "test")
+        XCTAssertEqual(array.dynamicAnchor, "test")
+
+        XCTAssertEqual(boolean.dynamicAnchor, "test")
+        XCTAssertEqual(number.dynamicAnchor, "test")
+        XCTAssertEqual(integer.dynamicAnchor, "test")
+        XCTAssertEqual(string.dynamicAnchor, "test")
+        XCTAssertEqual(fragment.dynamicAnchor, "test")
+
+        XCTAssertEqual(all.dynamicAnchor, "test")
+        XCTAssertEqual(one.dynamicAnchor, "test")
+        XCTAssertEqual(any.dynamicAnchor, "test")
+        XCTAssertEqual(not.dynamicAnchor, "test")
+        XCTAssertEqual(reference.dynamicAnchor, "test")
     }
 
     func test_coreContextAccessor() {
@@ -1942,6 +2009,8 @@ extension SchemaObjectTests {
         let constValueBooleanData = #"{"type": "boolean", "const": false}"#.data(using: .utf8)!
         let defaultValueBooleanData = #"{"type": "boolean", "default": false}"#.data(using: .utf8)!
         let discriminatorBooleanData = #"{"type": "boolean", "discriminator": { "propertyName": "hello" }}"#.data(using: .utf8)!
+        let anchorBooleanData = #"{"type": "boolean", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorBooleanData = #"{"type": "boolean", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let boolean = try orderUnstableDecode(JSONSchema.self, from: booleanData)
         let booleanOrNull = try orderUnstableDecode(JSONSchema.self, from: booleanOrNullData)
@@ -1953,6 +2022,8 @@ extension SchemaObjectTests {
         let constValueBoolean = try orderUnstableDecode(JSONSchema.self, from: constValueBooleanData)
         let defaultValueBoolean = try orderUnstableDecode(JSONSchema.self, from: defaultValueBooleanData)
         let discriminatorBoolean = try orderUnstableDecode(JSONSchema.self, from: discriminatorBooleanData)
+        let anchorBoolean = try orderUnstableDecode(JSONSchema.self, from: anchorBooleanData)
+        let dynamicAnchorBoolean = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorBooleanData)
 
         XCTAssertEqual(boolean, JSONSchema.boolean(.init(format: .generic)))
         XCTAssertEqual(booleanOrNull, JSONSchema.boolean(.init(format: .generic, nullable: true)))
@@ -1964,6 +2035,8 @@ extension SchemaObjectTests {
         XCTAssertEqual(constValueBoolean, JSONSchema.boolean(.init(format: .generic, allowedValues: [false])))
         XCTAssertEqual(defaultValueBoolean, JSONSchema.boolean(.init(format: .generic, defaultValue: false)))
         XCTAssertEqual(discriminatorBoolean, JSONSchema.boolean(.init(format: .generic, discriminator: .init(propertyName: "hello"))))
+        XCTAssertEqual(anchorBoolean, JSONSchema.boolean(.init(format: .generic, anchor: "test")))
+        XCTAssertEqual(dynamicAnchorBoolean, JSONSchema.boolean(.init(format: .generic, dynamicAnchor: "test")))
     }
 
     func test_encodeObject() {
@@ -2172,6 +2245,8 @@ extension SchemaObjectTests {
             "discriminator": {"propertyName": "hello"}
         }
         """.data(using: .utf8)!
+        let anchorObjectData = #"{"type": "object", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorObjectData = #"{"type": "object", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let object = try orderUnstableDecode(JSONSchema.self, from: objectData)
         let nullableObject = try orderUnstableDecode(JSONSchema.self, from: nullableObjectData)
@@ -2182,6 +2257,8 @@ extension SchemaObjectTests {
         let allowedValueObject = try orderUnstableDecode(JSONSchema.self, from: allowedValueObjectData)
         let defaultValueObject = try orderUnstableDecode(JSONSchema.self, from: defaultValueObjectData)
         let discriminatorObject = try orderUnstableDecode(JSONSchema.self, from: discriminatorObjectData)
+        let anchorObject = try orderUnstableDecode(JSONSchema.self, from: anchorObjectData)
+        let dynamicAnchorObject = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorObjectData)
 
         XCTAssertEqual(object, JSONSchema.object(.init(format: .generic), .init(properties: [:])))
         XCTAssertEqual(nullableObject, JSONSchema.object(.init(format: .generic, nullable: true), .init(properties: [:])))
@@ -2199,6 +2276,8 @@ extension SchemaObjectTests {
             return
         }
         XCTAssertEqual(contextB, .init(properties: ["hello": .boolean(.init(format: .generic, required: false))]))
+        XCTAssertEqual(anchorObject, JSONSchema.object(.init(format: .generic, anchor: "test"), .init(properties: [:])))
+        XCTAssertEqual(dynamicAnchorObject, JSONSchema.object(.init(format: .generic, dynamicAnchor: "test"), .init(properties: [:])))
     }
 
     func test_decodeObjectWithTypeInferred() throws {
@@ -3662,6 +3741,8 @@ extension SchemaObjectTests {
         let allowedValueArrayData = #"{"type": "array", "items": { "type": "boolean" }, "enum": [[false]]}"#.data(using: .utf8)!
         let defaultValueArrayData = #"{"type": "array", "items": { "type": "boolean" }, "default": [false]}"#.data(using: .utf8)!
         let discriminatorArrayData = #"{"type": "array", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
+        let anchorArrayData = #"{"type": "array", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorArrayData = #"{"type": "array", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let array = try orderUnstableDecode(JSONSchema.self, from: arrayData)
         let nullableArray = try orderUnstableDecode(JSONSchema.self, from: nullableArrayData)
@@ -3671,6 +3752,8 @@ extension SchemaObjectTests {
         let allowedValueArray = try orderUnstableDecode(JSONSchema.self, from: allowedValueArrayData)
         let defaultValueArray = try orderUnstableDecode(JSONSchema.self, from: defaultValueArrayData)
         let discriminatorArray = try orderUnstableDecode(JSONSchema.self, from: discriminatorArrayData)
+        let anchorArray = try orderUnstableDecode(JSONSchema.self, from: anchorArrayData)
+        let dynamicAnchorArray = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorArrayData)
 
         XCTAssertEqual(array, JSONSchema.array(.init(format: .generic), .init()))
         XCTAssertEqual(nullableArray, JSONSchema.array(.init(format: .generic, nullable: true), .init()))
@@ -3686,6 +3769,8 @@ extension SchemaObjectTests {
             return
         }
         XCTAssertEqual(contextB, .init(items: .boolean(.init(format: .generic))))
+        XCTAssertEqual(anchorArray, JSONSchema.array(.init(format: .generic, anchor: "test"), .init()))
+        XCTAssertEqual(dynamicAnchorArray, JSONSchema.array(.init(format: .generic, dynamicAnchor: "test"), .init()))
     }
 
     func test_decodeArrayWithTypeInferred() throws {
@@ -4014,6 +4099,8 @@ extension SchemaObjectTests {
         let allowedValueNumberData = #"{"type": "number", "enum": [1, 2]}"#.data(using: .utf8)!
         let defaultValueNumberData = #"{"type": "number", "default": 1}"#.data(using: .utf8)!
         let discriminatorNumberData = #"{"type": "number", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
+        let anchorNumberData = #"{"type": "number", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorNumberData = #"{"type": "number", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let number = try orderUnstableDecode(JSONSchema.self, from: numberData)
         let nullableNumber = try orderUnstableDecode(JSONSchema.self, from: nullableNumberData)
@@ -4023,6 +4110,8 @@ extension SchemaObjectTests {
         let allowedValueNumber = try orderUnstableDecode(JSONSchema.self, from: allowedValueNumberData)
         let defaultValueNumber = try orderUnstableDecode(JSONSchema.self, from: defaultValueNumberData)
         let discriminatorNumber = try orderUnstableDecode(JSONSchema.self, from: discriminatorNumberData)
+        let anchorNumber = try orderUnstableDecode(JSONSchema.self, from: anchorNumberData)
+        let dynamicAnchorNumber = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorNumberData)
 
         XCTAssertEqual(number, JSONSchema.number(.init(format: .generic), .init()))
         XCTAssertEqual(nullableNumber, JSONSchema.number(.init(format: .generic, nullable: true), .init()))
@@ -4032,6 +4121,8 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueNumber, JSONSchema.number(.init(format: .generic, allowedValues: [1, 2]), .init()))
         XCTAssertEqual(defaultValueNumber, JSONSchema.number(.init(format: .generic, defaultValue: 1), .init()))
         XCTAssertEqual(discriminatorNumber, JSONSchema.number(discriminator: .init(propertyName: "hello")))
+        XCTAssertEqual(anchorNumber, JSONSchema.number(.init(format: .generic, anchor: "test"), .init()))
+        XCTAssertEqual(dynamicAnchorNumber, JSONSchema.number(.init(format: .generic, dynamicAnchor: "test"), .init()))
     }
 
     func test_decodeNumberWithTypeInferred() throws {
@@ -4423,6 +4514,8 @@ extension SchemaObjectTests {
         let allowedValueIntegerData = #"{"type": "integer", "enum": [1, 2]}"#.data(using: .utf8)!
         let defaultValueIntegerData = #"{"type": "integer", "default": 1}"#.data(using: .utf8)!
         let discriminatorIntegerData = #"{"type": "integer", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
+        let anchorIntegerData = #"{"type": "integer", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorIntegerData = #"{"type": "integer", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let integer = try orderUnstableDecode(JSONSchema.self, from: integerData)
         let nullableInteger = try orderUnstableDecode(JSONSchema.self, from: nullableIntegerData)
@@ -4432,6 +4525,8 @@ extension SchemaObjectTests {
         let allowedValueInteger = try orderUnstableDecode(JSONSchema.self, from: allowedValueIntegerData)
         let defaultValueInteger = try orderUnstableDecode(JSONSchema.self, from: defaultValueIntegerData)
         let discriminatorInteger = try orderUnstableDecode(JSONSchema.self, from: discriminatorIntegerData)
+        let anchorInteger = try orderUnstableDecode(JSONSchema.self, from: anchorIntegerData)
+        let dynamicAnchorInteger = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorIntegerData)
 
         XCTAssertEqual(integer, JSONSchema.integer(.init(format: .generic), .init()))
         XCTAssertEqual(nullableInteger, JSONSchema.integer(.init(format: .generic, nullable: true), .init()))
@@ -4441,6 +4536,8 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueInteger, JSONSchema.integer(.init(format: .generic, allowedValues: [1, 2]), .init()))
         XCTAssertEqual(defaultValueInteger, JSONSchema.integer(.init(format: .generic, defaultValue: 1), .init()))
         XCTAssertEqual(discriminatorInteger, JSONSchema.integer(discriminator: .init(propertyName: "hello")))
+        XCTAssertEqual(anchorInteger, JSONSchema.integer(.init(format: .generic, anchor: "test"), .init()))
+        XCTAssertEqual(dynamicAnchorInteger, JSONSchema.integer(.init(format: .generic, dynamicAnchor: "test"), .init()))
     }
 
     func test_encode32bitInteger() {
@@ -4832,6 +4929,8 @@ extension SchemaObjectTests {
         let allowedValueStringData = #"{"type": "string", "enum": ["hello"]}"#.data(using: .utf8)!
         let discriminatorStringData = #"{"type": "string", "discriminator": {"propertyName": "hello"}}"#.data(using: .utf8)!
         let nullableStringWithAllowedValuesData = #"{"type": ["string", "null"], "enum": ["hello", null]}"#.data(using: .utf8)!
+        let anchorStringData = #"{"type": "string", "$anchor": "test"}"#.data(using: .utf8)!
+        let dynamicAnchorStringData = #"{"type": "string", "$dynamicAnchor": "test"}"#.data(using: .utf8)!
 
         let string = try orderUnstableDecode(JSONSchema.self, from: stringData)
         let nullableString = try orderUnstableDecode(JSONSchema.self, from: nullableStringData)
@@ -4841,6 +4940,8 @@ extension SchemaObjectTests {
         let allowedValueString = try orderUnstableDecode(JSONSchema.self, from: allowedValueStringData)
         let discriminatorString = try orderUnstableDecode(JSONSchema.self, from: discriminatorStringData)
         let nullableStringWithAllowedValues = try orderUnstableDecode(JSONSchema.self, from: nullableStringWithAllowedValuesData)
+        let anchorString = try orderUnstableDecode(JSONSchema.self, from: anchorStringData)
+        let dynamicAnchorString = try orderUnstableDecode(JSONSchema.self, from: dynamicAnchorStringData)
 
         XCTAssertEqual(string, JSONSchema.string(.init(format: .generic), .init()))
         XCTAssertEqual(nullableString, JSONSchema.string(.init(format: .generic, nullable: true), .init()))
@@ -4850,6 +4951,8 @@ extension SchemaObjectTests {
         XCTAssertEqual(allowedValueString, JSONSchema.string(.init(format: .generic, allowedValues: ["hello"]), .init()))
         XCTAssertEqual(discriminatorString, JSONSchema.string(discriminator: .init(propertyName: "hello")))
         XCTAssertEqual(nullableStringWithAllowedValues, JSONSchema.string(nullable: true, allowedValues: ["hello", nil]))
+        XCTAssertEqual(anchorString, JSONSchema.string(.init(format: .generic, anchor: "test"), .init()))
+        XCTAssertEqual(dynamicAnchorString, JSONSchema.string(.init(format: .generic, dynamicAnchor: "test"), .init()))
     }
 
     func test_decodeStringWithTypeInferred() throws {


### PR DESCRIPTION
This PR adds backwards compatible support for _parsing_ `$anchor` and `$dynamicAnchor` properties of `JSONSchema`s. It does not integrate those new properties with any additional functionality yet.

Related to https://github.com/mattpolzin/OpenAPIKit/issues/359.