### PR TITLE
Add vendor extension support to Content.Encoding type

### DIFF
--- a/Sources/OpenAPIKit/Content/ContentEncoding.swift
+++ b/Sources/OpenAPIKit/Content/ContentEncoding.swift
@@ -1,6 +1,6 @@
 //
 //  ContentEncoding.swift
-//  
+//
 //
 //  Created by Mathew Polzin on 12/29/19.
 //
@@ -9,9 +9,9 @@ import OpenAPIKitCore
 
 extension OpenAPI.Content {
     /// OpenAPI Spec "Encoding Object"
-    /// 
+    ///
     /// See [OpenAPI Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#encoding-object).
-    public struct Encoding: Equatable {
+    public struct Encoding: Equatable, CodableVendorExtendable {
         public typealias Style = OpenAPI.Parameter.SchemaContext.Style
 
         /// If an encoding object only contains 1 content type, it will be populated here.
@@ -35,6 +35,13 @@ extension OpenAPI.Content {
         public let explode: Bool
         public let allowReserved: Bool
 
+        /// Dictionary of vendor extensions.
+        ///
+        /// These should be of the form:
+        /// `[ "x-extensionKey": <anything>]`
+        /// where the values are anything codable.
+        public var vendorExtensions: [String: AnyCodable]
+
         /// The singular `contentType` argument is only provided for backwards compatibility and
         /// using the plural `contentTypes` argument should be preferred.
         public init(
@@ -42,13 +49,15 @@ extension OpenAPI.Content {
             contentTypes: [OpenAPI.ContentType] = [],
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable] = [:]
         ) {
             self.contentTypes = contentTypes + [contentType].compactMap { $0 }
             self.headers = headers
             self.style = style
             self.explode = style.defaultExplode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
         /// The singular `contentType` argument is only provided for backwards compatibility and
@@ -59,13 +68,15 @@ extension OpenAPI.Content {
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
             explode: Bool,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable] = [:]
         ) {
             self.contentTypes = contentTypes + [contentType].compactMap { $0 }
             self.headers = headers
             self.style = style
             self.explode = explode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
         public static let defaultStyle: Style = .default(for: .query)
@@ -96,6 +107,8 @@ extension OpenAPI.Content.Encoding: Encodable {
         if allowReserved != false {
             try container.encode(allowReserved, forKey: .allowReserved)
         }
+
+        try encodeExtensions(to: &container)
     }
 }
 
@@ -122,16 +135,61 @@ extension OpenAPI.Content.Encoding: Decodable {
         explode = try container.decodeIfPresent(Bool.self, forKey: .explode) ?? style.defaultExplode
 
         allowReserved = try container.decodeIfPresent(Bool.self, forKey: .allowReserved) ?? false
+
+        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 
 extension OpenAPI.Content.Encoding {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: ExtendableCodingKey {
         case contentType
         case headers
         case style
         case explode
         case allowReserved
+        case extended(String)
+
+        static var allBuiltinKeys: [CodingKeys] {
+            return [.contentType, .headers, .style, .explode, .allowReserved]
+        }
+
+        static func extendedKey(for value: String) -> CodingKeys {
+            return .extended(value)
+        }
+
+        init?(stringValue: String) {
+            switch stringValue {
+            case "contentType":
+                self = .contentType
+            case "headers":
+                self = .headers
+            case "style":
+                self = .style
+            case "explode":
+                self = .explode
+            case "allowReserved":
+                self = .allowReserved
+            default:
+                self = .extendedKey(for: stringValue)
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .contentType:
+                return "contentType"
+            case .headers:
+                return "headers"
+            case .style:
+                return "style"
+            case .explode:
+                return "explode"
+            case .allowReserved:
+                return "allowReserved"
+            case .extended(let key):
+                return key
+            }
+        }
     }
 }
 

--- a/Sources/OpenAPIKit30/Content/ContentEncoding.swift
+++ b/Sources/OpenAPIKit30/Content/ContentEncoding.swift
@@ -11,7 +11,7 @@ extension OpenAPI.Content {
     /// OpenAPI Spec "Encoding Object"
     /// 
     /// See [OpenAPI Encoding Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#encoding-object).
-    public struct Encoding: Equatable {
+    public struct Encoding: Equatable, CodableVendorExtendable {
         public typealias Style = OpenAPI.Parameter.SchemaContext.Style
 
         public let contentType: OpenAPI.ContentType?
@@ -20,17 +20,26 @@ extension OpenAPI.Content {
         public let explode: Bool
         public let allowReserved: Bool
 
+        /// Dictionary of vendor extensions.
+        ///
+        /// These should be of the form:
+        /// `[ "x-extensionKey": <anything>]`
+        /// where the values are anything codable.
+        public var vendorExtensions: [String: AnyCodable]
+
         public init(
             contentType: OpenAPI.ContentType? = nil,
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable] = [:]
         ) {
             self.contentType = contentType
             self.headers = headers
             self.style = style
             self.explode = style.defaultExplode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
         public init(
@@ -38,13 +47,15 @@ extension OpenAPI.Content {
             headers: OpenAPI.Header.Map? = nil,
             style: Style = Self.defaultStyle,
             explode: Bool,
-            allowReserved: Bool = false
+            allowReserved: Bool = false,
+            vendorExtensions: [String: AnyCodable] = [:]
         ) {
             self.contentType = contentType
             self.headers = headers
             self.style = style
             self.explode = explode
             self.allowReserved = allowReserved
+            self.vendorExtensions = vendorExtensions
         }
 
         public static let defaultStyle: Style = .default(for: .query)
@@ -70,6 +81,8 @@ extension OpenAPI.Content.Encoding: Encodable {
         if allowReserved != false {
             try container.encode(allowReserved, forKey: .allowReserved)
         }
+
+        try encodeExtensions(to: &container)
     }
 }
 
@@ -87,16 +100,61 @@ extension OpenAPI.Content.Encoding: Decodable {
         explode = try container.decodeIfPresent(Bool.self, forKey: .explode) ?? style.defaultExplode
 
         allowReserved = try container.decodeIfPresent(Bool.self, forKey: .allowReserved) ?? false
+
+        vendorExtensions = try Self.extensions(from: decoder)
     }
 }
 
 extension OpenAPI.Content.Encoding {
-    private enum CodingKeys: String, CodingKey {
+    internal enum CodingKeys: ExtendableCodingKey {
         case contentType
         case headers
         case style
         case explode
         case allowReserved
+        case extended(String)
+
+        static var allBuiltinKeys: [CodingKeys] {
+            return [.contentType, .headers, .style, .explode, .allowReserved]
+        }
+
+        static func extendedKey(for value: String) -> CodingKeys {
+            return .extended(value)
+        }
+
+        init?(stringValue: String) {
+            switch stringValue {
+            case "contentType":
+                self = .contentType
+            case "headers":
+                self = .headers
+            case "style":
+                self = .style
+            case "explode":
+                self = .explode
+            case "allowReserved":
+                self = .allowReserved
+            default:
+                self = .extendedKey(for: stringValue)
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case .contentType:
+                return "contentType"
+            case .headers:
+                return "headers"
+            case .style:
+                return "style"
+            case .explode:
+                return "explode"
+            case .allowReserved:
+                return "allowReserved"
+            case .extended(let key):
+                return key
+            }
+        }
     }
 }
 

--- a/Tests/OpenAPIKit30Tests/Content/ContentTests.swift
+++ b/Tests/OpenAPIKit30Tests/Content/ContentTests.swift
@@ -515,9 +515,7 @@ extension ContentTests {
                                          style: .form,
                                          explode: true)
     }
-}
 
-extension ContentTests {
     func test_encoding_minimal_encode() throws {
         let encoding = OpenAPI.Content.Encoding()
 
@@ -706,5 +704,48 @@ extension ContentTests {
             encoding,
             OpenAPI.Content.Encoding(allowReserved: true)
         )
+    }
+
+    func test_encoding_vendorExtensions_encode() throws {
+        let encoding = OpenAPI.Content.Encoding(
+            contentType: .json,
+            vendorExtensions: [
+                "x-custom": "value",
+                "x-nested": ["key": 123]
+            ]
+        )
+
+        let encodedEncoding = try orderUnstableTestStringFromEncoding(of: encoding)
+
+        assertJSONEquivalent(
+            encodedEncoding,
+            """
+            {
+              "contentType" : "application\\/json",
+              "x-custom" : "value",
+              "x-nested" : {
+                "key" : 123
+              }
+            }
+            """
+        )
+    }
+
+    func test_encoding_vendorExtensions_decode() throws {
+        let encodingData =
+        """
+        {
+            "contentType": "application/json",
+            "x-custom": "value",
+            "x-nested": {
+                "key": 123
+            }
+        }
+        """.data(using: .utf8)!
+        let encoding = try orderUnstableDecode(OpenAPI.Content.Encoding.self, from: encodingData)
+
+        XCTAssertEqual(encoding.contentType, .json)
+        XCTAssertEqual(encoding.vendorExtensions["x-custom"]?.value as? String, "value")
+        XCTAssertEqual((encoding.vendorExtensions["x-nested"]?.value as? [String: Int])?["key"], 123)
     }
 }


### PR DESCRIPTION
Issue #315 

This PR adds vendor extension support to the Content.Encoding type, addressing issue #315. The implementation follows the existing patterns used throughout the codebase for vendor extensions.

Changes made:
- Added VendorExtendable protocol conformance to Content.Encoding
- Introduced vendorExtensions property to store custom extensions
- Updated initializers to support optional vendor extensions
- Modified CodingKeys to properly handle vendor extension encoding/decoding
- Added comprehensive test cases for both encoding and decoding of vendor extensions

The changes are non-breaking as they:
- Maintain backward compatibility with existing code
- Make vendorExtensions parameter optional with a default empty dictionary
- Preserve all existing functionality

I've implemented these changes in both OpenAPIKit and OpenAPIKit30 to maintain consistency across versions. All tests are passing, including the new vendor extension test cases.

This enhancement allows users to add custom vendor extensions to Content.Encoding objects, following the OpenAPI specification's vendor extension pattern (x-prefixed properties).