### PR TITLE
Make Document.Info members mutable

### DIFF
--- a/Sources/OpenAPIKit/Document/DocumentInfo.swift
+++ b/Sources/OpenAPIKit/Document/DocumentInfo.swift
@@ -13,13 +13,13 @@ extension OpenAPI.Document {
     ///
     /// See [OpenAPI Info Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#info-object).
     public struct Info: Equatable, CodableVendorExtendable {
-        public let title: String
-        public let summary: String?
-        public let description: String?
-        public let termsOfService: URL?
-        public let contact: Contact?
-        public let license: License?
-        public let version: String
+        public var title: String
+        public var summary: String?
+        public var description: String?
+        public var termsOfService: URL?
+        public var contact: Contact?
+        public var license: License?
+        public var version: String
 
         /// Dictionary of vendor extensions.
         ///


### PR DESCRIPTION
I'm working on a project that requires lots of individual mutation of the entire Document structure, and I couldn't find a particular reason why all the Document.Info fields are immutable. The rest of the Document structure seems to be mutable. Wondering if there's something I'm overlooking. Thanks so much for this awesome package 😀