### PR TITLE
Tests for default behaviors of legacy xml structure properties in encode/decode

### DIFF
--- a/Tests/OpenAPIKitTests/XMLTests.swift
+++ b/Tests/OpenAPIKitTests/XMLTests.swift
@@ -124,6 +124,52 @@ extension XMLTests {
         )
     }
 
+    func test_legacyDefaultsOmitted_encode() throws {
+        let xml = OpenAPI.XML(
+            name: "hello",
+            namespace: URL(string: "http://hello.world.com")!,
+            prefix: "there",
+            attribute: false,
+            wrapped: false
+        )
+        let encodedXML = try orderUnstableTestStringFromEncoding(of: xml)
+
+        assertJSONEquivalent(
+            encodedXML,
+            """
+            {
+              "name" : "hello",
+              "namespace" : "http:\\/\\/hello.world.com",
+              "prefix" : "there"
+            }
+            """
+        )
+    }
+
+    // omitted defaults should be decoded as a modern representation, not legacy
+    func test_defaultsOmitted_decode() throws {
+        let xmlData =
+            """
+            {
+              "name" : "hello",
+              "namespace" : "http:\\/\\/hello.world.com",
+              "prefix" : "there"
+            }
+            """.data(using: .utf8)!
+
+        let xml = try orderUnstableDecode(OpenAPI.XML.self, from: xmlData)
+        XCTAssertEqual(xml.conditionalWarnings.count, 0)
+
+        XCTAssertEqual(
+            xml,
+                OpenAPI.XML(
+                name: "hello",
+                namespace: URL(string: "http://hello.world.com")!,
+                prefix: "there",
+            )
+        )
+    }
+
     func test_complete_encode() throws {
         let xml = OpenAPI.XML(
             name: "hello",


### PR DESCRIPTION
A recent Issue tracked a surprising behavior when encoding or decoding legacy XML structure properties with default values. The behavior is intended, but it wasn't under unit test. This PR adds tests of the intended but potentially surprising behavior.
