### PR TITLE
Allow object-aware external dereference component keys

### DIFF
--- a/Sources/OpenAPIKit/ExternalLoader.swift
+++ b/Sources/OpenAPIKit/ExternalLoader.swift
@@ -46,6 +46,38 @@ public protocol ExternalLoader: _ExternalLoaderMetatype where Message: Sendable 
     ///    time the same type and URL pair are passed in the same `ComponentKey` should be 
     ///    returned.
     static func componentKey<T>(type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey
+
+    /// Determine the next Component Key (where to store something in the
+    /// Components Object) for a newly loaded object.
+    ///
+    /// This overload allows loaders to inspect the decoded value itself when
+    /// deciding what key should be used.
+    static func componentKey<T>(
+        for loadedValue: T,
+        type: T.Type,
+        at url: URL
+    ) throws -> OpenAPI.ComponentKey
+}
+
+public extension ExternalLoader {
+    static func componentKey<T>(type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey {
+        try defaultComponentKey(at: url)
+    }
+
+    static func componentKey<T>(
+        for loadedValue: T,
+        type: T.Type,
+        at url: URL
+    ) throws -> OpenAPI.ComponentKey {
+        try componentKey(type: type, at: url)
+    }
+
+    private static func defaultComponentKey(at url: URL) throws -> OpenAPI.ComponentKey {
+        try .forceInit(rawValue: url.absoluteString
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "#", with: "_")
+            .replacingOccurrences(of: ".", with: "_"))
+    }
 }
 
 public protocol ExternallyDereferenceable {

--- a/Sources/OpenAPIKit/JSONReference.swift
+++ b/Sources/OpenAPIKit/JSONReference.swift
@@ -607,8 +607,8 @@ extension JSONReference: ExternallyDereferenceable where ReferenceType: External
         case .internal(let ref):
             return (.internal(ref), .init(), [])
         case .external(let url):
-            let componentKey = try loader.componentKey(type: ReferenceType.self, at: url)
             let (component, messages): (ReferenceType, [Loader.Message]) = try await loader.load(url)
+            let componentKey = try loader.componentKey(for: component, type: ReferenceType.self, at: url)
             var components = OpenAPI.Components()
             switch ReferenceType.openAPIComponentsKeyPath {
             case .a(let directPath):

--- a/Sources/OpenAPIKit/Path Item/DereferencedPathItem.swift
+++ b/Sources/OpenAPIKit/Path Item/DereferencedPathItem.swift
@@ -153,80 +153,68 @@ extension OpenAPI.PathItem: LocallyDereferenceable {
 
 extension OpenAPI.PathItem: ExternallyDereferenceable {
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) { 
-        let oldParameters = parameters
-        let oldServers = servers
-        let oldGet = get
-        let oldPut = put
-        let oldPost = post
-        let oldDelete = delete
-        let oldOptions = options
-        let oldHead = head
-        let oldPatch = patch
-        let oldTrace = trace
-        let oldQuery = query
-
-        let oldAdditionalOperations = additionalOperations
-
-        async let (newParameters, c1, m1) = oldParameters.externallyDereferenced(with: loader)
-//        async let (newServers, c2, m2) = oldServers.externallyDereferenced(with: loader)
-        async let (newGet, c3, m3) = oldGet.externallyDereferenced(with: loader)
-        async let (newPut, c4, m4) = oldPut.externallyDereferenced(with: loader)
-        async let (newPost, c5, m5) = oldPost.externallyDereferenced(with: loader)
-        async let (newDelete, c6, m6) = oldDelete.externallyDereferenced(with: loader)
-        async let (newOptions, c7, m7) = oldOptions.externallyDereferenced(with: loader)
-        async let (newHead, c8, m8) = oldHead.externallyDereferenced(with: loader)
-        async let (newPatch, c9, m9) = oldPatch.externallyDereferenced(with: loader)
-        async let (newTrace, c10, m10) = oldTrace.externallyDereferenced(with: loader)
-        async let (newQuery, c11, m11) = oldQuery.externallyDereferenced(with: loader)
-
-        async let (newAdditionalOperations, c12, m12) = oldAdditionalOperations.externallyDereferenced(with: loader)
-
+        async let (newParameters, c1, m1) = parameters.externallyDereferenced(with: loader)
         var pathItem = self
         var newComponents = try await c1
         var newMessages = try await m1
 
-        // ideally we would async let all of the props above and then set them here,
-        // but for now since there seems to be some sort of compiler bug we will do
-        // newServers in an if let below
         pathItem.parameters = try await newParameters
-        pathItem.get = try await newGet
-        pathItem.put = try await newPut
-        pathItem.post = try await newPost
-        pathItem.delete = try await newDelete
-        pathItem.options = try await newOptions
-        pathItem.head = try await newHead
-        pathItem.patch = try await newPatch
-        pathItem.trace = try await newTrace
-        pathItem.query = try await newQuery
-        pathItem.additionalOperations = try await newAdditionalOperations
 
-        try await newComponents.merge(c3)
-        try await newComponents.merge(c4)
-        try await newComponents.merge(c5)
-        try await newComponents.merge(c6)
-        try await newComponents.merge(c7)
-        try await newComponents.merge(c8)
-        try await newComponents.merge(c9)
-        try await newComponents.merge(c10)
-        try await newComponents.merge(c11)
-        try await newComponents.merge(c12)
+        let (newGet, c2, m2) = try await get.externallyDereferenced(with: loader)
+        pathItem.get = newGet
+        try newComponents.merge(c2)
+        newMessages += m2
 
-        try await newMessages += m3
-        try await newMessages += m4
-        try await newMessages += m5
-        try await newMessages += m6
-        try await newMessages += m7
-        try await newMessages += m8
-        try await newMessages += m9
-        try await newMessages += m10
-        try await newMessages += m11
-        try await newMessages += m12
+        let (newPut, c3, m3) = try await put.externallyDereferenced(with: loader)
+        pathItem.put = newPut
+        try newComponents.merge(c3)
+        newMessages += m3
 
-        if let oldServers {
-            async let (newServers, c2, m2) = oldServers.externallyDereferenced(with: loader)
-            pathItem.servers = try await newServers
-            try await newComponents.merge(c2)
-            try await newMessages += m2
+        let (newPost, c4, m4) = try await post.externallyDereferenced(with: loader)
+        pathItem.post = newPost
+        try newComponents.merge(c4)
+        newMessages += m4
+
+        let (newDelete, c5, m5) = try await delete.externallyDereferenced(with: loader)
+        pathItem.delete = newDelete
+        try newComponents.merge(c5)
+        newMessages += m5
+
+        let (newOptions, c6, m6) = try await options.externallyDereferenced(with: loader)
+        pathItem.options = newOptions
+        try newComponents.merge(c6)
+        newMessages += m6
+
+        let (newHead, c7, m7) = try await head.externallyDereferenced(with: loader)
+        pathItem.head = newHead
+        try newComponents.merge(c7)
+        newMessages += m7
+
+        let (newPatch, c8, m8) = try await patch.externallyDereferenced(with: loader)
+        pathItem.patch = newPatch
+        try newComponents.merge(c8)
+        newMessages += m8
+
+        let (newTrace, c9, m9) = try await trace.externallyDereferenced(with: loader)
+        pathItem.trace = newTrace
+        try newComponents.merge(c9)
+        newMessages += m9
+
+        let (newQuery, c10, m10) = try await query.externallyDereferenced(with: loader)
+        pathItem.query = newQuery
+        try newComponents.merge(c10)
+        newMessages += m10
+
+        let (newAdditionalOperations, c11, m11) = try await additionalOperations.externallyDereferenced(with: loader)
+        pathItem.additionalOperations = newAdditionalOperations
+        try newComponents.merge(c11)
+        newMessages += m11
+
+        if let servers {
+            let (newServers, c12, m12) = try await servers.externallyDereferenced(with: loader)
+            pathItem.servers = newServers
+            try newComponents.merge(c12)
+            newMessages += m12
         }
 
         return (pathItem, newComponents, newMessages)

--- a/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/DereferencedJSONSchema.swift
@@ -340,6 +340,7 @@ extension DereferencedJSONSchema {
         public let maxProperties: Int?
         let _minProperties: Int?
         public let properties: OrderedDictionary<String, DereferencedJSONSchema>
+        public let patternProperties: OrderedDictionary<String, DereferencedJSONSchema>
         public let additionalProperties: Either<Bool, DereferencedJSONSchema>?
 
         // NOTE that an object's required properties
@@ -372,7 +373,16 @@ extension DereferencedJSONSchema {
                 otherProperties[name] = dereferencedProperty
             }
 
+            var otherPatternProperties = OrderedDictionary<String, DereferencedJSONSchema>()
+            for (pattern, property) in objectContext.patternProperties {
+                guard let dereferencedPatternProperty = property.dereferenced() else {
+                    return nil
+                }
+                otherPatternProperties[pattern] = dereferencedPatternProperty
+            }
+
             properties = otherProperties
+            patternProperties = otherPatternProperties
             maxProperties = objectContext.maxProperties
             _minProperties = objectContext._minProperties
             switch objectContext.additionalProperties {
@@ -394,6 +404,7 @@ extension DereferencedJSONSchema {
             following references: Set<AnyHashable>
         ) throws {
             properties = try objectContext.properties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
+            patternProperties = try objectContext.patternProperties.mapValues { try $0._dereferenced(in: components, following: references, dereferencedFromComponentNamed: nil) }
             maxProperties = objectContext.maxProperties
             _minProperties = objectContext._minProperties
             switch objectContext.additionalProperties {
@@ -408,11 +419,13 @@ extension DereferencedJSONSchema {
 
         internal init(
             properties: OrderedDictionary<String, DereferencedJSONSchema>,
+            patternProperties: OrderedDictionary<String, DereferencedJSONSchema> = [:],
             additionalProperties: Either<Bool, DereferencedJSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil
         ) {
             self.properties = properties
+            self.patternProperties = patternProperties
             self.additionalProperties = additionalProperties
             self.maxProperties = maxProperties
             self._minProperties = minProperties
@@ -431,6 +444,7 @@ extension DereferencedJSONSchema {
 
             return .init(
                 properties: properties.mapValues { $0.jsonSchema },
+                patternProperties: patternProperties.mapValues { $0.jsonSchema },
                 additionalProperties: underlyingAdditionalProperties,
                 maxProperties: maxProperties,
                 minProperties: _minProperties
@@ -573,11 +587,15 @@ extension JSONSchema: ExternallyDereferenceable {
             try components.merge(c1)
             messages += m1
 
+            let (newPatternProperties, c2, m2) = try await object.patternProperties.externallyDereferenced(with: loader)
+            try components.merge(c2)
+            messages += m2
+
             let newAdditionalProperties: Either<Bool, JSONSchema>?
             if case .b(let schema) = object.additionalProperties {
-                let (additionalProperties, c2, m2) = try await schema.externallyDereferenced(with: loader)
-                try components.merge(c2)
-                messages += m2
+                let (additionalProperties, c3, m3) = try await schema.externallyDereferenced(with: loader)
+                try components.merge(c3)
+                messages += m3
                 newAdditionalProperties = .b(additionalProperties)
             } else {
                 newAdditionalProperties = object.additionalProperties
@@ -589,6 +607,7 @@ extension JSONSchema: ExternallyDereferenceable {
                     core, 
                     .init(
                         properties: newProperties, 
+                        patternProperties: newPatternProperties,
                         additionalProperties: newAdditionalProperties, 
                         maxProperties: object.maxProperties, 
                         minProperties: object._minProperties

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema+Combining.swift
@@ -528,6 +528,7 @@ extension JSONSchema.ArrayContext {
 extension JSONSchema.ObjectContext {
     internal func combined(with other: JSONSchema.ObjectContext, resolvingIn components: OpenAPI.Components) throws -> JSONSchema.ObjectContext {
         let combinedProperties = try combine(properties: properties, with: other.properties, resolvingIn: components)
+        let combinedPatternProperties = try combine(properties: patternProperties, with: other.patternProperties, resolvingIn: components)
 
         if let conflict = conflicting(maxProperties, other.maxProperties) {
             throw JSONSchemaResolutionError(.attributeConflict(jsonType: .object, name: "maxProperties", original: String(conflict.0), new: String(conflict.1)))
@@ -559,6 +560,7 @@ extension JSONSchema.ObjectContext {
         let newAdditionalProperties = additionalProperties ?? other.additionalProperties
         return .init(
             properties: combinedProperties,
+            patternProperties: combinedPatternProperties,
             additionalProperties: newAdditionalProperties,
             maxProperties: newMaxProperties,
             minProperties: newMinProperties

--- a/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchema.swift
@@ -1614,6 +1614,7 @@ extension JSONSchema {
         minProperties: Int? = nil,
         maxProperties: Int? = nil,
         properties: OrderedDictionary<String, JSONSchema> = [:],
+        patternProperties: OrderedDictionary<String, JSONSchema> = [:],
         additionalProperties: Either<Bool, JSONSchema>? = nil,
         allowedValues: [AnyCodable]? = nil,
         defaultValue: AnyCodable? = nil,
@@ -1643,6 +1644,7 @@ extension JSONSchema {
         )
         let objectContext = JSONSchema.ObjectContext(
             properties: properties,
+            patternProperties: patternProperties,
             additionalProperties: additionalProperties,
             maxProperties: maxProperties,
             minProperties: minProperties

--- a/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
+++ b/Sources/OpenAPIKit/Schema Object/JSONSchemaContext.swift
@@ -782,6 +782,10 @@ extension JSONSchema {
         /// allows you to omit the property from encoding.
         public let additionalProperties: Either<Bool, JSONSchema>?
 
+        /// Schemas keyed by regular expressions that matching property names
+        /// must satisfy.
+        public let patternProperties: OrderedDictionary<String, JSONSchema>
+
         /// The properties of this object that are required.
         ///
         /// - Note: An object's required properties array
@@ -811,11 +815,13 @@ extension JSONSchema {
 
         public init(
             properties: OrderedDictionary<String, JSONSchema>,
+            patternProperties: OrderedDictionary<String, JSONSchema> = [:],
             additionalProperties: Either<Bool, JSONSchema>? = nil,
             maxProperties: Int? = nil,
             minProperties: Int? = nil
         ) {
             self.properties = properties
+            self.patternProperties = patternProperties
             self.additionalProperties = additionalProperties
             self.maxProperties = maxProperties
             self._minProperties = minProperties
@@ -1260,6 +1266,7 @@ extension JSONSchema.ObjectContext {
         case maxProperties
         case minProperties
         case properties
+        case patternProperties
         case additionalProperties
         case required
     }
@@ -1273,6 +1280,10 @@ extension JSONSchema.ObjectContext: Encodable {
 
         if properties.count > 0 {
             try container.encode(properties, forKey: .properties)
+        }
+
+        if patternProperties.count > 0 {
+            try container.encode(patternProperties, forKey: .patternProperties)
         }
 
         try container.encodeIfPresent(additionalProperties, forKey: .additionalProperties)
@@ -1291,6 +1302,7 @@ extension JSONSchema.ObjectContext: Decodable {
 
         maxProperties = try container.decodeIfPresent(Int.self, forKey: .maxProperties)
         _minProperties = try container.decodeIfPresent(Int.self, forKey: .minProperties)
+        patternProperties = try container.decodeIfPresent(OrderedDictionary<String, JSONSchema>.self, forKey: .patternProperties) ?? [:]
         additionalProperties = try container.decodeIfPresent(Either<Bool, JSONSchema>.self, forKey: .additionalProperties)
 
         let requiredArray = try container.decodeIfPresent([String].self, forKey: .required) ?? []

--- a/Sources/OpenAPIKit/Schema Object/SimplifiedJSONSchema.swift
+++ b/Sources/OpenAPIKit/Schema Object/SimplifiedJSONSchema.swift
@@ -108,6 +108,7 @@ extension DereferencedJSONSchema {
                 core,
                 .init(
                     properties: try object.properties.mapValues { try $0.simplified() },
+                    patternProperties: try object.patternProperties.mapValues { try $0.simplified() },
                     additionalProperties: additionalProperties,
                     maxProperties: object.maxProperties,
                     minProperties: object._minProperties

--- a/Sources/OpenAPIKit/Utility/Array+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit/Utility/Array+ExternallyDereferenceable.swift
@@ -7,26 +7,18 @@ import OpenAPIKitCore
 extension Array where Element: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Int, (Element, OpenAPI.Components, [Loader.Message])).self) { group in
-            for (idx, elem) in zip(self.indices, self) {
-                group.addTask {
-                    return try await (idx, elem.externallyDereferenced(with: loader))
-                }
-            }
+        var newElements = Self()
+        newElements.reserveCapacity(count)
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-            var newElems = Array<(Int, Element)>()
-            var newComponents = OpenAPI.Components()
-            var newMessages = [Loader.Message]()
-
-            for try await (idx, (elem, components, messages)) in group {
-                newElems.append((idx, elem))
-                try newComponents.merge(components)
-                newMessages += messages
-            }
-            // things may come in out of order because of concurrency
-            // so we reorder after completing all entries.
-            newElems.sort { left, right in left.0 < right.0 }
-            return (newElems.map { $0.1 }, newComponents, newMessages)
+        for element in self {
+            let (newElement, components, messages) = try await element.externallyDereferenced(with: loader)
+            newElements.append(newElement)
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newElements, newComponents, newMessages)
     }
 }

--- a/Sources/OpenAPIKit/Utility/Dictionary+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit/Utility/Dictionary+ExternallyDereferenceable.swift
@@ -8,24 +8,17 @@ import OpenAPIKitCore
 extension Dictionary where Key: Sendable, Value: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Key, Value, OpenAPI.Components, [Loader.Message]).self) { group in
-          for (key, value) in self {
-              group.addTask {
-                  let (newRef, components, messages) = try await value.externallyDereferenced(with: loader)
-                  return (key, newRef, components, messages)
-              }
-          }
+        var newDict = Self()
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-          var newDict = Self()
-          var newComponents = OpenAPI.Components()
-          var newMessage = [Loader.Message]()
-
-          for try await (key, newRef, components, messages) in group {
-              newDict[key] = newRef
-              try newComponents.merge(components)
-              newMessage += messages
-          }
-          return (newDict, newComponents, newMessage)
+        for (key, value) in self {
+            let (newValue, components, messages) = try await value.externallyDereferenced(with: loader)
+            newDict[key] = newValue
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newDict, newComponents, newMessages)
     }
 }

--- a/Sources/OpenAPIKit/Utility/OrderedDictionary+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit/Utility/OrderedDictionary+ExternallyDereferenceable.swift
@@ -10,27 +10,17 @@ import OpenAPIKitCore
 extension OrderedDictionary where Key: Sendable, Value: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Key, Value, OpenAPI.Components, [Loader.Message]).self) { group in
-          for (key, value) in self {
-              group.addTask {
-                  let (newRef, components, messages) = try await value.externallyDereferenced(with: loader)
-                  return (key, newRef, components, messages)
-              }
-          }
+        var newDict = Self()
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-          var newDict = Self()
-          var newComponents = OpenAPI.Components()
-          var newMessages = [Loader.Message]()
-
-          for try await (key, newRef, components, messages) in group {
-              newDict[key] = newRef
-              try newComponents.merge(components)
-              newMessages += messages
-          }
-          // things may come in out of order because of concurrency
-          // so we reorder after completing all entries.
-          try newDict.applyOrder(self)
-          return (newDict, newComponents, newMessages)
+        for (key, value) in self {
+            let (newValue, components, messages) = try await value.externallyDereferenced(with: loader)
+            newDict[key] = newValue
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newDict, newComponents, newMessages)
     }
 }

--- a/Sources/OpenAPIKit30/ExternalLoader.swift
+++ b/Sources/OpenAPIKit30/ExternalLoader.swift
@@ -46,6 +46,38 @@ public protocol ExternalLoader: _ExternalLoaderMetatype where Message: Sendable 
     ///    time the same type and URL pair are passed in the same `ComponentKey` should be 
     ///    returned.
     static func componentKey<T>(type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey
+
+    /// Determine the next Component Key (where to store something in the
+    /// Components Object) for a newly loaded object.
+    ///
+    /// This overload allows loaders to inspect the decoded value itself when
+    /// deciding what key should be used.
+    static func componentKey<T>(
+        for loadedValue: T,
+        type: T.Type,
+        at url: URL
+    ) throws -> OpenAPI.ComponentKey
+}
+
+public extension ExternalLoader {
+    static func componentKey<T>(type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey {
+        try defaultComponentKey(at: url)
+    }
+
+    static func componentKey<T>(
+        for loadedValue: T,
+        type: T.Type,
+        at url: URL
+    ) throws -> OpenAPI.ComponentKey {
+        try componentKey(type: type, at: url)
+    }
+
+    private static func defaultComponentKey(at url: URL) throws -> OpenAPI.ComponentKey {
+        try .forceInit(rawValue: url.absoluteString
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "#", with: "_")
+            .replacingOccurrences(of: ".", with: "_"))
+    }
 }
 
 public protocol ExternallyDereferenceable {

--- a/Sources/OpenAPIKit30/JSONReference.swift
+++ b/Sources/OpenAPIKit30/JSONReference.swift
@@ -394,8 +394,8 @@ extension JSONReference: ExternallyDereferenceable where ReferenceType: External
         case .internal(let ref):
             return (.internal(ref), .init(), [])
         case .external(let url):
-            let componentKey = try loader.componentKey(type: ReferenceType.self, at: url)
             let (component, messages): (ReferenceType, [Loader.Message]) = try await loader.load(url)
+            let componentKey = try loader.componentKey(for: component, type: ReferenceType.self, at: url)
             var components = OpenAPI.Components()
             components[keyPath: ReferenceType.openAPIComponentsKeyPath][componentKey] = component
             return (try components.reference(named: componentKey.rawValue, ofType: ReferenceType.self), components, messages)

--- a/Sources/OpenAPIKit30/Path Item/DereferencedPathItem.swift
+++ b/Sources/OpenAPIKit30/Path Item/DereferencedPathItem.swift
@@ -142,68 +142,58 @@ extension OpenAPI.PathItem: LocallyDereferenceable {
 
 extension OpenAPI.PathItem: ExternallyDereferenceable {
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) { 
-        let oldParameters = parameters
-        let oldServers = servers
-        let oldGet = get
-        let oldPut = put
-        let oldPost = post
-        let oldDelete = delete
-        let oldOptions = options
-        let oldHead = head
-        let oldPatch = patch
-        let oldTrace = trace
-
-        async let (newParameters, c1, m1) = oldParameters.externallyDereferenced(with: loader)
-//        async let (newServers, c2, m2) = oldServers.externallyDereferenced(with: loader)
-        async let (newGet, c3, m3) = oldGet.externallyDereferenced(with: loader)
-        async let (newPut, c4, m4) = oldPut.externallyDereferenced(with: loader)
-        async let (newPost, c5, m5) = oldPost.externallyDereferenced(with: loader)
-        async let (newDelete, c6, m6) = oldDelete.externallyDereferenced(with: loader)
-        async let (newOptions, c7, m7) = oldOptions.externallyDereferenced(with: loader)
-        async let (newHead, c8, m8) = oldHead.externallyDereferenced(with: loader)
-        async let (newPatch, c9, m9) = oldPatch.externallyDereferenced(with: loader)
-        async let (newTrace, c10, m10) = oldTrace.externallyDereferenced(with: loader)
-
+        async let (newParameters, c1, m1) = parameters.externallyDereferenced(with: loader)
         var pathItem = self
         var newComponents = try await c1
         var newMessages = try await m1
 
-        // ideally we would async let all of the props above and then set them here,
-        // but for now since there seems to be some sort of compiler bug we will do
-        // newServers in an if let below
         pathItem.parameters = try await newParameters
-        pathItem.get = try await newGet
-        pathItem.put = try await newPut
-        pathItem.post = try await newPost
-        pathItem.delete = try await newDelete
-        pathItem.options = try await newOptions
-        pathItem.head = try await newHead
-        pathItem.patch = try await newPatch
-        pathItem.trace = try await newTrace
 
-        try await newComponents.merge(c3)
-        try await newComponents.merge(c4)
-        try await newComponents.merge(c5)
-        try await newComponents.merge(c6)
-        try await newComponents.merge(c7)
-        try await newComponents.merge(c8)
-        try await newComponents.merge(c9)
-        try await newComponents.merge(c10)
+        let (newGet, c2, m2) = try await get.externallyDereferenced(with: loader)
+        pathItem.get = newGet
+        try newComponents.merge(c2)
+        newMessages += m2
 
-        try await newMessages += m3
-        try await newMessages += m4
-        try await newMessages += m5
-        try await newMessages += m6
-        try await newMessages += m7
-        try await newMessages += m8
-        try await newMessages += m9
-        try await newMessages += m10
+        let (newPut, c3, m3) = try await put.externallyDereferenced(with: loader)
+        pathItem.put = newPut
+        try newComponents.merge(c3)
+        newMessages += m3
 
-        if let oldServers {
-            async let (newServers, c2, m2) = oldServers.externallyDereferenced(with: loader)
-            pathItem.servers = try await newServers
-            try await newComponents.merge(c2)
-            try await newMessages += m2
+        let (newPost, c4, m4) = try await post.externallyDereferenced(with: loader)
+        pathItem.post = newPost
+        try newComponents.merge(c4)
+        newMessages += m4
+
+        let (newDelete, c5, m5) = try await delete.externallyDereferenced(with: loader)
+        pathItem.delete = newDelete
+        try newComponents.merge(c5)
+        newMessages += m5
+
+        let (newOptions, c6, m6) = try await options.externallyDereferenced(with: loader)
+        pathItem.options = newOptions
+        try newComponents.merge(c6)
+        newMessages += m6
+
+        let (newHead, c7, m7) = try await head.externallyDereferenced(with: loader)
+        pathItem.head = newHead
+        try newComponents.merge(c7)
+        newMessages += m7
+
+        let (newPatch, c8, m8) = try await patch.externallyDereferenced(with: loader)
+        pathItem.patch = newPatch
+        try newComponents.merge(c8)
+        newMessages += m8
+
+        let (newTrace, c9, m9) = try await trace.externallyDereferenced(with: loader)
+        pathItem.trace = newTrace
+        try newComponents.merge(c9)
+        newMessages += m9
+
+        if let servers {
+            let (newServers, c10, m10) = try await servers.externallyDereferenced(with: loader)
+            pathItem.servers = newServers
+            try newComponents.merge(c10)
+            newMessages += m10
         }
 
         return (pathItem, newComponents, newMessages)

--- a/Sources/OpenAPIKit30/Utility/Array+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit30/Utility/Array+ExternallyDereferenceable.swift
@@ -7,26 +7,18 @@ import OpenAPIKitCore
 extension Array where Element: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Int, (Element, OpenAPI.Components, [Loader.Message])).self) { group in
-            for (idx, elem) in zip(self.indices, self) {
-                group.addTask {
-                    return try await (idx, elem.externallyDereferenced(with: loader))
-                }
-            }
+        var newElements = Self()
+        newElements.reserveCapacity(count)
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-            var newElems = Array<(Int, Element)>()
-            var newComponents = OpenAPI.Components()
-            var newMessages = [Loader.Message]()
-
-            for try await (idx, (elem, components, messages)) in group {
-                newElems.append((idx, elem))
-                try newComponents.merge(components)
-                newMessages += messages
-            }
-            // things may come in out of order because of concurrency
-            // so we reorder after completing all entries.
-            newElems.sort { left, right in left.0 < right.0 }
-            return (newElems.map { $0.1 }, newComponents, newMessages)
+        for element in self {
+            let (newElement, components, messages) = try await element.externallyDereferenced(with: loader)
+            newElements.append(newElement)
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newElements, newComponents, newMessages)
     }
 }

--- a/Sources/OpenAPIKit30/Utility/Dictionary+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit30/Utility/Dictionary+ExternallyDereferenceable.swift
@@ -8,24 +8,17 @@ import OpenAPIKitCore
 extension Dictionary where Key: Sendable, Value: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Key, Value, OpenAPI.Components, [Loader.Message]).self) { group in
-          for (key, value) in self {
-              group.addTask {
-                  let (newRef, components, messages) = try await value.externallyDereferenced(with: loader)
-                  return (key, newRef, components, messages)
-              }
-          }
+        var newDict = Self()
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-          var newDict = Self()
-          var newComponents = OpenAPI.Components()
-          var newMessages = [Loader.Message]()
-
-          for try await (key, newRef, components, messages) in group {
-              newDict[key] = newRef
-              try newComponents.merge(components)
-              newMessages += messages
-          }
-          return (newDict, newComponents, newMessages)
+        for (key, value) in self {
+            let (newValue, components, messages) = try await value.externallyDereferenced(with: loader)
+            newDict[key] = newValue
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newDict, newComponents, newMessages)
     }
 }

--- a/Sources/OpenAPIKit30/Utility/OrderedDictionary+ExternallyDereferenceable.swift
+++ b/Sources/OpenAPIKit30/Utility/OrderedDictionary+ExternallyDereferenceable.swift
@@ -10,27 +10,17 @@ import OpenAPIKitCore
 extension OrderedDictionary where Key: Sendable, Value: ExternallyDereferenceable & Sendable {
 
     public func externallyDereferenced<Loader: ExternalLoader>(with loader: Loader.Type) async throws -> (Self, OpenAPI.Components, [Loader.Message]) {
-        try await withThrowingTaskGroup(of: (Key, Value, OpenAPI.Components, [Loader.Message]).self) { group in
-          for (key, value) in self {
-              group.addTask {
-                  let (newRef, components, messages) = try await value.externallyDereferenced(with: loader)
-                  return (key, newRef, components, messages)
-              }
-          }
+        var newDict = Self()
+        var newComponents = OpenAPI.Components()
+        var newMessages = [Loader.Message]()
 
-          var newDict = Self()
-          var newComponents = OpenAPI.Components()
-          var newMessages = [Loader.Message]()
-
-          for try await (key, newRef, components, messages) in group {
-              newDict[key] = newRef
-              try newComponents.merge(components)
-              newMessages += messages
-          }
-          // things may come in out of order because of concurrency
-          // so we reorder after completing all entries.
-          try newDict.applyOrder(self)
-          return (newDict, newComponents, newMessages)
+        for (key, value) in self {
+            let (newValue, components, messages) = try await value.externallyDereferenced(with: loader)
+            newDict[key] = newValue
+            try newComponents.merge(components)
+            newMessages += messages
         }
+
+        return (newDict, newComponents, newMessages)
     }
 }

--- a/Tests/OpenAPIKit30Tests/JSONReferenceTests.swift
+++ b/Tests/OpenAPIKit30Tests/JSONReferenceTests.swift
@@ -356,6 +356,29 @@ extension JSONReferenceTests {
                 .replacingOccurrences(of: ".", with: "_"))
         }
     }
+
+    struct InformedSchemaLoader: ExternalLoader {
+        typealias Message = String
+
+        static func load<T>(_ url: URL) -> (T, [Message]) where T: Decodable {
+            return (JSONSchema.object(.init(), .init(properties: [:])) as! T, [url.absoluteString])
+        }
+
+        static func componentKey<T>(for loadedValue: T, type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey {
+            if let schema = loadedValue as? JSONSchema, schema.jsonType == .object {
+                return "loaded_object_schema"
+            }
+            return try componentKey(type: type, at: url)
+        }
+    }
+
+    struct DefaultSchemaLoader: ExternalLoader {
+        typealias Message = String
+
+        static func load<T>(_ url: URL) -> (T, [Message]) where T: Decodable {
+            return (JSONSchema.string as! T, [url.absoluteString])
+        }
+    }
 }
 
 // MARK: - External Dereferencing
@@ -388,5 +411,25 @@ extension JSONReferenceTests {
         XCTAssertEqual(newReference, .component(named: "__schema_json__components_schemas_test"))
         XCTAssertEqual(components, .init(schemas: ["__schema_json__components_schemas_test": .string]))
         XCTAssertEqual(messages, ["./schema.json#/components/schemas/test"])
+    }
+
+    func test_externalDerefUsesLoadedValueAwareComponentKeyWhenProvided() async throws {
+        let reference: JSONReference<JSONSchema> = .external(.init(string: "./schema.json")!)
+
+        let (newReference, components, messages) = try await reference.externallyDereferenced(with: InformedSchemaLoader.self)
+
+        XCTAssertEqual(newReference, .component(named: "loaded_object_schema"))
+        XCTAssertEqual(components, .init(schemas: ["loaded_object_schema": .object(.init(), .init(properties: [:]))]))
+        XCTAssertEqual(messages, ["./schema.json"])
+    }
+
+    func test_externalDerefUsesDefaultComponentKeyWhenNoComponentKeyOverridesAreProvided() async throws {
+        let reference: JSONReference<JSONSchema> = .external(.init(string: "./schema.json#/test")!)
+
+        let (newReference, components, messages) = try await reference.externallyDereferenced(with: DefaultSchemaLoader.self)
+
+        XCTAssertEqual(newReference, .component(named: "__schema_json__test"))
+        XCTAssertEqual(components, .init(schemas: ["__schema_json__test": .string]))
+        XCTAssertEqual(messages, ["./schema.json#/test"])
     }
 }

--- a/Tests/OpenAPIKitTests/JSONReferenceTests.swift
+++ b/Tests/OpenAPIKitTests/JSONReferenceTests.swift
@@ -447,6 +447,26 @@ extension JSONReferenceTests {
         XCTAssertEqual(components, .init(schemas: ["__schema_json__components_schemas_test": .string]))
         XCTAssertEqual(messages, ["./schema.json#/components/schemas/test"])
     }
+
+    func test_externalDerefUsesLoadedValueAwareComponentKeyWhenProvided() async throws {
+        let reference: JSONReference<JSONSchema> = .external(.init(string: "./schema.json")!)
+
+        let (newReference, components, messages) = try await reference.externallyDereferenced(with: InformedSchemaLoader.self)
+
+        XCTAssertEqual(newReference, .component(named: "loaded_object_schema"))
+        XCTAssertEqual(components, .init(schemas: ["loaded_object_schema": .object(.init(), .init(properties: [:]))]))
+        XCTAssertEqual(messages, ["./schema.json"])
+    }
+
+    func test_externalDerefUsesDefaultComponentKeyWhenNoComponentKeyOverridesAreProvided() async throws {
+        let reference: JSONReference<JSONSchema> = .external(.init(string: "./schema.json#/test")!)
+
+        let (newReference, components, messages) = try await reference.externallyDereferenced(with: DefaultSchemaLoader.self)
+
+        XCTAssertEqual(newReference, .component(named: "__schema_json__test"))
+        XCTAssertEqual(components, .init(schemas: ["__schema_json__test": .string]))
+        XCTAssertEqual(messages, ["./schema.json#/test"])
+    }
 }
 
 // MARK: - Test Types
@@ -465,6 +485,25 @@ extension JSONReferenceTests {
                 .replacingOccurrences(of: "/", with: "_")
                 .replacingOccurrences(of: "#", with: "_")
                 .replacingOccurrences(of: ".", with: "_"))
+        }
+    }
+
+    struct InformedSchemaLoader: ExternalLoader {
+        static func load<T: Decodable>(_ url: URL) -> (T, [String]) {
+            return (JSONSchema.object(.init(), .init(properties: [:])) as! T, [url.absoluteString])
+        }
+
+        static func componentKey<T>(for loadedValue: T, type: T.Type, at url: URL) throws -> OpenAPI.ComponentKey {
+            if let schema = loadedValue as? JSONSchema, schema.jsonType == .object {
+                return "loaded_object_schema"
+            }
+            return try componentKey(type: type, at: url)
+        }
+    }
+
+    struct DefaultSchemaLoader: ExternalLoader {
+        static func load<T: Decodable>(_ url: URL) -> (T, [String]) {
+            return (JSONSchema.string as! T, [url.absoluteString])
         }
     }
 }

--- a/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/DereferencedSchemaObjectTests.swift
@@ -304,6 +304,12 @@ final class DereferencedSchemaObjectTests: XCTestCase {
             .boolean(.init())
         )
 
+        let tPattern = JSONSchema.object(patternProperties: ["^x-": .string]).dereferenced()
+        XCTAssertEqual(
+            tPattern?.objectContext?.patternProperties["^x-"],
+            .string(.init(), .init())
+        )
+
         let t3 = JSONSchema.object(
             properties: [
                 "required": .string,
@@ -333,6 +339,12 @@ final class DereferencedSchemaObjectTests: XCTestCase {
         XCTAssertEqual(
             t2.objectContext?.additionalProperties?.schemaValue,
             .boolean(.init())
+        )
+
+        let tPattern = try JSONSchema.object(patternProperties: ["^x-": .string]).dereferenced(in: components)
+        XCTAssertEqual(
+            tPattern.objectContext?.patternProperties["^x-"],
+            .string(.init(), .init())
         )
 
         let t3 = try JSONSchema.object(

--- a/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/JSONSchemaTests.swift
@@ -3237,6 +3237,55 @@ extension SchemaObjectTests {
         XCTAssertEqual(contextB, .init(properties: ["hello": .boolean(.init(format: .generic, required: false))], additionalProperties: .init(.string)))
     }
 
+    func test_encodeObjectWithPatternProperties() {
+        let object = JSONSchema.object(
+            .init(format: .unspecified, required: true),
+            .init(
+                properties: ["hello": .boolean(.init(format: .unspecified, required: false))],
+                patternProperties: ["^x-": .string(required: false)]
+            )
+        )
+
+        testEncodingPropertyLines(entity: object,
+                                  propertyLines: [
+                                    "\"patternProperties\" : {",
+                                    "  \"^x-\" : {",
+                                    "    \"type\" : \"string\"",
+                                    "  }",
+                                    "},",
+                                    "\"properties\" : {",
+                                    "  \"hello\" : {",
+                                    "    \"type\" : \"boolean\"",
+                                    "  }",
+                                    "},",
+                                    "\"type\" : \"object\""
+        ])
+    }
+
+    func test_decodeObjectWithPatternProperties() {
+        let objectData = """
+        {
+            "patternProperties": {
+                "^x-": { "type": "string" }
+            },
+            "type": "object"
+        }
+        """.data(using: .utf8)!
+
+        let object = try! orderUnstableDecode(JSONSchema.self, from: objectData)
+
+        XCTAssertEqual(
+            object,
+            JSONSchema.object(
+                .init(format: .generic),
+                .init(
+                    properties: [:],
+                    patternProperties: ["^x-": .string]
+                )
+            )
+        )
+    }
+
     func test_encodeObjectWithExample() {
         let string = try! JSONSchema.string(.init(format: .unspecified, required: true), .init())
             .with(example: "hello")

--- a/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
+++ b/Tests/OpenAPIKitTests/Schema Object/SchemaFragmentCombiningTests.swift
@@ -1074,6 +1074,12 @@ final class SchemaFragmentCombiningTests: XCTestCase {
                 XCTAssert(error ~= .attributeConflict, "\(error) is not ~= `.attributeConflict` --  \(fragments)")
             }
         }
+
+        let patternPropertyDifference: [JSONSchema] = [
+            .object(.init(), .init(properties: [:], patternProperties: ["^x-": .boolean])),
+            .object(.init(), .init(properties: [:], patternProperties: ["^x-": .string]))
+        ]
+        XCTAssertThrowsError(try patternPropertyDifference.combined(resolvingAgainst: .noComponents))
     }
 
     // MARK: - Inconsistency Failures


### PR DESCRIPTION
Closes #438

## Summary
- add an object-aware `ExternalLoader.componentKey` overload in both OpenAPIKit variants
- keep the URL-only key path as the compatibility fallback so loaders can implement either form
- compute external reference component keys after loading so the decoded value can inform the key
- add regression tests covering the object-aware override path and the default compatibility path

## Testing
- swift test --filter JSONReferenceTests
- swift test --filter ExternalDereferencingDocumentTests