### PR TITLE
Add vendor extension support to ContentEncoding.Swift (fixes #315)

### DIFF
--- a/Sources/OpenAPIKit30/Content/ContentEncoding.swift
+++ b/Sources/OpenAPIKit30/Content/ContentEncoding.swift
@@ -1,6 +1,6 @@
 //
 //  ContentEncoding.swift
-//  
+//
 //
 //  Created by Mathew Polzin on 12/29/19.
 //
@@ -9,42 +9,71 @@ import OpenAPIKitCore
 
 extension OpenAPI.Content {
     /// OpenAPI Spec "Encoding Object"
-    /// 
-    /// See [OpenAPI Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#encoding-object).
+    ///
+    /// See [OpenAPI Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#encoding-object).
     public struct Encoding: Equatable {
         public typealias Style = OpenAPI.Parameter.SchemaContext.Style
 
-        public let contentType: OpenAPI.ContentType?
+        /// If an encoding object only contains 1 content type, it will be populated here.
+        /// Two or more content types will result in a null value here but the `contentTypes`
+        /// (plural) property will contain all content types specified.
+        ///
+        /// The singular `contentType` property is only provided for backwards compatibility and
+        /// using the plural `contentTypes` property should be preferred.
+        @available(*, deprecated, message: "use contentTypes instead")
+        public var contentType: OpenAPI.ContentType? {
+            guard let contentType = contentTypes.first,
+                contentTypes.count == 1
+            else {
+                return nil
+            }
+            return contentType
+        }
+
+        public let contentTypes: [OpenAPI.ContentType]
         public let headers: OpenAPI.Header.Map?
         public let style: Style
         public let explode: Bool
         public let allowReserved: Bool
 
+        /// Dictionary to store vendor extensions (e.g., x-custom-encoding)
+        public let vendorExtensions: [String: AnyCodable]?
+
+        /// The singular `contentType` argument is only provided for backwards compatibility and
+        /// using the plural `contentTypes` argument should be preferred.
         public init(
             contentType: OpenAPI.ContentType? = nil,
+            contentTypes: [OpenAPI.ContentType] = [],
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable]? = nil
         ) {
-            self.contentType = contentType
+            self.contentTypes = contentTypes + [contentType].compactMap { $0 }
             self.headers = headers
             self.style = style
             self.explode = style.defaultExplode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
+        /// The singular `contentType` argument is only provided for backwards compatibility and
+        /// using the plural `contentTypes` argument should be preferred.
         public init(
             contentType: OpenAPI.ContentType? = nil,
+            contentTypes: [OpenAPI.ContentType] = [],
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
             explode: Bool,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable]? = nil
         ) {
-            self.contentType = contentType
+            self.contentTypes = contentTypes + [contentType].compactMap { $0 }
             self.headers = headers
             self.style = style
             self.explode = explode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
         public static let defaultStyle: Style = .default(for: .query)
@@ -56,7 +85,13 @@ extension OpenAPI.Content.Encoding: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encodeIfPresent(contentType, forKey: .contentType)
+        if contentTypes.count > 0 {
+            let contentTypesString =
+                contentTypes
+                .map(\.rawValue)
+                .joined(separator: ", ")
+            try container.encode(contentTypesString, forKey: .contentType)
+        }
         try container.encodeIfPresent(headers, forKey: .headers)
 
         if style != Self.defaultStyle {
@@ -70,6 +105,13 @@ extension OpenAPI.Content.Encoding: Encodable {
         if allowReserved != false {
             try container.encode(allowReserved, forKey: .allowReserved)
         }
+
+        // Encode vendor extensions
+        if let vendorExtensions = vendorExtensions {
+            for (key, value) in vendorExtensions {
+                try container.encode(value, forKey: CodingKeys(stringValue: key)!)
+            }
+        }
     }
 }
 
@@ -77,16 +119,37 @@ extension OpenAPI.Content.Encoding: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        contentType = try container.decodeIfPresent(OpenAPI.ContentType.self, forKey: .contentType)
+        let contentTypesString = try container.decodeIfPresent(String.self, forKey: .contentType)
+        if let contentTypesString = contentTypesString {
+            contentTypes =
+                contentTypesString
+                .split(separator: ",")
+                .compactMap { string in
+                    OpenAPI.ContentType.init(rawValue: string.trimmingCharacters(in: .whitespaces))
+                }
+        } else {
+            contentTypes = []
+        }
 
         headers = try container.decodeIfPresent(OpenAPI.Header.Map.self, forKey: .headers)
 
-        let style: Style = try container.decodeIfPresent(Style.self, forKey: .style) ?? Self.defaultStyle
+        let style: Style =
+            try container.decodeIfPresent(Style.self, forKey: .style) ?? Self.defaultStyle
         self.style = style
 
         explode = try container.decodeIfPresent(Bool.self, forKey: .explode) ?? style.defaultExplode
 
         allowReserved = try container.decodeIfPresent(Bool.self, forKey: .allowReserved) ?? false
+
+        // Capture vendor extensions
+        var extensions: [String: AnyCodable] = [:]
+        let allKeys = container.allKeys
+        for key in allKeys where key.stringValue.hasPrefix("x-") {
+            if let value = try? container.decode(AnyCodable.self, forKey: key) {
+                extensions[key.stringValue] = value
+            }
+        }
+        vendorExtensions = extensions.isEmpty ? nil : extensions
     }
 }
 
@@ -97,6 +160,34 @@ extension OpenAPI.Content.Encoding {
         case style
         case explode
         case allowReserved
+
+        // Dynamic key for vendor extensions
+        case custom = ""
+        init?(stringValue: String) {
+            if stringValue.hasPrefix("x-") {
+                self = .custom
+            } else {
+                switch stringValue {
+                case "contentType": self = .contentType
+                case "headers": self = .headers
+                case "style": self = .style
+                case "explode": self = .explode
+                case "allowReserved": self = .allowReserved
+                default: return nil
+                }
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .contentType: return "contentType"
+            case .headers: return "headers"
+            case .style: return "style"
+            case .explode: return "explode"
+            case .allowReserved: return "allowReserved"
+            case .custom: return ""
+            }
+        }
     }
 }
 

--- a/Tests/OpenAPIKit30Tests/Content/ContentTests.swift
+++ b/Tests/OpenAPIKit30Tests/Content/ContentTests.swift
@@ -6,705 +6,739 @@
 //
 
 import Foundation
-import XCTest
 import OpenAPIKit30
+import XCTest
 
 final class ContentTests: XCTestCase {
-    func test_init() {
-        let t1 = OpenAPI.Content(schema: .init(.external(URL(string:"hello.json#/world")!)))
-        XCTAssertNotNil(t1.schema?.reference)
-        XCTAssertNil(t1.schema?.schemaValue)
+  func test_init() {
+    let t1 = OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!)))
+    XCTAssertNotNil(t1.schema?.reference)
+    XCTAssertNil(t1.schema?.schemaValue)
 
-        let t2 = OpenAPI.Content(schema: .init(.string))
-        XCTAssertNotNil(t2.schema?.schemaValue)
-        XCTAssertNil(t2.schema?.reference)
+    let t2 = OpenAPI.Content(schema: .init(.string))
+    XCTAssertNotNil(t2.schema?.schemaValue)
+    XCTAssertNil(t2.schema?.reference)
 
-        let t3 = OpenAPI.Content(schemaReference: .external(URL(string: "hello.json#/world")!))
-        XCTAssertNotNil(t3.schema?.reference)
-        XCTAssertNil(t3.schema?.schemaValue)
+    let t3 = OpenAPI.Content(schemaReference: .external(URL(string: "hello.json#/world")!))
+    XCTAssertNotNil(t3.schema?.reference)
+    XCTAssertNil(t3.schema?.schemaValue)
 
-        let withExample = OpenAPI.Content(
-            schema: .init(.string),
-            example: "hello",
-            encoding: [
-                "json": .init()
-            ]
+    let withExample = OpenAPI.Content(
+      schema: .init(.string),
+      example: "hello",
+      encoding: [
+        "json": .init()
+      ]
+    )
+    XCTAssertNotNil(withExample.example)
+    XCTAssertNil(withExample.examples)
+
+    let withExamples = OpenAPI.Content(
+      schema: .init(.string),
+      examples: [
+        "hello": .example(.init(value: .init("world"))),
+        "bbbb": .example(.init(value: .b("pick me"))),
+        "aaaa": .example(.init(value: .a(URL(string: "http://google.com")!))),
+      ]
+    )
+    XCTAssertNotNil(withExamples.examples)
+    // we expect the example to be the first example where ordering
+    // is the order in which the examples are given:
+    XCTAssertEqual(withExamples.example?.value as? String, "world")
+    XCTAssertEqual(withExamples.examples?["hello"]?.exampleValue, .init(value: .init("world")))
+
+    let t4 = OpenAPI.Content(
+      schemaReference: .external(URL(string: "hello.json#/world")!),
+      examples: nil
+    )
+    XCTAssertNotNil(t4.schema?.reference)
+    XCTAssertNil(t4.schema?.schemaValue)
+
+    let t5 = OpenAPI.Content(
+      schema: .string,
+      examples: nil
+    )
+    XCTAssertNotNil(t5.schema?.schemaValue)
+    XCTAssertNil(t5.schema?.reference)
+
+    let _ = OpenAPI.Content(
+      schema: .init(.string),
+      example: nil,
+      encoding: [
+        "hello": .init(
+          contentType: .json,
+          headers: [
+            "world": .init(OpenAPI.Header(schemaOrContent: .init(.header(.string))))
+          ],
+          allowReserved: true
         )
-        XCTAssertNotNil(withExample.example)
-        XCTAssertNil(withExample.examples)
+      ]
+    )
+  }
 
-        let withExamples = OpenAPI.Content(
-            schema: .init(.string),
-            examples: [
-                "hello": .example(.init(value: .init("world"))),
-                "bbbb": .example(.init(value: .b("pick me"))),
-                "aaaa": .example(.init(value: .a(URL(string: "http://google.com")!)))
-            ]
-        )
-        XCTAssertNotNil(withExamples.examples)
-        // we expect the example to be the first example where ordering
-        // is the order in which the examples are given:
-        XCTAssertEqual(withExamples.example?.value as? String, "world")
-        XCTAssertEqual(withExamples.examples?["hello"]?.exampleValue, .init(value: .init("world")))
+  func test_contentMap() {
+    let _: OpenAPI.Content.Map = [
+      .bmp: .init(schema: .init(.string(format: .binary))),
+      .css: .init(schema: .init(.string)),
+      .csv: .init(schema: .init(.string)),
+      .form: .init(schema: .init(.object(properties: ["hello": .string]))),
+      .html: .init(schema: .init(.string)),
+      .javascript: .init(schema: .init(.string)),
+      .jpg: .init(schema: .init(.string(format: .binary))),
+      .json: .init(schema: .init(.string)),
+      .jsonapi: .init(schema: .init(.string)),
+      .mov: .init(schema: .init(.string(format: .binary))),
+      .mp3: .init(schema: .init(.string(format: .binary))),
+      .mp4: .init(schema: .init(.string(format: .binary))),
+      .mpg: .init(schema: .init(.string(format: .binary))),
+      .multipartForm: .init(schema: .init(.string)),
+      .pdf: .init(schema: .init(.string)),
+      .rar: .init(schema: .init(.integer)),
+      .rtf: .init(schema: .init(.string)),
+      .tar: .init(schema: .init(.boolean)),
+      .tif: .init(schema: .init(.string(format: .binary))),
+      .txt: .init(schema: .init(.number)),
+      .xml: .init(schema: .init(.external(URL(string: "hello.json#/world")!))),
+      .yaml: .init(schema: .init(.string)),
+      .zip: .init(schema: .init(.string)),
 
-        let t4 = OpenAPI.Content(
-            schemaReference: .external(URL(string: "hello.json#/world")!),
-            examples: nil
-        )
-        XCTAssertNotNil(t4.schema?.reference)
-        XCTAssertNil(t4.schema?.schemaValue)
+      .other("application/custom"): .init(schema: .string),
 
-        let t5 = OpenAPI.Content(
-            schema: .string,
-            examples: nil
-        )
-        XCTAssertNotNil(t5.schema?.schemaValue)
-        XCTAssertNil(t5.schema?.reference)
+      .anyApplication: .init(schema: .string(format: .binary)),
+      .anyAudio: .init(schema: .string(format: .binary)),
+      .anyImage: .init(schema: .string(format: .binary)),
+      .anyText: .init(schema: .string(format: .binary)),
+      .anyVideo: .init(schema: .string(format: .binary)),
 
-        let _ = OpenAPI.Content(
-            schema: .init(.string),
-            example: nil,
-            encoding: [
-                "hello": .init(
-                    contentType: .json,
-                    headers: [
-                        "world": .init(OpenAPI.Header(schemaOrContent: .init(.header(.string))))
-                    ],
-                    allowReserved: true
-                )
-            ]
-        )
-    }
-
-    func test_contentMap() {
-        let _: OpenAPI.Content.Map = [
-            .bmp: .init(schema: .init(.string(format: .binary))),
-            .css: .init(schema: .init(.string)),
-            .csv: .init(schema: .init(.string)),
-            .form: .init(schema: .init(.object(properties: ["hello": .string]))),
-            .html: .init(schema: .init(.string)),
-            .javascript: .init(schema: .init(.string)),
-            .jpg: .init(schema: .init(.string(format: .binary))),
-            .json: .init(schema: .init(.string)),
-            .jsonapi: .init(schema: .init(.string)),
-            .mov: .init(schema: .init(.string(format: .binary))),
-            .mp3: .init(schema: .init(.string(format: .binary))),
-            .mp4: .init(schema: .init(.string(format: .binary))),
-            .mpg: .init(schema: .init(.string(format: .binary))),
-            .multipartForm: .init(schema: .init(.string)),
-            .pdf: .init(schema: .init(.string)),
-            .rar: .init(schema: .init(.integer)),
-            .rtf: .init(schema: .init(.string)),
-            .tar: .init(schema: .init(.boolean)),
-            .tif: .init(schema: .init(.string(format: .binary))),
-            .txt: .init(schema: .init(.number)),
-            .xml: .init(schema: .init(.external(URL(string: "hello.json#/world")!))),
-            .yaml: .init(schema: .init(.string)),
-            .zip: .init(schema: .init(.string)),
-
-            .other("application/custom"): .init(schema: .string),
-
-            .anyApplication: .init(schema: .string(format: .binary)),
-            .anyAudio: .init(schema: .string(format: .binary)),
-            .anyImage: .init(schema: .string(format: .binary)),
-            .anyText: .init(schema: .string(format: .binary)),
-            .anyVideo: .init(schema: .string(format: .binary)),
-
-            .any: .init(schema: .string(format: .binary))
-        ]
-    }
+      .any: .init(schema: .string(format: .binary)),
+    ]
+  }
 }
 
 // MARK: - Codable
 extension ContentTests {
-    func test_referenceContent_encode() {
-        let content = OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!)))
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+  func test_referenceContent_encode() {
+    let content = OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!)))
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "schema" : {
-                "$ref" : "hello.json#\\/world"
-              }
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "schema" : {
+          "$ref" : "hello.json#\\/world"
+        }
+      }
+      """
+    )
+  }
+
+  func test_referenceContent_decode() {
+    let contentData =
+      """
+      {
+        "schema" : {
+          "$ref" : "hello.json#\\/world"
+        }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    XCTAssertEqual(
+      content, OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!))))
+  }
+
+  func test_schemaContent_encode() {
+    let content = OpenAPI.Content(schema: .init(.string))
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        }
+      }
+      """
+    )
+  }
+
+  func test_schemaContent_decode() {
+    let contentData =
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    XCTAssertEqual(content, OpenAPI.Content(schema: .init(.string)))
+  }
+
+  func test_schemalessContent_encode() {
+    let content = OpenAPI.Content(schema: nil, example: "hello world")
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "example" : "hello world"
+      }
+      """
+    )
+  }
+
+  func test_schemalessContent_decode() {
+    let contentData =
+      """
+      {
+        "example" : "hello world"
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    XCTAssertEqual(content, OpenAPI.Content(schema: nil, example: "hello world"))
+  }
+
+  func test_exampleAndSchemaContent_encode() {
+    let content = OpenAPI.Content(
+      schema: .init(.object(properties: ["hello": .string])),
+      example: ["hello": "world"])
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "example" : {
+          "hello" : "world"
+        },
+        "schema" : {
+          "properties" : {
+            "hello" : {
+              "type" : "string"
             }
-            """
-        )
-    }
+          },
+          "required" : [
+            "hello"
+          ],
+          "type" : "object"
+        }
+      }
+      """
+    )
+  }
 
-    func test_referenceContent_decode() {
-        let contentData =
-        """
-        {
-          "schema" : {
-            "$ref" : "hello.json#\\/world"
+  func test_exampleAndSchemaContent_decode() {
+    let contentData =
+      """
+      {
+        "example" : {
+          "hello" : "world"
+        },
+        "schema" : {
+          "properties" : {
+            "hello" : {
+              "type" : "string"
+            }
+          },
+          "required" : [
+            "hello"
+          ],
+          "type" : "object"
+        }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    XCTAssertEqual(content.schema, .init(.object(properties: ["hello": .string])))
+
+    XCTAssertEqual(content.example?.value as? [String: String], ["hello": "world"])
+  }
+
+  func test_examplesAndSchemaContent_encode() {
+    let content = OpenAPI.Content(
+      schema: .init(.object(properties: ["hello": .string])),
+      examples: ["hello": .b(OpenAPI.Example(value: .init(["hello": "world"])))])
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "examples" : {
+          "hello" : {
+            "value" : {
+              "hello" : "world"
+            }
           }
-        }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
-
-        XCTAssertEqual(content, OpenAPI.Content(schema: .init(.external(URL(string: "hello.json#/world")!))))
-    }
-
-    func test_schemaContent_encode() {
-        let content = OpenAPI.Content(schema: .init(.string))
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "schema" : {
-                "type" : "string"
-              }
+        },
+        "schema" : {
+          "properties" : {
+            "hello" : {
+              "type" : "string"
             }
-            """
-        )
-    }
+          },
+          "required" : [
+            "hello"
+          ],
+          "type" : "object"
+        }
+      }
+      """
+    )
+  }
 
-    func test_schemaContent_decode() {
-        let contentData =
-        """
-        {
-          "schema" : {
-            "type" : "string"
+  func test_examplesAndSchemaContent_decode() {
+    let contentData =
+      """
+      {
+        "examples" : {
+          "hello": {
+              "value": {
+                  "hello" : "world"
+              }
           }
-        }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
-
-        XCTAssertEqual(content, OpenAPI.Content(schema: .init(.string)))
-    }
-
-    func test_schemalessContent_encode() {
-        let content = OpenAPI.Content(schema: nil, example: "hello world")
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "example" : "hello world"
+        },
+        "schema" : {
+          "properties" : {
+            "hello" : {
+              "type" : "string"
             }
-            """
-        )
-    }
-
-    func test_schemalessContent_decode() {
-        let contentData =
-        """
-        {
-          "example" : "hello world"
-        }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
-
-        XCTAssertEqual(content, OpenAPI.Content(schema: nil, example: "hello world"))
-    }
-
-    func test_exampleAndSchemaContent_encode() {
-        let content = OpenAPI.Content(schema: .init(.object(properties: ["hello": .string])),
-                                      example: [ "hello": "world" ])
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "example" : {
-                "hello" : "world"
-              },
-              "schema" : {
-                "properties" : {
-                  "hello" : {
-                    "type" : "string"
-                  }
-                },
-                "required" : [
-                  "hello"
-                ],
-                "type" : "object"
-              }
-            }
-            """
-        )
-    }
-
-    func test_exampleAndSchemaContent_decode() {
-        let contentData =
-        """
-        {
-          "example" : {
-            "hello" : "world"
           },
-          "schema" : {
-            "properties" : {
-              "hello" : {
-                "type" : "string"
+          "required" : [
+            "hello"
+          ],
+          "type" : "object"
+        }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    XCTAssertEqual(content.schema, .init(.object(properties: ["hello": .string])))
+
+    XCTAssertEqual(content.example?.value as? [String: String], ["hello": "world"])
+    XCTAssertEqual(
+      content.examples?["hello"]?.exampleValue?.value?.codableValue?.value as? [String: String],
+      ["hello": "world"])
+  }
+
+  func test_decodeFailureForBothExampleAndExamples() {
+    let contentData =
+      """
+      {
+        "examples" : {
+          "hello": {
+              "value": {
+                  "hello" : "world"
               }
-            },
-            "required" : [
-              "hello"
-            ],
-            "type" : "object"
           }
-        }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
-
-        XCTAssertEqual(content.schema, .init(.object(properties: ["hello": .string])))
-
-        XCTAssertEqual(content.example?.value as? [String: String], [ "hello": "world" ])
-    }
-
-    func test_examplesAndSchemaContent_encode() {
-        let content = OpenAPI.Content(schema: .init(.object(properties: ["hello": .string])),
-                                      examples: ["hello": .b(OpenAPI.Example(value: .init([ "hello": "world" ])))])
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "examples" : {
-                "hello" : {
-                  "value" : {
-                    "hello" : "world"
-                  }
-                }
-              },
-              "schema" : {
-                "properties" : {
-                  "hello" : {
-                    "type" : "string"
-                  }
-                },
-                "required" : [
-                  "hello"
-                ],
-                "type" : "object"
-              }
-            }
-            """
-        )
-    }
-
-    func test_examplesAndSchemaContent_decode() {
-        let contentData =
-        """
-        {
-          "examples" : {
-            "hello": {
-                "value": {
-                    "hello" : "world"
-                }
+        },
+        "example" : {
+          "hello" : "world"
+        },
+        "schema" : {
+          "properties" : {
+            "hello" : {
+              "type" : "string"
             }
           },
-          "schema" : {
-            "properties" : {
-              "hello" : {
-                "type" : "string"
-              }
-            },
-            "required" : [
-              "hello"
-            ],
-            "type" : "object"
+          "required" : [
+            "hello"
+          ],
+          "type" : "object"
+        }
+      }
+      """.data(using: .utf8)!
+    XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
+  }
+
+  func test_encodingAndSchema_encode() {
+    let content = OpenAPI.Content(
+      schema: .init(.string),
+      encoding: ["json": .init(contentType: .json)]
+    )
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "encoding" : {
+          "json" : {
+            "contentType" : "application\\/json"
           }
+        },
+        "schema" : {
+          "type" : "string"
         }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+      }
+      """
+    )
+  }
 
-        XCTAssertEqual(content.schema, .init(.object(properties: ["hello": .string])))
-
-        XCTAssertEqual(content.example?.value as? [String: String], [ "hello": "world" ])
-        XCTAssertEqual(content.examples?["hello"]?.exampleValue?.value?.codableValue?.value as? [String: String], [ "hello": "world" ])
-    }
-
-    func test_decodeFailureForBothExampleAndExamples() {
-        let contentData =
-        """
-        {
-          "examples" : {
-            "hello": {
-                "value": {
-                    "hello" : "world"
-                }
-            }
-          },
-          "example" : {
-            "hello" : "world"
-          },
-          "schema" : {
-            "properties" : {
-              "hello" : {
-                "type" : "string"
-              }
-            },
-            "required" : [
-              "hello"
-            ],
-            "type" : "object"
+  func test_encodingAndSchema_decode() {
+    let contentData =
+      """
+      {
+        "encoding" : {
+          "json" : {
+            "allowReserved" : false,
+            "contentType" : "application\\/json"
           }
+        },
+        "schema" : {
+          "type" : "string"
         }
-        """.data(using: .utf8)!
-        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
-    }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
 
-    func test_encodingAndSchema_encode() {
-        let content = OpenAPI.Content(
-            schema: .init(.string),
-            encoding: ["json": .init(contentType: .json)]
-        )
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+    XCTAssertEqual(
+      content,
+      OpenAPI.Content(
+        schema: .init(.string),
+        encoding: ["json": .init(contentType: .json)]
+      )
+    )
+  }
 
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "encoding" : {
-                "json" : {
-                  "contentType" : "application\\/json"
-                }
-              },
-              "schema" : {
-                "type" : "string"
-              }
-            }
-            """
-        )
-    }
+  func test_vendorExtensions_encode() {
+    let content = OpenAPI.Content(
+      schema: .init(.string),
+      vendorExtensions: ["x-hello": ["world": 123]]
+    )
 
-    func test_encodingAndSchema_decode() {
-        let contentData =
-        """
-        {
-          "encoding" : {
-            "json" : {
-              "allowReserved" : false,
-              "contentType" : "application\\/json"
-            }
-          },
-          "schema" : {
-            "type" : "string"
-          }
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
+
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        },
+        "x-hello" : {
+          "world" : 123
         }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+      }
+      """
+    )
+  }
 
-        XCTAssertEqual(
-            content,
-            OpenAPI.Content(
-                schema: .init(.string),
-                encoding: ["json": .init(contentType: .json)]
-            )
-        )
-    }
+  func test_vendorExtensions_encode_fixKey() {
+    let content = OpenAPI.Content(
+      schema: .init(.string),
+      vendorExtensions: ["hello": ["world": 123]]
+    )
 
-    func test_vendorExtensions_encode() {
-        let content = OpenAPI.Content(
-            schema: .init(.string),
-            vendorExtensions: [ "x-hello": [ "world": 123 ] ]
-        )
+    let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
 
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "schema" : {
-                "type" : "string"
-              },
-              "x-hello" : {
-                "world" : 123
-              }
-            }
-            """
-        )
-    }
-
-    func test_vendorExtensions_encode_fixKey() {
-        let content = OpenAPI.Content(
-            schema: .init(.string),
-            vendorExtensions: [ "hello": [ "world": 123 ] ]
-        )
-
-        let encodedContent = try! orderUnstableTestStringFromEncoding(of: content)
-
-        assertJSONEquivalent(
-            encodedContent,
-            """
-            {
-              "schema" : {
-                "type" : "string"
-              },
-              "x-hello" : {
-                "world" : 123
-              }
-            }
-            """
-        )
-    }
-
-    func test_vendorExtensions_decode() {
-        let contentData =
-        """
-        {
-          "schema" : {
-            "type" : "string"
-          },
-          "x-hello" : {
-            "world" : 123
-          }
+    assertJSONEquivalent(
+      encodedContent,
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        },
+        "x-hello" : {
+          "world" : 123
         }
-        """.data(using: .utf8)!
-        let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+      }
+      """
+    )
+  }
 
-        let contentToMatch = OpenAPI.Content(
-            schema: .init(.string),
-            vendorExtensions: ["x-hello": AnyCodable(["world": 123])]
-        )
-
-        // make sure we don't lose VendorExtendable existential support
-        let ve = content as VendorExtendable
-        XCTAssertEqual(ve.vendorExtensions.count, 1)
-
-        // needs to be broken down due to difficulties with equality comparing of AnyCodable
-        // created from code with a semantically equivalent AnyCodable from Data.
-        XCTAssertEqual(content.schema, contentToMatch.schema)
-        XCTAssertEqual(content.vendorExtensions.keys, contentToMatch.vendorExtensions.keys)
-        XCTAssertEqual(content.vendorExtensions["x-hello"]?.value as? [String: Int], contentToMatch.vendorExtensions["x-hello"]?.value as? [String: Int]?)
-    }
-
-    func test_nonStringKeyNonesenseDecodeFailure() {
-        let contentData =
-        """
-        {
-          "schema" : {
-            "type" : "string"
-          },
-          "x-hello" : {
-            "world" : 123
-          },
-          10: "hello"
+  func test_vendorExtensions_decode() {
+    let contentData =
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        },
+        "x-hello" : {
+          "world" : 123
         }
-        """.data(using: .utf8)!
-        XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
-    }
+      }
+      """.data(using: .utf8)!
+    let content = try! orderUnstableDecode(OpenAPI.Content.self, from: contentData)
+
+    let contentToMatch = OpenAPI.Content(
+      schema: .init(.string),
+      vendorExtensions: ["x-hello": AnyCodable(["world": 123])]
+    )
+
+    // make sure we don't lose VendorExtendable existential support
+    let ve = content as VendorExtendable
+    XCTAssertEqual(ve.vendorExtensions.count, 1)
+
+    // needs to be broken down due to difficulties with equality comparing of AnyCodable
+    // created from code with a semantically equivalent AnyCodable from Data.
+    XCTAssertEqual(content.schema, contentToMatch.schema)
+    XCTAssertEqual(content.vendorExtensions.keys, contentToMatch.vendorExtensions.keys)
+    XCTAssertEqual(
+      content.vendorExtensions["x-hello"]?.value as? [String: Int],
+      contentToMatch.vendorExtensions["x-hello"]?.value as? [String: Int]?)
+  }
+
+  func test_nonStringKeyNonesenseDecodeFailure() {
+    let contentData =
+      """
+      {
+        "schema" : {
+          "type" : "string"
+        },
+        "x-hello" : {
+          "world" : 123
+        },
+        10: "hello"
+      }
+      """.data(using: .utf8)!
+    XCTAssertThrowsError(try orderUnstableDecode(OpenAPI.Content.self, from: contentData))
+  }
 }
 
 // MARK: - Content.Encoding
 extension ContentTests {
-    func test_encodingInit() {
-        let _ = OpenAPI.Content.Encoding()
+  func test_encodingInit() {
+    let _ = OpenAPI.Content.Encoding()
 
-        let _ = OpenAPI.Content.Encoding(contentType: .json)
+    let _ = OpenAPI.Content.Encoding(contentType: .json)
 
-        let _ = OpenAPI.Content.Encoding(headers: ["special": .a(.external(URL(string: "hello.yml")!))])
+    let _ = OpenAPI.Content.Encoding(headers: ["special": .a(.external(URL(string: "hello.yml")!))])
 
-        let _ = OpenAPI.Content.Encoding(allowReserved: true)
+    let _ = OpenAPI.Content.Encoding(allowReserved: true)
 
-        let _ = OpenAPI.Content.Encoding(contentType: .form,
-                                         headers: ["special": .a(.external(URL(string: "hello.yml")!))],
-                                         allowReserved: true)
-        let _ = OpenAPI.Content.Encoding(contentType: .json,
-                                         style: .form)
-        let _ = OpenAPI.Content.Encoding(contentType: .json,
-                                         style: .form,
-                                         explode: true)
-    }
-}
+    let _ = OpenAPI.Content.Encoding(
+      contentType: .form,
+      headers: ["special": .a(.external(URL(string: "hello.yml")!))],
+      allowReserved: true)
+    let _ = OpenAPI.Content.Encoding(
+      contentType: .json,
+      style: .form)
+    let _ = OpenAPI.Content.Encoding(
+      contentType: .json,
+      style: .form,
+      explode: true)
+  }
 
-extension ContentTests {
-    func test_encoding_minimal_encode() throws {
-        let encoding = OpenAPI.Content.Encoding()
+  func test_encoding_minimal_encode() throws {
+    let encoding = OpenAPI.Content.Encoding()
 
-        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
 
-            }
-            """
-        )
-    }
+      }
+      """
+    )
+  }
 
-    func test_encoding_minimal_decode() throws {
-        let encodingData =
-        """
-        {}
-        """.data(using: .utf8)!
-        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+  func test_encoding_minimal_decode() throws {
+    let encodingData =
+      """
+      {}
+      """.data(using: .utf8)!
+    let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(encoding, OpenAPI.Content.Encoding())
-    }
+    XCTAssertEqual(encoding, OpenAPI.Content.Encoding())
+  }
 
-    func test_encoding_contentType_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(contentType: .csv)
+  func test_encoding_contentType_encode() throws {
+    let encoding = OpenAPI.Content.Encoding(contentType: .csv)
 
-        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
-              "contentType" : "text\\/csv"
-            }
-            """
-        )
-    }
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
+        "contentType" : "text\\/csv"
+      }
+      """
+    )
+  }
 
-    func test_encoding_contentType_decode() throws {
-        let encodingData =
-        """
-        {
-            "contentType": "text/csv"
-        }
-        """.data(using: .utf8)!
-        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+  func test_encoding_contentType_decode() throws {
+    let encodingData =
+      """
+      {
+          "contentType": "text/csv"
+      }
+      """.data(using: .utf8)!
+    let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(encoding, OpenAPI.Content.Encoding(contentType: .csv))
-    }
+    XCTAssertEqual(encoding, OpenAPI.Content.Encoding(contentType: .csv))
+  }
 
-    func test_encoding_headers_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(headers: [
-            "X-CustomThing": .init(OpenAPI.Header(schema: .string))
-        ])
+  func test_encoding_headers_encode() throws {
+    let encoding = OpenAPI.Content.Encoding(headers: [
+      "X-CustomThing": .init(OpenAPI.Header(schema: .string))
+    ])
 
-        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
-              "headers" : {
-                "X-CustomThing" : {
-                  "schema" : {
-                    "type" : "string"
-                  }
-                }
-              }
-            }
-            """
-        )
-    }
-
-    func test_encoding_headers_decode() throws {
-        let encodingData =
-        """
-        {
-          "headers" : {
-            "X-CustomThing" : {
-              "schema" : {
-                "type" : "string"
-              }
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
+        "headers" : {
+          "X-CustomThing" : {
+            "schema" : {
+              "type" : "string"
             }
           }
         }
-        """.data(using: .utf8)!
-        let encoding = try orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+      }
+      """
+    )
+  }
 
-        XCTAssertEqual(
-            encoding,
-            OpenAPI.Content.Encoding(
-                headers: [
-                    "X-CustomThing": .init(OpenAPI.Header(schema: .string))
-                ]
-            )
-        )
-    }
-
-    func test_encoding_style_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(style: .pipeDelimited)
-
-        let encodedEncoding = try orderUnstableTestStringFromEncoding(of: encoding)
-
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
-              "style" : "pipeDelimited"
+  func test_encoding_headers_decode() throws {
+    let encodingData =
+      """
+      {
+        "headers" : {
+          "X-CustomThing" : {
+            "schema" : {
+              "type" : "string"
             }
-            """
-        )
-    }
-
-    func test_encoding_style_decode() throws {
-        let encodingData =
-        """
-        {
-          "style" : "pipeDelimited"
+          }
         }
-        """.data(using: .utf8)!
-        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+      }
+      """.data(using: .utf8)!
+    let encoding = try orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(
-            encoding,
-            OpenAPI.Content.Encoding(style: .pipeDelimited)
-        )
-    }
+    XCTAssertEqual(
+      encoding,
+      OpenAPI.Content.Encoding(
+        headers: [
+          "X-CustomThing": .init(OpenAPI.Header(schema: .string))
+        ]
+      )
+    )
+  }
 
-    func test_encoding_explode_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(explode: false)
+  func test_encoding_style_encode() throws {
+    let encoding = OpenAPI.Content.Encoding(style: .pipeDelimited)
 
-        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
-              "explode" : false
-            }
-            """
-        )
-    }
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
+        "style" : "pipeDelimited"
+      }
+      """
+    )
+  }
 
-    func test_encoding_explode_decode() throws {
-        let encodingData =
-        """
-        {
-          "explode" : false
-        }
-        """.data(using: .utf8)!
-        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+  func test_encoding_style_decode() throws {
+    let encodingData =
+      """
+      {
+        "style" : "pipeDelimited"
+      }
+      """.data(using: .utf8)!
+    let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(
-            encoding,
-            OpenAPI.Content.Encoding(explode: false)
-        )
-    }
+    XCTAssertEqual(
+      encoding,
+      OpenAPI.Content.Encoding(style: .pipeDelimited)
+    )
+  }
 
-    func test_encoding_allowReserved_encode() throws {
-        let encoding = OpenAPI.Content.Encoding(allowReserved: true)
+  func test_encoding_explode_encode() throws {
+    let encoding = OpenAPI.Content.Encoding(explode: false)
 
-        let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
 
-        assertJSONEquivalent(
-            encodedEncoding,
-            """
-            {
-              "allowReserved" : true
-            }
-            """
-        )
-    }
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
+        "explode" : false
+      }
+      """
+    )
+  }
 
-    func test_encoding_allowReserved_decode() throws {
-        let encodingData =
-        """
-        {
-          "allowReserved" : true
-        }
-        """.data(using: .utf8)!
-        let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+  func test_encoding_explode_decode() throws {
+    let encodingData =
+      """
+      {
+        "explode" : false
+      }
+      """.data(using: .utf8)!
+    let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
 
-        XCTAssertEqual(
-            encoding,
-            OpenAPI.Content.Encoding(allowReserved: true)
-        )
-    }
+    XCTAssertEqual(
+      encoding,
+      OpenAPI.Content.Encoding(explode: false)
+    )
+  }
+
+  func test_encoding_allowReserved_encode() throws {
+    let encoding = OpenAPI.Content.Encoding(allowReserved: true)
+
+    let encodedEncoding = try! orderUnstableTestStringFromEncoding(of: encoding)
+
+    assertJSONEquivalent(
+      encodedEncoding,
+      """
+      {
+        "allowReserved" : true
+      }
+      """
+    )
+  }
+
+  func test_encoding_allowReserved_decode() throws {
+    let encodingData =
+      """
+      {
+        "allowReserved" : true
+      }
+      """.data(using: .utf8)!
+    let encoding = try! orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+
+    XCTAssertEqual(
+      encoding,
+      OpenAPI.Content.Encoding(allowReserved: true)
+    )
+  }
+
+  // New test for vendor extensions
+  func test_encodingVendorExtensions() throws {
+    // Test data with a vendor extension
+    let json = """
+      {
+          "contentType": "application/json",
+          "x-custom-encoding": "my-type"
+      }
+      """
+    let decoder = JSONDecoder()
+    let encoding = try decoder.decode(OpenAPI.Content.Encoding.self, from: Data(json.utf8))
+
+    // Verify vendor extension is captured
+    XCTAssertNotNil(encoding.vendorExtensions)
+    XCTAssertEqual(encoding.vendorExtensions?["x-custom-encoding"]?.value as? String, "my-type")
+    XCTAssertEqual(encoding.contentTypes.first?.rawValue, "application/json")
+
+    // Verify encoding back to JSON
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+    let encodedData = try encoder.encode(encoding)
+    let encodedString = String(data: encodedData, encoding: .utf8)
+    XCTAssertTrue(encodedString?.contains("\"x-custom-encoding\": \"my-type\"") ?? false)
+    XCTAssertTrue(encodedString?.contains("\"contentType\": \"application/json\"") ?? false)
+  }
 }


### PR DESCRIPTION
**Added vendorExtensions Property**
A new vendorExtensions property has been added to the OpenAPI.Content.Encoding type to store custom x-* fields.

**Updated Codable Conformance**
The Codable implementation has been updated to properly encode and decode x- prefixed keys, ensuring compatibility with OpenAPI specifications that include vendor extensions.

A new test case, test_encodingVendorExtensions, has been added to ContentTests.swift to verify that vendor extensions are correctly handled during encoding and decoding.
