### PR TITLE
Add support for new patch versions of OAS

### DIFF
--- a/Sources/OpenAPIKit/Document/Document.swift
+++ b/Sources/OpenAPIKit/Document/Document.swift
@@ -374,6 +374,7 @@ extension OpenAPI.Document {
     /// OpenAPIKit to a certain extent.
     public enum Version: String, Codable {
         case v3_1_0 = "3.1.0"
+        case v3_1_1 = "3.1.1"
     }
 }
 

--- a/Sources/OpenAPIKit30/Document/Document.swift
+++ b/Sources/OpenAPIKit30/Document/Document.swift
@@ -361,6 +361,7 @@ extension OpenAPI.Document {
         case v3_0_1 = "3.0.1"
         case v3_0_2 = "3.0.2"
         case v3_0_3 = "3.0.3"
+        case v3_0_4 = "3.0.4"
     }
 }
 

--- a/Sources/OpenAPIKitCompat/Compat30To31.swift
+++ b/Sources/OpenAPIKitCompat/Compat30To31.swift
@@ -10,10 +10,7 @@ import OpenAPIKit30
 
 public extension OpenAPIKit30.OpenAPI.Document {
     func `convert`(to version: OpenAPIKit.OpenAPI.Document.Version) -> OpenAPIKit.OpenAPI.Document {
-        switch version {
-        case .v3_1_0:
-            return self.to31()
-        }
+        return self.to31(version: version)
     }
 }
 
@@ -22,10 +19,10 @@ private protocol To31 {
     func to31() -> Destination
 }
 
-extension OpenAPIKit30.OpenAPI.Document: To31 {
-    fileprivate func to31() -> OpenAPIKit.OpenAPI.Document {
+extension OpenAPIKit30.OpenAPI.Document {
+    fileprivate func to31(version: OpenAPIKit.OpenAPI.Document.Version = .v3_1_0) -> OpenAPIKit.OpenAPI.Document {
         OpenAPIKit.OpenAPI.Document(
-            openAPIVersion: .v3_1_0,
+            openAPIVersion: version,
             info: info.to31(),
             servers: servers.map { $0.to31() },
             paths: paths.mapValues { eitherRefTo31($0) },


### PR DESCRIPTION
New OAS versions dropped with no need to update code other than to indicate the versions are supported.

https://www.openapis.org/blog/2024/10/25/announcing-openapi-specification-patch-releases