### PR TITLE
Added a Validation that checks all operationIds in Link objects are valid

### DIFF
--- a/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit/Validator/Validation+Builtins.swift
@@ -479,6 +479,30 @@ extension Validation {
     public static var serverVarialbeDefaultExistsInEnum : Validation<OpenAPI.Server.Variable> {
         return serverVariableDefaultExistsInEnum
     }
+
+    /// Validate the OpenAPI Document's `Links` with operationIds refer to
+    /// Operations that exist in the document.
+    ///
+    /// This validation ensures that Link Objects using operationIds have corresponding
+    /// Operations in the document that have those IDs.
+    ///
+    /// - Important: This is not an included validation by default.
+    public static var linkOperationsExist: Validation<OpenAPI.Link> {
+        .init(
+            description: "Links with operationIds have corresponding Operations",
+            check: { context in
+                guard case let .b(operationId) = context.subject.operation else {
+                    // don't make assertions about Links that don't have operationIds
+                    return true
+                }
+                
+                // Collect all operation IDs from the document
+                let operationIds = context.document.allOperationIds
+                
+                return operationIds.contains(operationId)
+            }
+        )
+    }
 }
 
 /// Used by both the Path Item parameter check and the

--- a/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
@@ -396,6 +396,33 @@ extension Validation {
             }
         )
     }
+
+    /// Validate the OpenAPI Document's `Links` with operationIds refer to
+    /// Operations that exist in the document.
+    ///
+    /// This validation ensures that Link Objects using operationIds have corresponding
+    /// Operations in the document that have those IDs.
+    ///
+    /// - Important: This is not an included validation by default.
+    public static var linkOperationsExist: Validation<OpenAPI.Link> {
+        .init(
+            description: "Links with operationIds have corresponding Operations",
+            check: { context in
+                guard case let .b(operationId) = context.subject.operation else {
+                    // don't make assertions about Links that don't have operationIds
+                    return true
+                }
+                
+                // Collect all operation IDs from the document
+                let operationIds = context.document.paths.values
+                    .compactMap { context.document.components[$0] }
+                    .flatMap { $0.endpoints }
+                    .compactMap { $0.operation.operationId }
+                
+                return operationIds.contains(operationId)
+            }
+        )
+    }
 }
 
 /// Used by both the Path Item parameter check and the

--- a/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
+++ b/Sources/OpenAPIKit30/Validator/Validation+Builtins.swift
@@ -413,11 +413,8 @@ extension Validation {
                     return true
                 }
                 
-                // Collect all operation IDs from the document
-                let operationIds = context.document.paths.values
-                    .compactMap { context.document.components[$0] }
-                    .flatMap { $0.endpoints }
-                    .compactMap { $0.operation.operationId }
+                // Use the allOperationIds helper to get all operation IDs from the document
+                let operationIds = context.document.allOperationIds
                 
                 return operationIds.contains(operationId)
             }

--- a/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
@@ -750,29 +750,6 @@ final class BuiltinValidationTests: XCTestCase {
         try document.validate()
     }
 
-    func test_securityRequirementComponentsExist_fails() throws {
-        let document = OpenAPI.Document(
-            info: .init(title: "test", version: "1.0"),
-            servers: [],
-            paths: [:],
-            components: .noComponents,
-            security: [
-                [.component(named: "oauth"): ["scope2"]]
-            ]
-        )
-
-        XCTAssertThrowsError(try document.validate()) { error in
-            let errorCollection = error as? ValidationErrorCollection
-            XCTAssertEqual(errorCollection?.values.first?.reason, "Failed to satisfy: Security Requirement security scheme can be found in components/securitySchemes")
-            XCTAssertEqual(errorCollection?.values.first?.codingPath.map { $0.stringValue }, ["security"])
-            XCTAssertEqual(errorCollection?.values.count, 1)
-
-            let openAPIError = OpenAPI.Error(from: error)
-            XCTAssertEqual(openAPIError.localizedDescription, "Failed to satisfy: Security Requirement security scheme can be found in components/securitySchemes at path: .security")
-            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["security"])
-        }
-    }
-    
     func test_linkOperationsExist_validates() throws {
         // Create a link with an operationId that exists in the document
         let link = OpenAPI.Link(operationId: "testOperation")

--- a/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKit30Tests/Validator/BuiltinValidationTests.swift
@@ -749,4 +749,86 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         try document.validate()
     }
+
+    func test_securityRequirementComponentsExist_fails() throws {
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [:],
+            components: .noComponents,
+            security: [
+                [.component(named: "oauth"): ["scope2"]]
+            ]
+        )
+
+        XCTAssertThrowsError(try document.validate()) { error in
+            let errorCollection = error as? ValidationErrorCollection
+            XCTAssertEqual(errorCollection?.values.first?.reason, "Failed to satisfy: Security Requirement security scheme can be found in components/securitySchemes")
+            XCTAssertEqual(errorCollection?.values.first?.codingPath.map { $0.stringValue }, ["security"])
+            XCTAssertEqual(errorCollection?.values.count, 1)
+
+            let openAPIError = OpenAPI.Error(from: error)
+            XCTAssertEqual(openAPIError.localizedDescription, "Failed to satisfy: Security Requirement security scheme can be found in components/securitySchemes at path: .security")
+            XCTAssertEqual(openAPIError.codingPath.map { $0.stringValue }, ["security"])
+        }
+    }
+    
+    func test_linkOperationsExist_validates() throws {
+        // Create a link with an operationId that exists in the document
+        let link = OpenAPI.Link(operationId: "testOperation")
+        
+        // Create a document with an operation using that ID
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .init(
+                    get: .init(
+                        operationId: "testOperation",
+                        responses: [:]
+                    )
+                )
+            ],
+            components: .init(
+                links: [
+                    "testLink": link
+                ]
+            )
+        )
+        
+        let validator = Validator.blank.validating(.linkOperationsExist)
+        try document.validate(using: validator)
+    }
+    
+    func test_linkOperationsExist_fails() throws {
+        // Create a link with an operationId that doesn't exist in the document
+        let link = OpenAPI.Link(operationId: "nonExistentOperation")
+        
+        // Create a document with an operation using a different ID
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .init(
+                    get: .init(
+                        operationId: "testOperation",
+                        responses: [:]
+                    )
+                )
+            ],
+            components: .init(
+                links: [
+                    "testLink": link
+                ]
+            )
+        )
+        
+        let validator = Validator.blank.validating(.linkOperationsExist)
+        
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let errorCollection = error as? ValidationErrorCollection
+            XCTAssertEqual(errorCollection?.values.first?.reason, "Failed to satisfy: Links with operationIds have corresponding Operations")
+            XCTAssertTrue((errorCollection?.values.first?.codingPath.map { $0.stringValue }.joined(separator: ".") ?? "").contains("testLink"))
+        }
+    }
 }

--- a/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
+++ b/Tests/OpenAPIKitTests/Validator/BuiltinValidationTests.swift
@@ -860,4 +860,84 @@ final class BuiltinValidationTests: XCTestCase {
         // NOTE this is part of default validation
         try document.validate()
     }
+
+    func test_pathItemsTopLevelReferencesReferencingPathItemComponentsSuccess() throws {
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .reference(.component(named: "hello")),
+                "/world": .reference(.component(named: "world"))
+            ],
+            components: .init(
+                pathItems: [
+                    "hello": .init(),
+                    "world": .init()
+                ]
+            )
+        )
+
+        let validator = Validator.blank.validating(.pathItemReferencesAreValid)
+
+        try document.validate(using: validator)
+    }
+    
+    func test_linkOperationsExist_validates() throws {
+        // Create a link with an operationId that exists in the document
+        let link = OpenAPI.Link(operationId: "testOperation")
+        
+        // Create a document with an operation using that ID
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .init(
+                    get: .init(
+                        operationId: "testOperation",
+                        responses: [:]
+                    )
+                )
+            ],
+            components: .init(
+                links: [
+                    "testLink": link
+                ]
+            )
+        )
+        
+        let validator = Validator.blank.validating(.linkOperationsExist)
+        try document.validate(using: validator)
+    }
+    
+    func test_linkOperationsExist_fails() throws {
+        // Create a link with an operationId that doesn't exist in the document
+        let link = OpenAPI.Link(operationId: "nonExistentOperation")
+        
+        // Create a document with an operation using a different ID
+        let document = OpenAPI.Document(
+            info: .init(title: "test", version: "1.0"),
+            servers: [],
+            paths: [
+                "/hello": .init(
+                    get: .init(
+                        operationId: "testOperation",
+                        responses: [:]
+                    )
+                )
+            ],
+            components: .init(
+                links: [
+                    "testLink": link
+                ]
+            )
+        )
+        
+        let validator = Validator.blank.validating(.linkOperationsExist)
+        
+        XCTAssertThrowsError(try document.validate(using: validator)) { error in
+            let errorCollection = error as? ValidationErrorCollection
+            XCTAssertEqual(errorCollection?.values.first?.reason, "Failed to satisfy: Links with operationIds have corresponding Operations")
+            XCTAssertTrue((errorCollection?.values.first?.codingPath.map { $0.stringValue }.joined(separator: ".") ?? "").contains("testLink"))
+        }
+    }
 }


### PR DESCRIPTION
Issue #236 

This PR directly addresses the issue mentioned in the GitHub project (issue #236) for OpenAPIKit.

I have added a validation that ensures operationIds in Link objects refer to actual Operations that exist in the document. 

Changes

1. I've created a new optional validation called linkOperationsExist that verifies Link objects with operationIds are pointing to valid Operations in the document.

2. Extracting the operationId from the Link object (ignoring Links that use operationRef instead)
- Collecting all operationIds from all Operations in the document (using different approaches in OpenAPIKit and OpenAPIKit30)
- Checking if the Link's operationId is contained in the list of valid operationIds

3. When a Link refers to a non-existent operationId, the validation produces a clear error message indicating that the Link's operationId has no corresponding Operation in the document.

This validation is optional and not included in the default validator.

```
let validator = Validator.default.validating(.linkOperationsExist)
try document.validate(using: validator)
```

The PR completes the TODO item in the project while maintaining consistency with the existing validation framework, ensuring that OpenAPI documents can be properly validated for correctness in their Link references.
