### PR TITLE
Support vendor extensions in `anyOf` `allOf` `oneOf` for OAS 3.1

### DIFF
--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -1918,6 +1918,57 @@ extension SchemaObjectTests {
             JSONSchema.fragment(.init(examples: ["hello"])).with(vendorExtensions: ["x-hello": "hello"])
         )
     }
+    
+    func test_decodeAnyOfWithVendorExtension() throws {
+        let extensionSchema = """
+        {
+            "anyOf" : [
+                { "type": "string" },
+                { "type": "number" }
+            ],
+            "x-hello" : "hello"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertEqual(
+            try orderUnstableDecode(JSONSchema.self, from: extensionSchema),
+            JSONSchema.any(of: [JSONSchema.string, JSONSchema.number]).with(vendorExtensions: ["x-hello": "hello"])
+        )
+    }
+    
+    func test_decodeAllOfWithVendorExtension() throws {
+        let extensionSchema = """
+        {
+            "allOf" : [
+                { "type": "string" },
+                { "type": "number" }
+            ],
+            "x-hello" : "hello"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertEqual(
+            try orderUnstableDecode(JSONSchema.self, from: extensionSchema),
+            JSONSchema.all(of: [JSONSchema.string, JSONSchema.number]).with(vendorExtensions: ["x-hello": "hello"])
+        )
+    }
+    
+    func test_decodeOneOfWithVendorExtension() throws {
+        let extensionSchema = """
+        {
+            "oneOf" : [
+                { "type": "string" },
+                { "type": "number" }
+            ],
+            "x-hello" : "hello"
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertEqual(
+            try orderUnstableDecode(JSONSchema.self, from: extensionSchema),
+            JSONSchema.one(of: [JSONSchema.string, JSONSchema.number]).with(vendorExtensions: ["x-hello": "hello"])
+        )
+    }
 
     func test_encodeExamplesVendorExtension() throws {
         let fragment = JSONSchema.fragment(.init(examples: ["hello"])).with(vendorExtensions: ["x-hello": "hello"])


### PR DESCRIPTION
Hi, thanks for a great library.

I noticed that for `anyOf` `allOf` `oneOf` schemas the vendor-extensions don't seem to get parsed.

I tweaked the parsing code, that seemed to skip it because of a early return, to handle that, and also added some test.

Please let me know if theres anything else i can contribute 