### PR TITLE
Remove deprecated contentType property

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.8-bionic
           - swift:5.8-focal
           - swift:5.8-jammy
           - swift:5.9-focal

--- a/Sources/OpenAPIKit/Content/ContentEncoding.swift
+++ b/Sources/OpenAPIKit/Content/ContentEncoding.swift
@@ -14,21 +14,6 @@ extension OpenAPI.Content {
     public struct Encoding: Equatable {
         public typealias Style = OpenAPI.Parameter.SchemaContext.Style
 
-        /// If an encoding object only contains 1 content type, it will be populated here.
-        /// Two or more content types will result in a null value here but the `contentTypes`
-        /// (plural) property will contain all content types specified.
-        ///
-        /// The singular `contentType` property is only provided for backwards compatibility and
-        /// using the plural `contentTypes` property should be preferred.
-        @available(*, deprecated, message: "use contentTypes instead")
-        public var contentType: OpenAPI.ContentType? {
-            guard let contentType = contentTypes.first,
-                  contentTypes.count == 1 else {
-                return nil
-            }
-            return contentType
-        }
-
         public let contentTypes: [OpenAPI.ContentType]
         public let headers: OpenAPI.Header.Map?
         public let style: Style
@@ -38,13 +23,12 @@ extension OpenAPI.Content {
         /// The singular `contentType` argument is only provided for backwards compatibility and
         /// using the plural `contentTypes` argument should be preferred.
         public init(
-            contentType: OpenAPI.ContentType? = nil,
             contentTypes: [OpenAPI.ContentType] = [],
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
             allowReserved: Bool = false
         ) {
-            self.contentTypes = contentTypes + [contentType].compactMap { $0 }
+            self.contentTypes = contentTypes
             self.headers = headers
             self.style = style
             self.explode = style.defaultExplode
@@ -54,14 +38,13 @@ extension OpenAPI.Content {
         /// The singular `contentType` argument is only provided for backwards compatibility and
         /// using the plural `contentTypes` argument should be preferred.
         public init(
-            contentType: OpenAPI.ContentType? = nil,
             contentTypes: [OpenAPI.ContentType] = [],
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
             explode: Bool,
             allowReserved: Bool = false
         ) {
-            self.contentTypes = contentTypes + [contentType].compactMap { $0 }
+            self.contentTypes = contentTypes
             self.headers = headers
             self.style = style
             self.explode = explode
@@ -104,7 +87,7 @@ extension OpenAPI.Content.Encoding: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let contentTypesString = try container.decodeIfPresent(String.self, forKey: .contentType)
-        if let contentTypesString = contentTypesString {
+        if let contentTypesString {
             contentTypes = contentTypesString
                 .split(separator: ",")
                 .compactMap { string in

--- a/Sources/OpenAPIKit/Content/DereferencedContentEncoding.swift
+++ b/Sources/OpenAPIKit/Content/DereferencedContentEncoding.swift
@@ -72,7 +72,7 @@ extension OpenAPI.Content.Encoding: ExternallyDereferenceable {
         }
 
         let newEncoding = OpenAPI.Content.Encoding(
-            contentType: contentType,
+            contentTypes: contentTypes,
             headers: newHeaders,
             style: style,
             explode: explode,

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -135,22 +135,6 @@ public protocol JSONSchemaContext {
     var vendorExtensions: [String: AnyCodable] { get }
 }
 
-extension JSONSchemaContext {
-
-    // TODO: Remove the default implementations of the following in v4 of OpenAPIKit.
-    //       They are only here to make their addition non-breaking.
-
-    // Default implementation to make addition of this new property which is only
-    // supposed to be set internally a non-breaking addition.
-    public var inferred: Bool { false }
-
-    // Default implementation to make addition non-breaking
-    public var anchor: String? { nil }
-
-    // Default implementation to make addition non-breaking
-    public var dynamicAnchor: String? { nil }
-}
-
 extension JSONSchema {
     /// The context that applies to all schemas.
     public struct CoreContext<Format: OpenAPIFormat>: JSONSchemaContext, HasWarnings {

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -214,7 +214,7 @@ extension OpenAPIKit30.OpenAPI.Parameter.SchemaContext: To31 {
 extension OpenAPIKit30.OpenAPI.Content.Encoding: To31 {
     fileprivate func to31() -> OpenAPIKit.OpenAPI.Content.Encoding {
         OpenAPIKit.OpenAPI.Content.Encoding(
-            contentType: contentType,
+            contentTypes: [contentType].compactMap { $0 },
             headers: headers?.mapValues(eitherRefTo31),
             style: style,
             explode: explode,

--- a/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
+++ b/Tests/OpenAPIKitCompatTests/DocumentConversionTests.swift
@@ -1233,7 +1233,7 @@ fileprivate func assertEqualNewToOld(_ newExample: OpenAPIKit.OpenAPI.Example, _
 }
 
 fileprivate func assertEqualNewToOld(_ newEncoding: OpenAPIKit.OpenAPI.Content.Encoding, _ oldEncoding: OpenAPIKit30.OpenAPI.Content.Encoding) throws {
-    XCTAssertEqual(newEncoding.contentType, oldEncoding.contentType)
+    XCTAssertEqual(newEncoding.contentTypes.first, oldEncoding.contentType)
     if let newEncodingHeaders = newEncoding.headers {
         let oldEncodingHeaders = try XCTUnwrap(oldEncoding.headers)
         for ((newKey, newHeader), (oldKey, oldHeader)) in zip(newEncodingHeaders, oldEncodingHeaders) {

--- a/Tests/OpenAPIKitTests/Content/ContentTests.swift
+++ b/Tests/OpenAPIKitTests/Content/ContentTests.swift
@@ -66,7 +66,7 @@ final class ContentTests: XCTestCase {
             example: nil,
             encoding: [
                 "hello": .init(
-                    contentType: .json,
+                    contentTypes: [.json],
                     headers: [
                         "world": .init(OpenAPI.Header(schemaOrContent: .init(.header(.string))))
                     ],
@@ -355,7 +355,7 @@ extension ContentTests {
     func test_encodingAndSchema_encode() {
         let content = OpenAPI.Content(
             schema: .init(.string),
-            encoding: ["json": .init(contentType: .json)]
+            encoding: ["json": .init(contentTypes: [.json])]
         )
         let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
@@ -397,7 +397,7 @@ extension ContentTests {
             content,
             OpenAPI.Content(
                 schema: .init(.string),
-                encoding: ["json": .init(contentType: .json)]
+                encoding: ["json": .init(contentTypes: [.json])]
             )
         )
     }
@@ -500,18 +500,18 @@ extension ContentTests {
     func test_encodingInit() {
         let _ = OpenAPI.Content.Encoding()
 
-        let _ = OpenAPI.Content.Encoding(contentType: .json)
+        let _ = OpenAPI.Content.Encoding(contentTypes: [.json])
 
         let _ = OpenAPI.Content.Encoding(headers: ["special": .a(.external(URL(string: "hello.yml")!))])
 
         let _ = OpenAPI.Content.Encoding(allowReserved: true)
 
-        let _ = OpenAPI.Content.Encoding(contentType: .form,
+        let _ = OpenAPI.Content.Encoding(contentTypes: [.form],
                                          headers: ["special": .a(.external(URL(string: "hello.yml")!))],
                                          allowReserved: true)
-        let _ = OpenAPI.Content.Encoding(contentType: .json,
+        let _ = OpenAPI.Content.Encoding(contentTypes: [.json],
                                          style: .form)
-        let _ = OpenAPI.Content.Encoding(contentType: .json,
+        let _ = OpenAPI.Content.Encoding(contentTypes: [.json],
                                          style: .form,
                                          explode: true)
     }
@@ -544,7 +544,7 @@ extension ContentTests {
     }
 
     func test_encoding_contentType_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(contentType: .csv)
+        let encoding = OpenAPI.Content.Encoding(contentTypes: [.csv])
 
         let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
@@ -567,7 +567,7 @@ extension ContentTests {
         """.data(using: .utf8)!
         let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(encoding, OpenAPI.Content.Encoding(contentType: .csv))
+        XCTAssertEqual(encoding, OpenAPI.Content.Encoding(contentTypes: [.csv]))
     }
 
     func test_encoding_multiple_contentTypes_encode() throws {


### PR DESCRIPTION
The Content Encoding Object's `contentType` (singular) property was deprecated in v3.2.0 and has now been removed in favor of `contentTypes` (plural).

The default implementations of `inferred`, `anchor`, and `dynamicAnchor` in the `JSONSchemaContext` have been removed. They were only there to make any third party conformances to `JSONSchemaContext` non-breaking. 99% of code will not change as a result of this.